### PR TITLE
fix: embed final editor version when packaging plugin (#30)

### DIFF
--- a/.github/workflows/check-editor-releases.yml
+++ b/.github/workflows/check-editor-releases.yml
@@ -57,6 +57,8 @@ jobs:
           EXELEARNING_EDITOR_REPO_URL: https://github.com/exelearning/exelearning.git
           EXELEARNING_EDITOR_REF: ${{ steps.check.outputs.tag }}
           EXELEARNING_EDITOR_REF_TYPE: tag
+          # Embed the final release version in the editor build (not 0.0.0-alpha).
+          APP_VERSION: ${{ steps.check.outputs.tag }}
         run: make build-editor
 
       - name: Compute version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,10 @@ jobs:
             VERSION_TAG="${RAW_TAG#v}"
             echo "RELEASE_TAG=${VERSION_TAG}" >> $GITHUB_ENV
             echo "EXELEARNING_EDITOR_REPO_URL=https://github.com/exelearning/exelearning.git" >> $GITHUB_ENV
-            echo "EXELEARNING_EDITOR_REF=main" >> $GITHUB_ENV
-            echo "EXELEARNING_EDITOR_REF_TYPE=branch" >> $GITHUB_ENV
+            # Build the editor from the matching editor tag so the embedded
+            # editor reports the final release version (not a nightly/alpha build).
+            echo "EXELEARNING_EDITOR_REF=v${VERSION_TAG}" >> $GITHUB_ENV
+            echo "EXELEARNING_EDITOR_REF_TYPE=tag" >> $GITHUB_ENV
           else
             INPUT_RELEASE="${{ github.event.inputs.release_tag }}"
             if [ -z "$INPUT_RELEASE" ]; then

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,24 @@ fetch-editor-source:
 build-editor: check-bun fetch-editor-source
 	@echo "Building eXeLearning static editor..."
 	rm -rf $(EDITOR_OUTPUT_DIR)
-	cd $(EDITOR_SUBMODULE_PATH) && bun install && OUTPUT_DIR=$(EDITOR_OUTPUT_DIR) bun run build:static
+	@# Resolve the version to embed in the editor build. The editor's build script
+	@# (scripts/build-static-bundle.ts) reads APP_VERSION/VERSION; without it the
+	@# build falls back to package.json (0.0.0-alpha). Resolution order:
+	@#   APP_VERSION -> VERSION -> EXELEARNING_EDITOR_REF (env or .env) ->
+	@#   exact git tag of the checked-out editor -> empty (dev default -> alpha)
+	@set -e; \
+	get_env() { \
+		if [ -f .env ]; then \
+			grep -E "^$$1=" .env | tail -n1 | cut -d '=' -f2-; \
+		fi; \
+	}; \
+	APP_VER="$${APP_VERSION:-$${VERSION:-$${EXELEARNING_EDITOR_REF:-$$(get_env EXELEARNING_EDITOR_REF)}}}"; \
+	if [ -z "$$APP_VER" ] || [ "$$APP_VER" = "main" ] || [ "$$APP_VER" = "master" ]; then \
+		EXACT_TAG="$$(git -C $(EDITOR_SUBMODULE_PATH) describe --tags --exact-match 2>/dev/null || true)"; \
+		if [ -n "$$EXACT_TAG" ]; then APP_VER="$$EXACT_TAG"; fi; \
+	fi; \
+	echo "Editor version input: $${APP_VER:-(default -> alpha)}"; \
+	cd $(EDITOR_SUBMODULE_PATH) && bun install && OUTPUT_DIR=$(EDITOR_OUTPUT_DIR) APP_VERSION="$$APP_VER" bun run build:static
 	@# If the build script ignored OUTPUT_DIR, copy from fetched source output.
 	@if [ ! -f "$(EDITOR_OUTPUT_DIR)/index.html" ] && [ -f "$(EDITOR_SUBMODULE_PATH)/dist/static/index.html" ]; then \
 		echo "Copying build output to dist/static/..."; \


### PR DESCRIPTION
Closes exelearning/exelearning#2044

## Problem

The `wp-exelearning` plugin **v4.0.0** was published with the embedded editor reporting `v0.0.0-alpha`, even though the plugin identifies itself as `4.0.0`.

Verified by downloading the artifacts:
- `exelearning-4.0.0.zip` (WP plugin) → embedded editor = `v0.0.0-alpha` ❌
- `exelearning-static-v4.0.0.zip` (`exelearning` repo) → editor = `v4.0.0` ✅ (this bundle was fine)

The problem was **only in the `wp-exelearning` packaging**, not in the `exelearning` repo bundle.

## Root cause

`exelearning/scripts/build-static-bundle.ts` resolves the version only from `--version=` / `VERSION` / `APP_VERSION`, and otherwise falls back to `v${packageJson.version}` = `0.0.0-alpha`. It does **not** derive the version from the git tag.

The `build-editor` target in the `Makefile` ran `bun run build:static` **without passing any of those variables**, so it always produced `0.0.0-alpha`. In addition, `release.yml` built the editor from `main` instead of the matching tag.

## Changes

- **`Makefile`** (`build-editor`): resolves `APP_VERSION` (order: `APP_VERSION` → `VERSION` → `EXELEARNING_EDITOR_REF` env/`.env` → exact git tag of the editor checkout → empty for local dev) and passes it to `build:static`.
- **`.github/workflows/release.yml`**: on the `release` event, builds the editor from the matching editor tag (`vX.Y.Z`) instead of `main`.
- **`.github/workflows/check-editor-releases.yml`**: passes `APP_VERSION` explicitly.

## Verification

```
EXELEARNING_EDITOR_REF=v4.0.0 EXELEARNING_EDITOR_REF_TYPE=tag make build-editor
# [Version] Input: v4.0.0 (APP_VERSION env) → Output: v4.0.0
grep '"version"' dist/static/data/bundle.json   # → "version": "v4.0.0"
grep name dist/static/manifest.json             # → "eXeLearning Editor (v4.0.0)"
```

Local build without variables (dev) still works with its alpha/nightly fallback.

## Acceptance criteria
- [x] The packaged plugin no longer includes `0.0.0-alpha` in final releases.
- [x] The embedded editor version matches the release version.
- [x] The packaging workflow prevents alpha/dev editor versions in final releases.
