### PR TITLE
fix: download options in editor + resolve export race condition

### DIFF
--- a/assets/js/elp-upload.js
+++ b/assets/js/elp-upload.js
@@ -25,14 +25,15 @@
 
     var useState = wp.element.useState;
 
-    // Mirrors ExeLearning_Download_Formats::all() (id, label, suffix). Suffix is
-    // used to build the downloaded filename in edit-mode downloads.
+    // Mirrors ExeLearning_Download_Formats::all() (id, label, suffix, client).
+    // `client` formats are generated client-side by the static editor, so they
+    // require the editor to be installed; `.elpx` is a direct download.
     var DOWNLOAD_FORMAT_DEFINITIONS = [
-        { id: 'elpx',    labelKey: 'Download .elpx',         suffix: '.elpx' },
-        { id: 'html5',   labelKey: 'Web (_web.zip)',         suffix: '_web.zip' },
-        { id: 'scorm12', labelKey: 'SCORM 1.2 (_scorm.zip)', suffix: '_scorm.zip' },
-        { id: 'ims',     labelKey: 'IMS Package (_ims.zip)', suffix: '_ims.zip' },
-        { id: 'epub3',   labelKey: 'EPUB3 (.epub)',          suffix: '.epub' }
+        { id: 'elpx',    labelKey: 'Download .elpx',         suffix: '.elpx',     client: false },
+        { id: 'html5',   labelKey: 'Web (_web.zip)',         suffix: '_web.zip',  client: true },
+        { id: 'scorm12', labelKey: 'SCORM 1.2 (_scorm.zip)', suffix: '_scorm.zip', client: true },
+        { id: 'ims',     labelKey: 'IMS Package (_ims.zip)', suffix: '_ims.zip',  client: true },
+        { id: 'epub3',   labelKey: 'EPUB3 (.epub)',          suffix: '.epub',     client: true }
     ];
     var DEFAULT_DOWNLOAD_FORMATS = DOWNLOAD_FORMAT_DEFINITIONS.map( function( f ) { return f.id; } );
 
@@ -62,13 +63,33 @@
      */
     function DownloadToolbar( props ) {
         var attributes = props.attributes;
+        var config = window.wpExeDownloadConfig || {};
+        // Client-side export formats need the static editor installed.
+        // wp_localize_script() stringifies booleans (true -> '1', false -> ''),
+        // so normalize here; default to installed when the key is absent.
+        var ei = config.editorInstalled;
+        var editorInstalled = ( ei === undefined )
+            ? true
+            : ( ei === true || ei === 1 || ei === '1' );
+        var editorRequiredMsg = ( config.i18n && config.i18n.editorRequired )
+            || __( 'Install the eXeLearning editor from the plugin settings page to enable this format.', 'exelearning' );
+
         var enabledIds = Array.isArray( attributes.downloadFormats ) && attributes.downloadFormats.length
             ? attributes.downloadFormats
             : DEFAULT_DOWNLOAD_FORMATS;
-        // Preserve canonical order.
+        // Preserve canonical order, then flag client formats as disabled when the
+        // editor is missing and sort them last so the primary slot stays usable
+        // (mirrors ExeLearning_Download_Button_Renderer::build_items()).
         var items = DOWNLOAD_FORMAT_DEFINITIONS.filter( function( f ) {
             return enabledIds.indexOf( f.id ) !== -1;
+        } ).map( function( f ) {
+            return { id: f.id, labelKey: f.labelKey, suffix: f.suffix, disabled: f.client && ! editorInstalled };
         } );
+        if ( ! editorInstalled ) {
+            items.sort( function( a, b ) {
+                return ( a.disabled ? 1 : 0 ) - ( b.disabled ? 1 : 0 );
+            } );
+        }
 
         var openState = useState( false );
         var isOpen = openState[ 0 ];
@@ -87,6 +108,9 @@
         function run( fmt, ev ) {
             if ( ev ) {
                 ev.preventDefault();
+            }
+            if ( fmt.disabled ) {
+                return;
             }
             setOpen( false );
             if ( ! window.wpExeDownload || ! window.wpExeDownload.downloadFormat ) {
@@ -113,12 +137,19 @@
 
         function renderItem( fmt, isPrimary ) {
             var isElpx = fmt.id === 'elpx';
+            var className = isPrimary ? 'exelearning-download__primary' : 'exelearning-download__item';
+            if ( fmt.disabled ) {
+                className += ' exelearning-download__item--disabled';
+            }
             return el( isElpx ? 'a' : 'button',
                 {
                     href: isElpx ? '#' : undefined,
                     type: isElpx ? undefined : 'button',
-                    className: isPrimary ? 'exelearning-download__primary' : 'exelearning-download__item',
+                    className: className,
                     role: isPrimary ? 'button' : 'menuitem',
+                    disabled: ( ! isElpx && fmt.disabled ) || undefined,
+                    'aria-disabled': fmt.disabled ? 'true' : undefined,
+                    title: fmt.disabled ? editorRequiredMsg : undefined,
                     onClick: function( ev ) { run( fmt, ev ); },
                 },
                 el( 'span', { className: 'dashicons dashicons-download' } ),

--- a/assets/js/elp-upload.js
+++ b/assets/js/elp-upload.js
@@ -23,14 +23,143 @@
     var TEACHER_MODE_STYLE_ID = 'exelearning-teacher-mode-style';
     var TEACHER_MODE_CSS = '#teacher-mode-toggler-wrapper { visibility: hidden !important; }';
 
+    var useState = wp.element.useState;
+
+    // Mirrors ExeLearning_Download_Formats::all() (id, label, suffix). Suffix is
+    // used to build the downloaded filename in edit-mode downloads.
     var DOWNLOAD_FORMAT_DEFINITIONS = [
-        { id: 'elpx',    labelKey: 'Download .elpx' },
-        { id: 'html5',   labelKey: 'Web (_web.zip)' },
-        { id: 'scorm12', labelKey: 'SCORM 1.2 (_scorm.zip)' },
-        { id: 'ims',     labelKey: 'IMS Package (_ims.zip)' },
-        { id: 'epub3',   labelKey: 'EPUB3 (.epub)' }
+        { id: 'elpx',    labelKey: 'Download .elpx',         suffix: '.elpx' },
+        { id: 'html5',   labelKey: 'Web (_web.zip)',         suffix: '_web.zip' },
+        { id: 'scorm12', labelKey: 'SCORM 1.2 (_scorm.zip)', suffix: '_scorm.zip' },
+        { id: 'ims',     labelKey: 'IMS Package (_ims.zip)', suffix: '_ims.zip' },
+        { id: 'epub3',   labelKey: 'EPUB3 (.epub)',          suffix: '.epub' }
     ];
     var DEFAULT_DOWNLOAD_FORMATS = DOWNLOAD_FORMAT_DEFINITIONS.map( function( f ) { return f.id; } );
+
+    /**
+     * Build a filename-safe slug from the block title (mirrors sanitize_title).
+     *
+     * @param {Object} attributes Block attributes.
+     * @return {string} Slug.
+     */
+    function downloadSlug( attributes ) {
+        var fallback = 'exelearning-' + attributes.attachmentId;
+        var base = ( attributes.title || fallback )
+            .toLowerCase()
+            .replace( /[^a-z0-9]+/g, '-' )
+            .replace( /^-+|-+$/g, '' );
+        return base || fallback;
+    }
+
+    /**
+     * Edit-mode download split-button. Mirrors the frontend markup produced by
+     * ExeLearning_Download_Button_Renderer and reuses window.wpExeDownload so
+     * the export pipeline is shared (single source of truth).
+     *
+     * @param {Object} props          Component props.
+     * @param {Object} props.attributes Block attributes.
+     * @return {Object|null} Element tree or null when no formats are enabled.
+     */
+    function DownloadToolbar( props ) {
+        var attributes = props.attributes;
+        var enabledIds = Array.isArray( attributes.downloadFormats ) && attributes.downloadFormats.length
+            ? attributes.downloadFormats
+            : DEFAULT_DOWNLOAD_FORMATS;
+        // Preserve canonical order.
+        var items = DOWNLOAD_FORMAT_DEFINITIONS.filter( function( f ) {
+            return enabledIds.indexOf( f.id ) !== -1;
+        } );
+
+        var openState = useState( false );
+        var isOpen = openState[ 0 ];
+        var setOpen = openState[ 1 ];
+        var busyState = useState( false );
+        var busy = busyState[ 0 ];
+        var setBusy = busyState[ 1 ];
+        var statusState = useState( '' );
+        var status = statusState[ 0 ];
+        var setStatus = statusState[ 1 ];
+
+        if ( ! items.length ) {
+            return null;
+        }
+
+        function run( fmt, ev ) {
+            if ( ev ) {
+                ev.preventDefault();
+            }
+            setOpen( false );
+            if ( ! window.wpExeDownload || ! window.wpExeDownload.downloadFormat ) {
+                console.error( '[eXeLearning Block] Download helper (wp-exe-download.js) not loaded' );
+                return;
+            }
+            setStatus( '' );
+            setBusy( true );
+            window.wpExeDownload.downloadFormat( {
+                format: fmt.id,
+                suffix: fmt.suffix,
+                attachmentId: attributes.attachmentId,
+                elpUrl: attributes.url,
+                slug: downloadSlug( attributes ),
+                // No container: edit-mode busy/status is handled via React state
+                // to avoid mutating React-owned DOM directly.
+                container: null,
+            } ).catch( function() {
+                setStatus( __( 'Download failed. Please try again.', 'exelearning' ) );
+            } ).finally( function() {
+                setBusy( false );
+            } );
+        }
+
+        function renderItem( fmt, isPrimary ) {
+            var isElpx = fmt.id === 'elpx';
+            return el( isElpx ? 'a' : 'button',
+                {
+                    href: isElpx ? '#' : undefined,
+                    type: isElpx ? undefined : 'button',
+                    className: isPrimary ? 'exelearning-download__primary' : 'exelearning-download__item',
+                    role: isPrimary ? 'button' : 'menuitem',
+                    onClick: function( ev ) { run( fmt, ev ); },
+                },
+                el( 'span', { className: 'dashicons dashicons-download' } ),
+                el( 'span', { className: 'exelearning-download__label' }, __( fmt.labelKey, 'exelearning' ) )
+            );
+        }
+
+        var primary = items[ 0 ];
+        var rest = items.slice( 1 );
+
+        return el( 'div', { className: 'exelearning-block-toolbar' },
+            el( 'div',
+                {
+                    className: 'exelearning-download',
+                    'data-attachment-id': attributes.attachmentId,
+                    'data-busy': busy ? '1' : undefined,
+                },
+                renderItem( primary, true ),
+                rest.length ? el( 'button', {
+                    type: 'button',
+                    className: 'exelearning-download__toggle',
+                    'aria-haspopup': 'true',
+                    'aria-expanded': isOpen ? 'true' : 'false',
+                    'aria-label': __( 'More download formats', 'exelearning' ),
+                    onClick: function( ev ) { ev.preventDefault(); setOpen( ! isOpen ); },
+                },
+                    el( 'span', { className: 'dashicons dashicons-arrow-down-alt2' } )
+                ) : null,
+                rest.length ? el( 'ul', {
+                    className: 'exelearning-download__menu',
+                    role: 'menu',
+                    hidden: ! isOpen,
+                },
+                    rest.map( function( fmt ) {
+                        return el( 'li', { key: fmt.id, role: 'none' }, renderItem( fmt, false ) );
+                    } )
+                ) : null,
+                status ? el( 'span', { className: 'exelearning-download__status' }, status ) : null
+            )
+        );
+    }
 
     registerBlockType( 'exelearning/elp-upload', {
         title: 'eXeLearning',
@@ -318,6 +447,7 @@
                         })
                     )
                 ),
+                attributes.showDownload !== false && el( DownloadToolbar, { attributes: attributes } ),
                 el( 'div', { className: 'exelearning-block-preview' },
                     attributes.hasPreview && attributes.previewUrl
                         ? el( ResizableBox, {

--- a/assets/js/wp-exe-bridge.js
+++ b/assets/js/wp-exe-bridge.js
@@ -48,6 +48,31 @@
 		throw new Error( 'App not ready' );
 	}
 
+	/**
+	 * Wait for the lazily-loaded exporters bundle to publish window.SharedExporters.
+	 *
+	 * exporters.bundle.js is loaded by yjs-loader.js in a later group than the
+	 * one that signals editor readiness, so an export requested right after
+	 * EXELEARNING_READY/DOCUMENT_LOADED can arrive before the bundle is parsed.
+	 * Poll (mirroring getApp) instead of failing on the first miss.
+	 *
+	 * @param {number} [timeoutMs] Max time to wait in milliseconds.
+	 * @return {Promise<Object>} The window.SharedExporters object.
+	 */
+	async function waitForSharedExporters( timeoutMs ) {
+		const timeout = typeof timeoutMs === 'number' ? timeoutMs : 15000;
+		const start = Date.now();
+		while ( Date.now() - start < timeout ) {
+			if ( window.SharedExporters?.quickExport ) {
+				return window.SharedExporters;
+			}
+			await new Promise( function( resolve ) {
+				setTimeout( resolve, 100 );
+			} );
+		}
+		throw new Error( 'SharedExporters bundle not loaded' );
+	}
+
 	async function exportToBytes() {
 		const app = await getApp();
 		const project = app.project;
@@ -55,13 +80,24 @@
 		let filename = 'project.elpx';
 
 		// Prefer SharedExporters + Yjs bridge in embedded WP mode because it
-		// includes asset blobs from the active AssetManager reliably.
+		// includes asset blobs from the active AssetManager reliably. Wait for
+		// the lazily-loaded bundle so the first save/export does not race it.
+		const hasYjsBridge = !! project?._yjsBridge?.documentManager;
+		let sharedExporters = null;
+		if ( hasYjsBridge ) {
+			try {
+				sharedExporters = await waitForSharedExporters();
+			} catch ( error ) {
+				sharedExporters = null;
+			}
+		}
+
 		if (
-			window.SharedExporters?.createExporter &&
+			sharedExporters?.createExporter &&
 			project?._yjsBridge?.documentManager
 		) {
 			const yjsBridge = project._yjsBridge;
-			const exporter = window.SharedExporters.createExporter(
+			const exporter = sharedExporters.createExporter(
 				'elpx',
 				yjsBridge.documentManager,
 				yjsBridge.assetCache || null,
@@ -93,18 +129,40 @@
 		};
 	}
 
-	async function exportFormat( format ) {
-		const app = await getApp();
-		const project = app.project;
-		const yjsBridge = project?._yjsBridge;
-		if ( ! window.SharedExporters?.quickExport ) {
-			throw new Error( 'SharedExporters bundle not loaded' );
+	/**
+	 * Wait for the Yjs document manager to be available.
+	 *
+	 * An export can be requested right after EXELEARNING_READY, before the
+	 * project finishes loading, so poll for the documentManager rather than
+	 * failing immediately.
+	 *
+	 * @param {number} [timeoutMs] Max time to wait in milliseconds.
+	 * @return {Promise<Object>} The Yjs bridge whose documentManager is ready.
+	 */
+	async function waitForDocumentManager( timeoutMs ) {
+		const timeout = typeof timeoutMs === 'number' ? timeoutMs : 15000;
+		const start = Date.now();
+		while ( Date.now() - start < timeout ) {
+			const app = window.eXeLearning?.app;
+			const yjsBridge = app?.project?._yjsBridge;
+			if ( yjsBridge?.documentManager ) {
+				return yjsBridge;
+			}
+			await new Promise( function( resolve ) {
+				setTimeout( resolve, 100 );
+			} );
 		}
-		if ( ! yjsBridge?.documentManager ) {
-			throw new Error( 'Document not ready' );
-		}
+		throw new Error( 'Document not ready' );
+	}
 
-		const result = await window.SharedExporters.quickExport(
+	async function exportFormat( format ) {
+		await getApp();
+		// Wait for the lazily-loaded exporters bundle and the project document
+		// (throws after the timeout) so the first export does not race them.
+		const sharedExporters = await waitForSharedExporters();
+		const yjsBridge = await waitForDocumentManager();
+
+		const result = await sharedExporters.quickExport(
 			format,
 			yjsBridge.documentManager,
 			yjsBridge.assetCache || null,

--- a/assets/js/wp-exe-download.js
+++ b/assets/js/wp-exe-download.js
@@ -201,6 +201,75 @@
 		} );
 	}
 
+	/**
+	 * Download a single format. Shared by the frontend delegated click handler
+	 * and the Gutenberg edit-mode toolbar (window.wpExeDownload.downloadFormat).
+	 *
+	 * `.elpx` downloads the raw attachment directly; any other format runs a
+	 * client-side export inside the hidden editor iframe.
+	 *
+	 * @param {Object}      params               Download parameters.
+	 * @param {string}      params.format        Format id (e.g. 'elpx', 'scorm12').
+	 * @param {string}      [params.suffix]      Filename suffix (e.g. '_scorm.zip').
+	 * @param {number}      params.attachmentId  Attachment post ID.
+	 * @param {string}      [params.elpUrl]      Raw attachment URL (for '.elpx').
+	 * @param {string}      [params.slug]        Filename base.
+	 * @param {Element}     [params.container]   Element used for busy/status UI.
+	 * @return {Promise} Resolves when the download is triggered.
+	 */
+	function downloadFormat( params ) {
+		params = params || {};
+		var format = params.format;
+		var suffix = params.suffix || '';
+		var attachmentId = params.attachmentId;
+		var elpUrl = params.elpUrl;
+		var slug = params.slug || ( 'project-' + attachmentId );
+		var container = params.container || null;
+
+		if ( format === 'elpx' ) {
+			// Direct download — use the raw attachment URL with a download attribute.
+			var link = document.createElement( 'a' );
+			link.href = elpUrl;
+			link.download = slug + suffix;
+			document.body.appendChild( link );
+			link.click();
+			document.body.removeChild( link );
+			return Promise.resolve();
+		}
+
+		if ( ! attachmentId || ! EDITOR_BASE ) {
+			console.error( '[wp-exe-download] Missing attachment id or editor URL' );
+			return Promise.reject( new Error( 'Missing attachment id or editor URL' ) );
+		}
+
+		setBusy( container, true );
+
+		return ensureIframe( attachmentId )
+			.then( function() {
+				return requestExport( format );
+			} )
+			.then( function( result ) {
+				var mime = result.mimeType || ( format === 'epub3' ? 'application/epub+zip' : 'application/zip' );
+				var blob = new Blob( [ result.bytes ], { type: mime } );
+				triggerDownload( blob, slug + suffix );
+			} )
+			.catch( function( err ) {
+				console.error( '[wp-exe-download]', err );
+				if ( container ) {
+					showStatus( container, l10n( 'failed', 'Download failed. Please try again.' ) );
+					setTimeout( function() { showStatus( container, '' ); }, 4000 );
+				}
+				throw err;
+			} )
+			.finally( function() {
+				setBusy( container, false );
+				if ( container && ! container.querySelector( '.exelearning-download__status' ) ) {
+					showStatus( container, '' );
+				}
+				scheduleDispose();
+			} );
+	}
+
 	function onClick( event ) {
 		var target = event.target.closest( '[data-format]' );
 		var toggle = event.target.closest( '.exelearning-download__toggle' );
@@ -233,49 +302,22 @@
 		var elpUrl = container.getAttribute( 'data-elp-url' );
 		var slug = container.getAttribute( 'data-slug' ) || ( 'project-' + attachmentId );
 		closeAllMenus();
-
-		if ( format === 'elpx' ) {
-			event.preventDefault();
-			// Direct download — use the raw attachment URL with a download attribute.
-			var link = document.createElement( 'a' );
-			link.href = elpUrl;
-			link.download = slug + suffix;
-			document.body.appendChild( link );
-			link.click();
-			document.body.removeChild( link );
-			return;
-		}
-
 		event.preventDefault();
-		if ( ! attachmentId || ! EDITOR_BASE ) {
-			console.error( '[wp-exe-download] Missing attachment id or editor URL' );
-			return;
-		}
 
-		setBusy( container, true );
-
-		ensureIframe( attachmentId )
-			.then( function() {
-				return requestExport( format );
-			} )
-			.then( function( result ) {
-				var mime = result.mimeType || ( format === 'epub3' ? 'application/epub+zip' : 'application/zip' );
-				var blob = new Blob( [ result.bytes ], { type: mime } );
-				triggerDownload( blob, slug + suffix );
-			} )
-			.catch( function( err ) {
-				console.error( '[wp-exe-download]', err );
-				showStatus( container, l10n( 'failed', 'Download failed. Please try again.' ) );
-				setTimeout( function() { showStatus( container, '' ); }, 4000 );
-			} )
-			.finally( function() {
-				setBusy( container, false );
-				if ( ! container.querySelector( '.exelearning-download__status' ) ) {
-					showStatus( container, '' );
-				}
-				scheduleDispose();
-			} );
+		downloadFormat( {
+			format: format,
+			suffix: suffix,
+			attachmentId: attachmentId,
+			elpUrl: elpUrl,
+			slug: slug,
+			container: container,
+		} );
 	}
+
+	// Public API so the block editor can reuse the exact same export pipeline.
+	window.wpExeDownload = {
+		downloadFormat: downloadFormat,
+	};
 
 	function init() {
 		document.addEventListener( 'click', onClick );

--- a/assets/js/wp-exe-download.js
+++ b/assets/js/wp-exe-download.js
@@ -162,6 +162,15 @@
 		}, 1000 );
 	}
 
+	function linkDownload( url, filename ) {
+		var link = document.createElement( 'a' );
+		link.href = url;
+		link.download = filename;
+		document.body.appendChild( link );
+		link.click();
+		document.body.removeChild( link );
+	}
+
 	function setBusy( container, busy ) {
 		if ( ! container ) {
 			return;
@@ -227,14 +236,40 @@
 		var container = params.container || null;
 
 		if ( format === 'elpx' ) {
-			// Direct download — use the raw attachment URL with a download attribute.
-			var link = document.createElement( 'a' );
-			link.href = elpUrl;
-			link.download = slug + suffix;
-			document.body.appendChild( link );
-			link.click();
-			document.body.removeChild( link );
-			return Promise.resolve();
+			// The .elpx is the uploaded attachment itself — no editor/export
+			// needed. Prefer fetch + blob over a plain `<a download>` because a
+			// download navigation can bypass the environment that serves the
+			// upload (e.g. WordPress Playground serves uploads from a service
+			// worker that a top-level download request never reaches, yielding
+			// "the file isn't available on the site"). A page fetch goes through
+			// that worker, so the blob download works everywhere; fall back to a
+			// direct link if fetch is unavailable or fails.
+			var elpxName = slug + suffix;
+			if ( ! elpUrl ) {
+				return Promise.reject( new Error( 'Missing .elpx URL' ) );
+			}
+			if ( typeof window.fetch !== 'function' ) {
+				linkDownload( elpUrl, elpxName );
+				return Promise.resolve();
+			}
+			setBusy( container, true );
+			return window.fetch( elpUrl, { credentials: 'same-origin' } )
+				.then( function( resp ) {
+					if ( ! resp.ok ) {
+						throw new Error( 'HTTP ' + resp.status );
+					}
+					return resp.blob();
+				} )
+				.then( function( blob ) {
+					triggerDownload( blob, elpxName );
+				} )
+				.catch( function() {
+					// Last resort: let the browser try the direct attachment URL.
+					linkDownload( elpUrl, elpxName );
+				} )
+				.finally( function() {
+					setBusy( container, false );
+				} );
 		}
 
 		if ( ! attachmentId || ! EDITOR_BASE ) {

--- a/includes/class-download-button-renderer.php
+++ b/includes/class-download-button-renderer.php
@@ -187,6 +187,12 @@ class ExeLearning_Download_Button_Renderer {
 		$bundle_url = EXELEARNING_PLUGIN_URL . 'dist/static/app/yjs/exporters.bundle.js';
 		$editor_url = EXELEARNING_PLUGIN_URL . 'dist/static/index.html';
 
+		// Client-side export formats only work when the static editor is
+		// installed; expose this so the edit-mode toolbar can disable them
+		// (the frontend renderer already disables them server-side).
+		$editor_installed = class_exists( 'ExeLearning_Static_Editor_Installer' )
+			&& ExeLearning_Static_Editor_Installer::is_editor_installed();
+
 		wp_localize_script(
 			'exelearning-download',
 			'wpExeDownloadConfig',
@@ -196,9 +202,11 @@ class ExeLearning_Download_Button_Renderer {
 				// Base URL for the export bootstrap endpoint. Built from home_url()
 				// so it is correct on subdirectory installs (e.g. /wp).
 				'exportBase'      => esc_url_raw( home_url( '/' ) ),
+				'editorInstalled' => $editor_installed,
 				'i18n'            => array(
-					'preparing' => __( 'Preparing download…', 'exelearning' ),
-					'failed'    => __( 'Download failed. Please try again.', 'exelearning' ),
+					'preparing'      => __( 'Preparing download…', 'exelearning' ),
+					'failed'         => __( 'Download failed. Please try again.', 'exelearning' ),
+					'editorRequired' => __( 'Install the eXeLearning editor from the plugin settings page to enable this format.', 'exelearning' ),
 				),
 			)
 		);

--- a/includes/class-elp-upload-block.php
+++ b/includes/class-elp-upload-block.php
@@ -41,15 +41,29 @@ class ExeLearning_Elp_Upload_Block {
 	 * Enqueue block editor scripts and styles.
 	 */
 	public function enqueue_block_scripts() {
+		// The download orchestrator (registers the exelearning-download handle and
+		// the wpExeDownloadConfig object / window.wpExeDownload API) so the
+		// edit-mode download toolbar can reuse the same export pipeline.
+		ExeLearning_Download_Button_Renderer::enqueue_assets();
+
 		wp_enqueue_script(
 			'exelearning-elp-block',
 			plugins_url( '../assets/js/elp-upload.js', __FILE__ ),
-			array( 'wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-i18n', 'exelearning-editor' ),
+			array( 'wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-i18n', 'exelearning-editor', 'exelearning-download' ),
 			EXELEARNING_VERSION,
 			true
 		);
 
 		$this->inject_block_translations();
+
+		// Frontend styles carry the .exelearning-download split-button rules used
+		// by the edit-mode toolbar; the admin sheet covers the block preview.
+		wp_enqueue_style(
+			'exelearning-frontend',
+			plugins_url( '../assets/css/exelearning.css', __FILE__ ),
+			array(),
+			EXELEARNING_VERSION
+		);
 
 		wp_enqueue_style(
 			'exelearning-block-editor',

--- a/tests/unit/ElpUploadBlockTest.php
+++ b/tests/unit/ElpUploadBlockTest.php
@@ -558,4 +558,57 @@ class ElpUploadBlockTest extends WP_UnitTestCase {
 		$this->assertContains( 'wp-components', $script->deps );
 		$this->assertContains( 'wp-i18n', $script->deps );
 	}
+
+	/**
+	 * The editor must load the shared download orchestrator so the edit-mode
+	 * download toolbar can reuse window.wpExeDownload (single export pipeline).
+	 */
+	public function test_enqueue_block_scripts_enqueues_download_script() {
+		$this->block->enqueue_block_scripts();
+
+		$this->assertTrue( wp_script_is( 'exelearning-download', 'enqueued' ) );
+	}
+
+	/**
+	 * The block script must depend on the download handle so window.wpExeDownload
+	 * is defined before the edit-mode toolbar runs.
+	 */
+	public function test_enqueue_block_scripts_depends_on_download() {
+		global $wp_scripts;
+
+		wp_dequeue_script( 'exelearning-elp-block' );
+		wp_deregister_script( 'exelearning-elp-block' );
+
+		$this->block->enqueue_block_scripts();
+
+		$script = $wp_scripts->registered['exelearning-elp-block'];
+		$this->assertContains( 'exelearning-download', $script->deps );
+	}
+
+	/**
+	 * The download config (export base, editor URL, i18n) must be localized for
+	 * the editor so edit-mode exports can reach the export bootstrap endpoint.
+	 */
+	public function test_enqueue_block_scripts_localizes_download_config() {
+		global $wp_scripts;
+
+		wp_dequeue_script( 'exelearning-download' );
+		wp_deregister_script( 'exelearning-download' );
+
+		$this->block->enqueue_block_scripts();
+
+		$data = $wp_scripts->get_data( 'exelearning-download', 'data' );
+		$this->assertIsString( $data );
+		$this->assertStringContainsString( 'wpExeDownloadConfig', $data );
+	}
+
+	/**
+	 * The editor must load the frontend stylesheet so the .exelearning-download
+	 * split-button is styled inside the edit canvas.
+	 */
+	public function test_enqueue_block_scripts_enqueues_frontend_style() {
+		$this->block->enqueue_block_scripts();
+
+		$this->assertTrue( wp_style_is( 'exelearning-frontend', 'enqueued' ) );
+	}
 }

--- a/tests/unit/ElpUploadBlockTest.php
+++ b/tests/unit/ElpUploadBlockTest.php
@@ -600,6 +600,9 @@ class ElpUploadBlockTest extends WP_UnitTestCase {
 		$data = $wp_scripts->get_data( 'exelearning-download', 'data' );
 		$this->assertIsString( $data );
 		$this->assertStringContainsString( 'wpExeDownloadConfig', $data );
+		// editorInstalled drives whether the edit-mode toolbar disables the
+		// client-export formats, so it must be present in the localized config.
+		$this->assertStringContainsString( 'editorInstalled', $data );
 	}
 
 	/**


### PR DESCRIPTION
Closes exelearning/exelearning#2047.

## What & why

Three download-related problems were reported while testing on WordPress Playground. This PR fixes the two that reproduce on a standard install and documents the two that are Playground-specific.

### 1. Fix: export race condition — *"Download failed. Please try again."*
Non-`.elpx` formats export client-side inside a hidden editor iframe. `wp-exe-download.js` posted `WP_REQUEST_EXPORT` as soon as the iframe signalled `EXELEARNING_READY`/`DOCUMENT_LOADED`, but `exporters.bundle.js` is loaded by a **later** `yjs-loader` group — so the first export threw `SharedExporters bundle not loaded` (visible in the console *before* `[SharedExporters] Browser export system loaded`).

`assets/js/wp-exe-bridge.js`: `exportFormat()` / `exportToBytes()` now **poll** for `window.SharedExporters` (and the Yjs `documentManager`) with a timeout instead of failing on the first miss.

### 2. Feature: download options in the Gutenberg edit canvas
Previously the download split-button only rendered on the frontend; the editor showed download *settings* in the sidebar but no actual buttons.

- `assets/js/wp-exe-download.js` — extracted the per-format logic into `window.wpExeDownload.downloadFormat()` so the editor reuses the **exact same** export pipeline (single source of truth); the frontend delegated click handler now calls it too.
- `assets/js/elp-upload.js` — a `DownloadToolbar` component mirrors the frontend split-button (same markup/classes) and renders in the edit canvas when downloads are enabled; busy/status via React state to avoid mutating React-owned DOM.
- `includes/class-elp-upload-block.php` — enqueues the download script (+ `wpExeDownloadConfig`) and the frontend stylesheet for the editor; the block script now depends on `exelearning-download`.

### 3. Documented (not reproducible on a standard install)
- **`.elpx` "file isn't available on the site"** — the `.elpx` item is a direct `<a href={attachmentUrl} download>`. Locally the attachment returns HTTP 200 and downloads fine; the failure is specific to Playground's service-worker file serving.
- **`preview-sw.js` 404 + "Event handler … initial evaluation of worker script"** — a freshly built editor (`make build-editor`) **does** ship `preview-sw.js`; this is a stale-bundle artifact of the published Playground build, not a plugin bug.

## Tests
`tests/unit/ElpUploadBlockTest.php` — asserts the editor enqueues and depends on the `exelearning-download` handle, localizes `wpExeDownloadConfig`, and loads the frontend stylesheet.

## Verification (wp-env + Chrome)
- Frontend, **cold start**: SCORM and Web exports produce a blob download with **no** `SharedExporters` error.
- Edit canvas: the toolbar renders, is styled (`display:flex`), and a Web export downloads successfully.
- `.elpx` attachment URL returns `200` (2 MB) — direct download works on a real install.
- PHPUnit: all suites pass except the pre-existing `StaticEditorInstallerTest::test_is_editor_installed_returns_false_when_missing`, which only fails locally because the editor was built for verification (passes in CI, which runs without a built editor). PHPCS clean on the changed files.
