### PR TITLE
Use assets directly instead of using wp-json endpoint

### DIFF
--- a/includes/class-content-proxy.php
+++ b/includes/class-content-proxy.php
@@ -258,7 +258,7 @@ class ExeLearning_Content_Proxy {
 			return;
 		}
 
-		$base_url = rest_url( 'exelearning/v1/content/' . $hash . '/' );
+		$base_url = self::get_uploads_url( $hash );
 
 		// Get the directory of the current CSS file for resolving relative paths.
 		$current_dir = '';
@@ -301,7 +301,8 @@ class ExeLearning_Content_Proxy {
 	 * @return string Modified HTML with absolute URLs.
 	 */
 	private function rewrite_relative_urls( $html, $hash, $file_path = '' ) {
-		$base_url = rest_url( 'exelearning/v1/content/' . $hash . '/' );
+		$uploads_url = self::get_uploads_url( $hash );
+		$proxy_url   = self::get_proxy_url( $hash, '' );
 
 		// Get the directory of the current file for resolving relative paths.
 		$current_dir = '';
@@ -325,7 +326,7 @@ class ExeLearning_Content_Proxy {
 		foreach ( $patterns as $pattern ) {
 			$html = preg_replace_callback(
 				$pattern,
-				function ( $matches ) use ( $base_url, $current_dir ) {
+				function ( $matches ) use ( $uploads_url, $proxy_url, $current_dir ) {
 					$prefix    = $matches[1];
 					$attr      = $matches[2];
 					$url       = $matches[3];
@@ -339,31 +340,45 @@ class ExeLearning_Content_Proxy {
 					// Resolve the relative URL based on current directory.
 					$resolved_path = $this->resolve_relative_path( $current_dir, $url );
 
-					// Build absolute URL.
-					$absolute_url = $base_url . $resolved_path;
+					// HTML files go through the proxy (for CSP headers);
+					// all other assets are served directly from uploads.
+					$base_url = self::is_html_path( $resolved_path ) ? $proxy_url : $uploads_url;
 
-					return $prefix . $attr . esc_url( $absolute_url ) . $end_quote;
+					return $prefix . $attr . esc_url( $base_url . $resolved_path ) . $end_quote;
 				},
 				$html
 			);
 		}
 
-		// Also handle url() in inline styles.
+		// Also handle url() in inline styles (never HTML, always assets).
 		$html = preg_replace_callback(
 			'/url\s*\(\s*["\']?(?!https?:\/\/|data:|\/\/|#)([^"\')\s]+)["\']?\s*\)/i',
-			function ( $matches ) use ( $base_url, $current_dir ) {
+			function ( $matches ) use ( $uploads_url, $current_dir ) {
 				$url = $matches[1];
 				if ( empty( $url ) || '/' === $url[0] ) {
 					return $matches[0];
 				}
 				// Resolve the relative URL based on current directory.
 				$resolved_path = $this->resolve_relative_path( $current_dir, $url );
-				return 'url("' . esc_url( $base_url . $resolved_path ) . '")';
+				return 'url("' . esc_url( $uploads_url . $resolved_path ) . '")';
 			},
 			$html
 		);
 
 		return $html;
+	}
+
+	/**
+	 * Check if a file path points to an HTML file.
+	 *
+	 * @param string $path File path to check.
+	 * @return bool True if the path ends with .html or .htm.
+	 */
+	private static function is_html_path( $path ) {
+		// Strip query string and fragment before checking extension.
+		$clean_path = strtok( $path, '?#' );
+		$extension  = strtolower( pathinfo( $clean_path, PATHINFO_EXTENSION ) );
+		return 'html' === $extension || 'htm' === $extension;
 	}
 
 	/**
@@ -500,5 +515,21 @@ class ExeLearning_Content_Proxy {
 			return null;
 		}
 		return rest_url( 'exelearning/v1/content/' . $hash . '/' . $file );
+	}
+
+	/**
+	 * Generate a direct uploads URL for the given hash and file.
+	 *
+	 * Sub-assets (CSS, JS, images, fonts) are served directly from the uploads
+	 * directory to avoid 404s on hosted environments where the web server
+	 * intercepts requests with static file extensions.
+	 *
+	 * @param string $hash Extraction hash.
+	 * @param string $file File path (default: empty).
+	 * @return string Uploads URL.
+	 */
+	public static function get_uploads_url( $hash, $file = '' ) {
+		$upload_dir = wp_upload_dir();
+		return trailingslashit( $upload_dir['baseurl'] ) . 'exelearning/' . $hash . '/' . $file;
 	}
 }

--- a/includes/class-elp-upload-handler.php
+++ b/includes/class-elp-upload-handler.php
@@ -189,40 +189,50 @@ class ExeLearning_Elp_Upload_Handler {
 	}
 
 	/**
-	 * Creates a security .htaccess file to block direct access to extracted content.
+	 * Creates a security .htaccess file to control direct access to extracted content.
 	 *
-	 * All content must be served through the secure proxy controller.
+	 * HTML files are blocked (must be served through the secure proxy for CSP headers).
+	 * Static assets (CSS, JS, images, fonts, media) are allowed for direct serving,
+	 * which avoids 403/404 errors on hosted environments where the web server
+	 * intercepts requests with static file extensions.
 	 */
 	private function create_security_htaccess() {
 		$upload_dir    = wp_upload_dir();
 		$htaccess_path = trailingslashit( $upload_dir['basedir'] ) . 'exelearning/.htaccess';
 
-		// Only create if it doesn't exist.
-		if ( file_exists( $htaccess_path ) ) {
-			return;
-		}
-
 		$htaccess_content = <<<'HTACCESS'
-# Security: Block direct access to eXeLearning extracted content
-# All content must be served through the secure proxy controller
+# Security: Control direct access to eXeLearning extracted content
+# HTML files must be served through the secure proxy controller (for CSP headers)
+# Static assets (CSS, JS, images, fonts, media) are allowed for direct serving
 
-# Deny all direct access
-<IfModule mod_authz_core.c>
-    # Apache 2.4+
-    Require all denied
-</IfModule>
-<IfModule !mod_authz_core.c>
-    # Apache 2.2
-    Order deny,allow
-    Deny from all
-</IfModule>
-
-# Alternative: return 403 for all requests
 <IfModule mod_rewrite.c>
     RewriteEngine On
+
+    # Allow static assets to be served directly
+    RewriteCond %{REQUEST_URI} \.(css|js|json|png|jpe?g|gif|svg|webp|ico|woff2?|ttf|eot|otf|mp[34]|webm|og[gv]|wav|pdf|zip|txt|xml)$ [NC]
+    RewriteRule ^ - [L]
+
+    # Block direct access to everything else (HTML files, etc.)
     RewriteRule ^ - [F,L]
 </IfModule>
+
+<IfModule !mod_rewrite.c>
+    # Fallback without mod_rewrite: deny all (proxy will still work)
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Deny from all
+    </IfModule>
+</IfModule>
 HTACCESS;
+
+		// Only write if the file doesn't exist or its content has changed.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		if ( file_exists( $htaccess_path ) && file_get_contents( $htaccess_path ) === $htaccess_content ) {
+			return;
+		}
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 		file_put_contents( $htaccess_path, $htaccess_content );

--- a/tests/unit/ContentProxyTest.php
+++ b/tests/unit/ContentProxyTest.php
@@ -664,7 +664,7 @@ class ContentProxyTest extends WP_UnitTestCase {
 		$hash   = str_repeat( 'a', 40 );
 		$result = $method->invoke( $this->proxy, $html, $hash, '' );
 
-		$this->assertStringContainsString( 'exelearning/v1/content/', $result );
+		$this->assertStringContainsString( 'uploads/exelearning/', $result );
 		$this->assertStringContainsString( 'images/logo.png', $result );
 	}
 
@@ -707,7 +707,7 @@ class ContentProxyTest extends WP_UnitTestCase {
 		$hash   = str_repeat( 'a', 40 );
 		$result = $method->invoke( $this->proxy, $html, $hash, '' );
 
-		$this->assertStringContainsString( 'exelearning/v1/content/', $result );
+		$this->assertStringContainsString( 'uploads/exelearning/', $result );
 		$this->assertStringContainsString( 'css/style.css', $result );
 	}
 
@@ -722,7 +722,7 @@ class ContentProxyTest extends WP_UnitTestCase {
 		$hash   = str_repeat( 'a', 40 );
 		$result = $method->invoke( $this->proxy, $html, $hash, '' );
 
-		$this->assertStringContainsString( 'exelearning/v1/content/', $result );
+		$this->assertStringContainsString( 'uploads/exelearning/', $result );
 		$this->assertStringContainsString( 'thumbnails/video.jpg', $result );
 	}
 
@@ -737,7 +737,7 @@ class ContentProxyTest extends WP_UnitTestCase {
 		$hash   = str_repeat( 'a', 40 );
 		$result = $method->invoke( $this->proxy, $html, $hash, '' );
 
-		$this->assertStringContainsString( 'exelearning/v1/content/', $result );
+		$this->assertStringContainsString( 'uploads/exelearning/', $result );
 		$this->assertStringContainsString( 'images/bg.png', $result );
 	}
 
@@ -852,6 +852,37 @@ class ContentProxyTest extends WP_UnitTestCase {
 
 		// Absolute paths starting with / should not be rewritten.
 		$this->assertEquals( $html, $result );
+	}
+
+	/**
+	 * Test rewrite_relative_urls routes HTML links through proxy.
+	 */
+	public function test_rewrite_relative_urls_html_links_use_proxy() {
+		$method = new ReflectionMethod( ExeLearning_Content_Proxy::class, 'rewrite_relative_urls' );
+		$method->setAccessible( true );
+
+		$html   = '<a href="html/page2.html">Next</a>';
+		$hash   = str_repeat( 'a', 40 );
+		$result = $method->invoke( $this->proxy, $html, $hash, '' );
+
+		$this->assertStringContainsString( 'exelearning/v1/content/', $result );
+		$this->assertStringContainsString( 'html/page2.html', $result );
+		$this->assertStringNotContainsString( 'uploads/exelearning/', $result );
+	}
+
+	/**
+	 * Test rewrite_relative_urls routes HTM links through proxy.
+	 */
+	public function test_rewrite_relative_urls_htm_links_use_proxy() {
+		$method = new ReflectionMethod( ExeLearning_Content_Proxy::class, 'rewrite_relative_urls' );
+		$method->setAccessible( true );
+
+		$html   = '<a href="page.htm">Page</a>';
+		$hash   = str_repeat( 'a', 40 );
+		$result = $method->invoke( $this->proxy, $html, $hash, '' );
+
+		$this->assertStringContainsString( 'exelearning/v1/content/', $result );
+		$this->assertStringNotContainsString( 'uploads/exelearning/', $result );
 	}
 
 	/**


### PR DESCRIPTION
This pull request makes significant improvements to how eXeLearning extracted content is served and secured. The main changes separate the handling of HTML files (which require proxying for security and CSP headers) from static assets (which can be served directly from uploads), and update the `.htaccess` rules to reflect this. Unit tests are also updated and expanded to verify the new behavior.

**Content serving and URL rewriting:**

* Updated `rewrite_relative_urls` and related methods in `class-content-proxy.php` to serve HTML files via the proxy (for CSP headers), while static assets (CSS, JS, images, fonts, etc.) are served directly from the uploads directory. Introduced `get_uploads_url` and `is_html_path` helpers for this logic.
* Updated unit tests in `ContentProxyTest.php` to expect asset URLs to use the uploads path, and added new tests to ensure HTML/HTM links are routed through the proxy. 
**Security and access control:**

* Revised the `.htaccess` generation in `class-elp-upload-handler.php` to allow direct access to static assets but block HTML files, using mod_rewrite for fine-grained control and fallback rules for environments without mod_rewrite.

These changes improve compatibility with hosted environments, prevent 403/404 errors for assets, and ensure HTML files are securely proxied for CSP and other headers.