### PR TITLE
chore: bump tested up to WordPress 7.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: intef
 Tags: elearning, education, elpx, exelearning, learning
 Requires at least: 6.1
-Tested up to: 6.7
+Tested up to: 7.0
 Stable tag: 0.0.0
 Requires PHP: 8.0
 License: AGPLv3 or later


### PR DESCRIPTION
## Summary
- Update `Tested up to` in `readme.txt` from 6.7 to 7.0 so plugin-check (and the WordPress.org listing) treats the plugin as compatible with the current WP version.

## Test plan
- [x] `make check-plugin` (o equivalente) pasa sin el error `outdated_tested_upto_header`.