### PR TITLE
Add developer lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,26 @@ Administrators can upload eXeLearning style packages and control which styles th
 
 Uploaded ZIPs are validated against path traversal, absolute paths, oversize archives (default 20 MB, filterable via `exelearning_styles_max_zip_size`), and a strict file-extension allow-list.
 
+## Developer hooks
+
+The plugin exposes a set of WordPress actions and filters (all prefixed with
+`exelearning_`) at its main lifecycle boundaries, so you can observe events and
+enrich presentation or metadata without modifying the plugin:
+
+- **ELPX extraction** — `exelearning_before_elpx_extract`, `exelearning_after_elpx_extract`
+- **Metadata** — `exelearning_elpx_metadata` (filter), `exelearning_after_elpx_metadata_saved`
+- **REST save** — `exelearning_before_elpx_save`, `exelearning_after_elpx_save`
+- **Shortcode rendering** — `exelearning_shortcode_atts`, `exelearning_preview_url`, `exelearning_shortcode_output` (filters)
+- **Styles** — `exelearning_after_style_installed`, `exelearning_after_style_deleted`, `exelearning_after_style_enabled_changed`, `exelearning_style_registry_entry` (filter)
+- **Static editor install** — `exelearning_before_editor_install`, `exelearning_after_editor_install`, `exelearning_editor_install_failed`
+
+These hooks are limited to observation and presentation/metadata enrichment: they
+cannot bypass validation, capability/nonce checks, path-traversal protection,
+checksum verification, or the content-proxy security model.
+
+See [`docs/HOOKS.md`](docs/HOOKS.md) for the full reference, parameters, return
+values, and usage examples.
+
 ## Development
 
 For development, you can bring up a local WordPress environment with the plugin pre-installed:

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -1,0 +1,402 @@
+# Developer hooks
+
+The eXeLearning plugin exposes a set of WordPress actions and filters at its main
+lifecycle boundaries so third-party developers and institutional integrations can
+observe events and enrich presentation or metadata.
+
+All hook names are prefixed with `exelearning_`.
+
+## Security model
+
+These hooks are intentionally limited to **observation** and **presentation/metadata
+enrichment**. They do **not** let a callback bypass any security control. In
+particular, no hook can:
+
+- Skip ZIP, MIME, or path-traversal validation.
+- Skip capability or nonce checks.
+- Change the trusted storage directories or the extraction hash.
+- Disable CSP/security headers or the content-proxy model.
+- Allow arbitrary remote editor download URLs, or weaken checksum/digest checks.
+- Alter cleanup behavior in a way that could leave orphaned or unsafe files.
+
+Every filter validates its return value defensively. Required internal keys are
+always restored from the plugin's trusted values, so a misbehaving callback can add
+data but can never drop or corrupt the data the plugin depends on.
+
+---
+
+## Actions
+
+### `exelearning_before_elpx_extract`
+
+Fires right before an `.elpx` archive is extracted, after it has already passed
+open/validation and the zip-bomb count guard. Observation only — it must not be used
+to bypass validation or change extraction behavior.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `$file` | `string` | Source `.elpx` file path. |
+| `$destination` | `string` | Destination directory the archive extracts into. |
+
+```php
+add_action(
+    'exelearning_before_elpx_extract',
+    function ( $file, $destination ) {
+        error_log( sprintf( 'About to extract %s into %s', $file, $destination ) );
+    },
+    10,
+    2
+);
+```
+
+### `exelearning_after_elpx_extract`
+
+Fires after an `.elpx` archive has been **successfully** extracted. It never fires on
+a failed or partial extraction.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `$file` | `string` | Source `.elpx` file path. |
+| `$destination` | `string` | Final extraction directory. |
+| `$metadata` | `array` | Metadata parsed from the archive. |
+
+```php
+add_action(
+    'exelearning_after_elpx_extract',
+    function ( $file, $destination, $metadata ) {
+        error_log( sprintf( 'ELPX extracted: %s', $file ) );
+    },
+    10,
+    3
+);
+```
+
+### `exelearning_after_elpx_metadata_saved`
+
+Fires after ELPX metadata has been written to the attachment post meta (both on
+upload and on reprocessing).
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `$attachment_id` | `int` | WordPress attachment ID. |
+| `$metadata` | `array` | Final metadata array that was saved. |
+
+```php
+add_action(
+    'exelearning_after_elpx_metadata_saved',
+    function ( $attachment_id, $metadata ) {
+        // For example, index the resource in an external catalogue.
+        do_my_catalogue_sync( $attachment_id, $metadata );
+    },
+    10,
+    2
+);
+```
+
+### `exelearning_before_elpx_save`
+
+Fires before an existing `.elpx` file is replaced through the REST editor endpoint,
+after the request has already passed capability and nonce checks. Observation only —
+it must not change the storage path or replacement/cleanup behavior.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `$attachment_id` | `int` | Attachment being updated. |
+| `$old_file_path` | `string` | Current file path before replacement. |
+
+```php
+add_action(
+    'exelearning_before_elpx_save',
+    function ( $attachment_id, $old_file_path ) {
+        error_log( sprintf( 'Saving attachment %d', $attachment_id ) );
+    },
+    10,
+    2
+);
+```
+
+### `exelearning_after_elpx_save`
+
+Fires after an `.elpx` file has been successfully saved and committed: the new file
+is written, the new content is extracted, and metadata is persisted. It never fires
+on a failed save, extraction, or metadata persistence.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `$attachment_id` | `int` | Updated attachment ID. |
+| `$new_hash` | `string` | Hash of the new extracted content. |
+| `$old_hash` | `string` | Previous extraction hash, or `''` if none. |
+
+```php
+add_action(
+    'exelearning_after_elpx_save',
+    function ( $attachment_id, $new_hash, $old_hash ) {
+        error_log( sprintf( 'Attachment %d now at %s', $attachment_id, $new_hash ) );
+    },
+    10,
+    3
+);
+```
+
+### `exelearning_after_style_installed`
+
+Fires after a style ZIP has been installed and registered.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `$slug` | `string` | Style slug. |
+| `$entry` | `array` | Final style registry entry that was persisted. |
+
+```php
+add_action(
+    'exelearning_after_style_installed',
+    function ( $slug, $entry ) {
+        error_log( sprintf( 'Style installed: %s', $slug ) );
+    },
+    10,
+    2
+);
+```
+
+### `exelearning_after_style_deleted`
+
+Fires after an uploaded style has been deleted (both the files on disk and the
+registry entry).
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `$slug` | `string` | Style slug that was deleted. |
+
+```php
+add_action(
+    'exelearning_after_style_deleted',
+    function ( $slug ) {
+        error_log( sprintf( 'Style deleted: %s', $slug ) );
+    }
+);
+```
+
+### `exelearning_after_style_enabled_changed`
+
+Fires after an uploaded style has been enabled or disabled.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `$slug` | `string` | Style slug. |
+| `$enabled` | `bool` | New enabled state. |
+
+```php
+add_action(
+    'exelearning_after_style_enabled_changed',
+    function ( $slug, $enabled ) {
+        error_log( sprintf( 'Style %s enabled=%s', $slug, $enabled ? 'yes' : 'no' ) );
+    },
+    10,
+    2
+);
+```
+
+### `exelearning_before_editor_install`
+
+Fires before the static editor installation starts, after the target version has
+been resolved. Observation only — it must not change the download URL or skip
+checksum/archive validation.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `$version` | `string` | Requested editor version. |
+
+```php
+add_action(
+    'exelearning_before_editor_install',
+    function ( $version ) {
+        error_log( sprintf( 'Installing editor %s', $version ) );
+    }
+);
+```
+
+### `exelearning_after_editor_install`
+
+Fires after the static editor has been installed successfully.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `$metadata` | `array` | Installed editor metadata (`version`, `installed_at`). |
+
+```php
+add_action(
+    'exelearning_after_editor_install',
+    function ( $metadata ) {
+        error_log( sprintf( 'Editor installed: %s', $metadata['version'] ) );
+    }
+);
+```
+
+### `exelearning_editor_install_failed`
+
+Fires when the static editor installation fails.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `$error` | `WP_Error` | WP_Error describing the failure. |
+
+```php
+add_action(
+    'exelearning_editor_install_failed',
+    function ( $error ) {
+        error_log( sprintf( 'Editor install failed: %s', $error->get_error_message() ) );
+    }
+);
+```
+
+---
+
+## Filters
+
+### `exelearning_elpx_metadata`
+
+Filters the ELPX metadata array before it is saved to attachment meta. Callbacks may
+enrich the array with additional keys but **must return an array**. Required internal
+keys (`_exelearning_title`, `_exelearning_description`, `_exelearning_license`,
+`_exelearning_language`, `_exelearning_resource_type`, `_exelearning_extracted`,
+`_exelearning_version`, `_exelearning_has_preview`) are always restored afterwards,
+so this filter cannot drop or tamper with the plugin's own metadata or the extraction
+hash.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `$metadata` | `array` | Metadata array keyed by post meta key. |
+| `$file` | `string` | Source `.elpx` file path, or `''` when unavailable. |
+| `$elp_service` | `ExeLearning_Elp_File_Service` | The service that parsed the archive. |
+
+**Returns:** `array` — the enriched metadata array.
+
+```php
+add_filter(
+    'exelearning_elpx_metadata',
+    function ( $metadata, $file, $elp_service ) {
+        $metadata['_exelearning_department'] = 'Mathematics';
+        return $metadata;
+    },
+    10,
+    3
+);
+```
+
+### `exelearning_shortcode_atts`
+
+Filters the `[exelearning]` shortcode attributes after defaults are merged and before
+rendering. The values the renderer relies on are re-sanitized afterwards, so this
+filter cannot inject unsafe values or bypass the attachment/permission checks.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `$atts` | `array` | Sanitized shortcode attributes. |
+| `$file_id` | `int` | Attachment ID parsed from the shortcode. |
+
+**Returns:** `array` — the shortcode attributes.
+
+```php
+add_filter(
+    'exelearning_shortcode_atts',
+    function ( $atts, $file_id ) {
+        $atts['height'] = 900;
+        return $atts;
+    },
+    10,
+    2
+);
+```
+
+### `exelearning_preview_url`
+
+Filters the preview URL before it is rendered into the iframe. The value is still
+escaped with `esc_url()` at output time. This filter must **not** be used to bypass
+the content-proxy security model; pointing the iframe at an unverified external
+origin is unsupported.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `$preview_url` | `string` | Proxy preview URL. |
+| `$file_id` | `int` | Attachment ID. |
+| `$extracted_dir` | `string` | Extraction hash/directory for the attachment. |
+
+**Returns:** `string` — the preview URL.
+
+```php
+add_filter(
+    'exelearning_preview_url',
+    function ( $preview_url, $file_id, $extracted_dir ) {
+        return add_query_arg( 'lang', 'en', $preview_url );
+    },
+    10,
+    3
+);
+```
+
+### `exelearning_shortcode_output`
+
+Filters the final shortcode HTML before it is returned. It receives the
+already-rendered, escaped HTML and lets themes or integrations wrap or modify it. The
+default output is unchanged when no callback is attached. Any HTML added by a callback
+is its own responsibility to keep safe.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `$html` | `string` | Rendered shortcode HTML. |
+| `$file_id` | `int` | Attachment ID. |
+| `$atts` | `array` | Shortcode attributes used to render the output. |
+
+**Returns:** `string` — the shortcode HTML.
+
+```php
+add_filter(
+    'exelearning_shortcode_output',
+    function ( $html, $file_id, $atts ) {
+        return '<div class="my-wrapper">' . $html . '</div>';
+    },
+    10,
+    3
+);
+```
+
+### `exelearning_style_registry_entry`
+
+Filters a style registry entry before it is persisted. **Must return an array**; a
+non-array return is discarded. Required internal keys (`css_files`, `enabled`,
+`installed_at`, `checksum`, `size`) are always restored from the trusted built entry
+so this filter cannot inject unsafe paths, strip integrity fields, or bypass ZIP
+validation.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `$entry` | `array` | Style registry entry built from the validated ZIP. |
+| `$slug` | `string` | Allocated style slug. |
+| `$config` | `array` | Parsed style configuration. |
+
+**Returns:** `array` — the registry entry.
+
+```php
+add_filter(
+    'exelearning_style_registry_entry',
+    function ( $entry, $slug, $config ) {
+        $entry['category'] = 'institutional';
+        return $entry;
+    },
+    10,
+    3
+);
+```
+
+---
+
+## Existing configuration filters
+
+The plugin also exposes a few low-level configuration filters used as safety limits:
+
+| Filter | Default | Purpose |
+|--------|---------|---------|
+| `exelearning_max_extract_files` | `10000` | Maximum number of files allowed in an ELPX archive. |
+| `exelearning_max_extract_bytes` | `1073741824` (1 GB) | Maximum uncompressed extraction size. |
+| `exelearning_styles_max_zip_size` | `20 MB` | Maximum uploaded style ZIP size. |
+| `exelearning_content_origin` | `''` | Origin URL used when serving extracted content. |

--- a/includes/class-elp-file-service.php
+++ b/includes/class-elp-file-service.php
@@ -195,6 +195,22 @@ class ExeLearning_Elp_File_Service {
 			return new WP_Error( 'elp_too_many_files', 'ELP archive contains too many files.' );
 		}
 
+		/**
+		 * Fires right before an .elpx archive is extracted.
+		 *
+		 * Intended for logging, audit trails, metrics, or external integrations.
+		 * This is an observation point only: it runs after the archive has already
+		 * passed open/validation and the zip-bomb count guard, and it must NOT be
+		 * used to bypass validation, archive safety checks, path-traversal
+		 * protection, or alter extraction behavior.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $file_path   Source .elpx file path.
+		 * @param string $destination Destination directory the archive extracts into.
+		 */
+		do_action( 'exelearning_before_elpx_extract', $file_path, $destination );
+
 		// Extract entry by entry instead of ZipArchive::extractTo(): this lets us
 		// reject path traversal / absolute paths / stream wrappers, neutralize
 		// symlink entries (we always write regular files), and cap the total
@@ -212,6 +228,22 @@ class ExeLearning_Elp_File_Service {
 				return new WP_Error( 'elp_extract_empty', 'ZIP extraction produced no files.' );
 			}
 		}
+
+		/**
+		 * Fires after an .elpx archive has been successfully extracted.
+		 *
+		 * Only runs when extraction completed without error; it never fires on a
+		 * failed or partial extraction. Intended for logging, audit trails,
+		 * metrics, or external integrations. It is an observation point only and
+		 * must NOT be used to bypass any validation or safety check.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $file_path   Source .elpx file path.
+		 * @param string $destination Final extraction directory.
+		 * @param array  $metadata    Metadata parsed from the archive.
+		 */
+		do_action( 'exelearning_after_elpx_extract', $file_path, $destination, $this->to_array() );
 
 		return true;
 	}
@@ -427,5 +459,83 @@ class ExeLearning_Elp_File_Service {
 			'language'             => $this->metadata['language'],
 			'learningResourceType' => $this->metadata['learning_resource_type'],
 		);
+	}
+
+	/**
+	 * Attachment meta keys that the plugin relies on internally.
+	 *
+	 * These are always preserved from the trusted, pre-filter values so a
+	 * third-party callback on {@see 'exelearning_elpx_metadata'} cannot drop or
+	 * corrupt the data the plugin needs to locate and render extracted content.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string[]
+	 */
+	const REQUIRED_META_KEYS = array(
+		'_exelearning_title',
+		'_exelearning_description',
+		'_exelearning_license',
+		'_exelearning_language',
+		'_exelearning_resource_type',
+		'_exelearning_extracted',
+		'_exelearning_version',
+		'_exelearning_has_preview',
+	);
+
+	/**
+	 * Applies the metadata filter before ELPX metadata is persisted.
+	 *
+	 * Lets integrations enrich the attachment metadata array (for example, add
+	 * custom keys for an LMS or catalogue) right before it is written to post
+	 * meta. The return value is validated defensively: a non-array return is
+	 * discarded, and every required internal key is restored from the trusted
+	 * pre-filter values so a misbehaving callback can add keys but can never drop
+	 * or overwrite the data the plugin depends on.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array                        $metadata    Metadata array keyed by post meta key.
+	 * @param string                       $file        Source .elpx file path, or '' when unavailable.
+	 * @param ExeLearning_Elp_File_Service $elp_service The service that parsed the archive.
+	 * @return array Sanitized metadata array with all required internal keys preserved.
+	 */
+	public static function filter_metadata( array $metadata, string $file, $elp_service ): array {
+		// Snapshot trusted internal values before handing data to third parties.
+		$trusted = array();
+		foreach ( self::REQUIRED_META_KEYS as $key ) {
+			if ( array_key_exists( $key, $metadata ) ) {
+				$trusted[ $key ] = $metadata[ $key ];
+			}
+		}
+
+		/**
+		 * Filters the ELPX metadata array before it is saved to attachment meta.
+		 *
+		 * Callbacks may enrich the array with additional keys but MUST return an
+		 * array. Required internal keys (see REQUIRED_META_KEYS) are always
+		 * restored afterwards, so this filter cannot be used to drop or tamper
+		 * with the plugin's own metadata, the extraction hash, or any security
+		 * relevant value.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param array                        $metadata    Metadata array keyed by post meta key.
+		 * @param string                       $file        Source .elpx file path, or '' when unavailable.
+		 * @param ExeLearning_Elp_File_Service $elp_service The service that parsed the archive.
+		 * @return array Enriched metadata array. Must be an array.
+		 */
+		$filtered = apply_filters( 'exelearning_elpx_metadata', $metadata, $file, $elp_service );
+
+		if ( ! is_array( $filtered ) ) {
+			$filtered = array();
+		}
+
+		// Restore the trusted internal keys regardless of what the filter did.
+		foreach ( $trusted as $key => $value ) {
+			$filtered[ $key ] = $value;
+		}
+
+		return $filtered;
 	}
 }

--- a/includes/class-elp-reprocessor.php
+++ b/includes/class-elp-reprocessor.php
@@ -338,14 +338,24 @@ class ExeLearning_Reprocessor {
 	 * @param bool                         $has_preview   Whether index.html exists.
 	 */
 	public function apply_metadata( $attachment_id, $elp_service, $hash, $has_preview ) {
-		update_post_meta( $attachment_id, '_exelearning_title', $elp_service->get_title() );
-		update_post_meta( $attachment_id, '_exelearning_description', $elp_service->get_description() );
-		update_post_meta( $attachment_id, '_exelearning_license', $elp_service->get_license() );
-		update_post_meta( $attachment_id, '_exelearning_language', $elp_service->get_language() );
-		update_post_meta( $attachment_id, '_exelearning_resource_type', $elp_service->get_learning_resource_type() );
-		update_post_meta( $attachment_id, '_exelearning_extracted', $hash );
-		update_post_meta( $attachment_id, '_exelearning_version', $elp_service->get_version() );
-		update_post_meta( $attachment_id, '_exelearning_has_preview', $has_preview ? '1' : '0' );
+		$metadata = array(
+			'_exelearning_title'         => $elp_service->get_title(),
+			'_exelearning_description'   => $elp_service->get_description(),
+			'_exelearning_license'       => $elp_service->get_license(),
+			'_exelearning_language'      => $elp_service->get_language(),
+			'_exelearning_resource_type' => $elp_service->get_learning_resource_type(),
+			'_exelearning_extracted'     => $hash,
+			'_exelearning_version'       => $elp_service->get_version(),
+			'_exelearning_has_preview'   => $has_preview ? '1' : '0',
+		);
+
+		// Allow integrations to enrich metadata (required keys are preserved).
+		$file     = (string) get_attached_file( $attachment_id );
+		$metadata = ExeLearning_Elp_File_Service::filter_metadata( $metadata, $file, $elp_service );
+
+		foreach ( $metadata as $key => $value ) {
+			update_post_meta( $attachment_id, $key, $value );
+		}
 
 		// Update attachment title/caption.
 		wp_update_post(
@@ -355,6 +365,16 @@ class ExeLearning_Reprocessor {
 				'post_content' => $elp_service->get_description(),
 			)
 		);
+
+		/**
+		 * Fires after ELPX metadata has been saved to the attachment.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param int   $attachment_id WordPress attachment ID.
+		 * @param array $metadata      Final metadata array that was saved.
+		 */
+		do_action( 'exelearning_after_elpx_metadata_saved', $attachment_id, $metadata );
 	}
 
 	/**

--- a/includes/class-elp-upload-handler.php
+++ b/includes/class-elp-upload-handler.php
@@ -135,6 +135,9 @@ class ExeLearning_Elp_Upload_Handler {
 			'_exelearning_has_preview'   => $has_preview ? '1' : '0',
 		);
 
+		// Allow integrations to enrich metadata (required keys are preserved).
+		$metadata = ExeLearning_Elp_File_Service::filter_metadata( $metadata, $file, $elp_service );
+
 		$transient_key = 'exelearning_data_' . md5( $file );
 
 		set_transient(
@@ -186,6 +189,16 @@ class ExeLearning_Elp_Upload_Handler {
 			}
 
 			delete_transient( $transient_key );
+
+			/**
+			 * Fires after ELPX metadata has been saved to the attachment.
+			 *
+			 * @since 1.0.0
+			 *
+			 * @param int   $attachment_id WordPress attachment ID.
+			 * @param array $metadata      Final metadata array that was saved.
+			 */
+			do_action( 'exelearning_after_elpx_metadata_saved', $attachment_id, $data['metadata'] );
 		}
 	}
 

--- a/includes/class-exelearning-rest-api.php
+++ b/includes/class-exelearning-rest-api.php
@@ -376,6 +376,21 @@ class ExeLearning_REST_API {
 		// Save old extraction hash before it gets replaced.
 		$old_hash = get_post_meta( $attachment_id, '_exelearning_extracted', true );
 
+		/**
+		 * Fires before an existing .elpx file is replaced via the REST editor.
+		 *
+		 * Observation point only (logging, audit trails, metrics). It runs after
+		 * the request has already passed capability and nonce checks and must NOT
+		 * be used to alter the storage path, skip validation, or change the
+		 * replacement/cleanup behavior.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param int    $attachment_id Attachment being updated.
+		 * @param string $old_file_path Current file path before replacement.
+		 */
+		do_action( 'exelearning_before_elpx_save', $attachment_id, $old_file_path );
+
 		// Route the uploaded file through WordPress so the move (and MIME check)
 		// goes via the wp_handle_upload() wrapper that Plugin Check accepts.
 		require_once ABSPATH . 'wp-admin/includes/file.php';
@@ -460,6 +475,21 @@ class ExeLearning_REST_API {
 				'post_modified_gmt' => current_time( 'mysql', true ),
 			)
 		);
+
+		/**
+		 * Fires after an .elpx file has been successfully saved and committed.
+		 *
+		 * Only runs once the new file is written, the new content is extracted,
+		 * and metadata is persisted; it never fires on a failed save, failed
+		 * extraction, or failed metadata persistence. Observation point only.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param int    $attachment_id Updated attachment ID.
+		 * @param string $new_hash      Hash of the new extracted content.
+		 * @param string $old_hash      Previous extraction hash, or '' if none.
+		 */
+		do_action( 'exelearning_after_elpx_save', $attachment_id, $extraction['hash'], (string) $old_hash );
 
 		return rest_ensure_response( $this->build_save_response( $attachment_id ) );
 	}

--- a/includes/class-static-editor-installer.php
+++ b/includes/class-static-editor-installer.php
@@ -151,9 +151,67 @@ class ExeLearning_Static_Editor_Installer {
 	public function install_latest_editor() {
 		$version = $this->discover_latest_version();
 		if ( is_wp_error( $version ) ) {
+			$this->fire_install_failed( $version );
 			return $version;
 		}
 
+		/**
+		 * Fires before the static editor installation starts.
+		 *
+		 * Observation point only. It runs after the target version has been
+		 * resolved and must NOT be used to change the download URL, skip checksum
+		 * or archive validation, or alter the trusted install directory.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $version Requested editor version.
+		 */
+		do_action( 'exelearning_before_editor_install', $version );
+
+		$result = $this->perform_editor_install( $version );
+
+		if ( is_wp_error( $result ) ) {
+			$this->fire_install_failed( $result );
+			return $result;
+		}
+
+		/**
+		 * Fires after the static editor has been installed successfully.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param array $metadata Installed editor metadata (version, installed_at).
+		 */
+		do_action( 'exelearning_after_editor_install', $result );
+
+		return $result;
+	}
+
+	/**
+	 * Fire the editor-install failure action.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param WP_Error $error The failure that aborted installation.
+	 */
+	private function fire_install_failed( $error ) {
+		/**
+		 * Fires when the static editor installation fails.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param WP_Error $error WP_Error describing the failure.
+		 */
+		do_action( 'exelearning_editor_install_failed', $error );
+	}
+
+	/**
+	 * Download, verify, and install the editor for a resolved version.
+	 *
+	 * @param string $version Resolved editor version.
+	 * @return array|WP_Error Installed metadata on success, WP_Error on failure.
+	 */
+	private function perform_editor_install( $version ) {
 		$asset_url = $this->get_asset_url( $version );
 
 		$tmp_file = $this->download_asset( $asset_url );

--- a/includes/class-styles-service.php
+++ b/includes/class-styles-service.php
@@ -243,8 +243,19 @@ class ExeLearning_Styles_Service {
 		if ( ! isset( $registry['uploaded'][ $slug ] ) ) {
 			return new WP_Error( 'style_not_found', __( 'Style not found.', 'exelearning' ) );
 		}
-		$registry['uploaded'][ $slug ]['enabled'] = (bool) $enabled;
+		$enabled                                  = (bool) $enabled;
+		$registry['uploaded'][ $slug ]['enabled'] = $enabled;
 		self::save_registry( $registry );
+
+		/**
+		 * Fires after an uploaded style has been enabled or disabled.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $slug    Style slug.
+		 * @param bool   $enabled New enabled state.
+		 */
+		do_action( 'exelearning_after_style_enabled_changed', $slug, $enabled );
 		return true;
 	}
 
@@ -287,6 +298,17 @@ class ExeLearning_Styles_Service {
 		}
 		unset( $registry['uploaded'][ $slug ] );
 		self::save_registry( $registry );
+
+		/**
+		 * Fires after an uploaded style has been deleted.
+		 *
+		 * Runs after both the files on disk and the registry entry are removed.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $slug Style slug that was deleted.
+		 */
+		do_action( 'exelearning_after_style_deleted', $slug );
 		return true;
 	}
 
@@ -336,10 +358,49 @@ class ExeLearning_Styles_Service {
 			);
 		}
 
-		$entry                         = ExeLearning_Style_Package::build_entry( $config, $slug, $zip_path, $css_files );
+		$entry = ExeLearning_Style_Package::build_entry( $config, $slug, $zip_path, $css_files );
+
+		/**
+		 * Filters the style registry entry before it is persisted.
+		 *
+		 * Allows integrations to enrich the stored style metadata (for example,
+		 * add a category or display label). Must return an array; a non-array
+		 * return is discarded. Required internal keys (css_files, enabled,
+		 * installed_at, checksum, size) are always restored from the trusted
+		 * built entry so this filter cannot inject unsafe paths, strip integrity
+		 * fields, or bypass ZIP validation.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param array  $entry  Style registry entry built from the validated ZIP.
+		 * @param string $slug   Allocated style slug.
+		 * @param array  $config Parsed style configuration (theme.json / config).
+		 * @return array Registry entry. Must be an array.
+		 */
+		$filtered = apply_filters( 'exelearning_style_registry_entry', $entry, $slug, $config );
+		if ( is_array( $filtered ) ) {
+			// Restore trusted internal keys regardless of what the filter did.
+			foreach ( array( 'css_files', 'enabled', 'installed_at', 'checksum', 'size' ) as $required_key ) {
+				if ( array_key_exists( $required_key, $entry ) ) {
+					$filtered[ $required_key ] = $entry[ $required_key ];
+				}
+			}
+			$entry = $filtered;
+		}
+
 		$registry                      = self::get_registry();
 		$registry['uploaded'][ $slug ] = $entry;
 		self::save_registry( $registry );
+
+		/**
+		 * Fires after a style ZIP has been installed and registered.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $slug  Style slug.
+		 * @param array  $entry Final style registry entry that was persisted.
+		 */
+		do_action( 'exelearning_after_style_installed', $slug, $entry );
 
 		$entry['id']   = $slug;
 		$entry['name'] = $slug;

--- a/public/class-shortcodes.php
+++ b/public/class-shortcodes.php
@@ -51,6 +51,29 @@ class ExeLearning_Shortcodes {
 		);
 
 		$file_id = intval( $atts['id'] );
+
+		/**
+		 * Filters the shortcode attributes after defaults are merged and before rendering.
+		 *
+		 * Allows integrations to change presentation-level options (height,
+		 * teacher mode, download button, download formats). The values the
+		 * renderer relies on are re-sanitized below, so this filter cannot inject
+		 * unsafe values, bypass the attachment/permission checks, or change which
+		 * file is rendered in an unsafe way.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param array $atts    Sanitized shortcode attributes.
+		 * @param int   $file_id Attachment ID parsed from the shortcode.
+		 * @return array Shortcode attributes. Must be an array.
+		 */
+		$filtered_atts = apply_filters( 'exelearning_shortcode_atts', $atts, $file_id );
+		if ( is_array( $filtered_atts ) ) {
+			$atts = $filtered_atts;
+		}
+
+		// Recompute the file ID from the (possibly filtered) attributes.
+		$file_id = intval( $atts['id'] );
 		if ( ! $file_id ) {
 			return $this->render_error( __( 'Invalid eXeLearning file ID.', 'exelearning' ) );
 		}
@@ -83,13 +106,50 @@ class ExeLearning_Shortcodes {
 
 		if ( ! $extracted_dir || '1' !== $has_preview ) {
 			// No preview available - show download link.
-			return $this->render_no_preview( $title, $file_url, $download_html );
+			$html = $this->render_no_preview( $title, $file_url, $download_html );
+
+			/** This filter is documented below where the preview branch returns. */
+			return apply_filters( 'exelearning_shortcode_output', $html, $file_id, $atts );
 		}
 
 		// Build preview URL using secure proxy.
 		$preview_url = ExeLearning_Content_Proxy::get_proxy_url( $extracted_dir );
 
-		return $this->render_preview( $title, $preview_url, $height, $file_url, $teacher_mode_visible, $download_html );
+		/**
+		 * Filters the preview URL before it is rendered into the iframe.
+		 *
+		 * Allows integrations to wrap or adjust the preview URL. The value is
+		 * still escaped with esc_url() at output time. This filter must NOT be
+		 * used to bypass the plugin's content-proxy security model; pointing the
+		 * iframe at an unverified external origin is unsupported.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $preview_url   Proxy preview URL.
+		 * @param int    $file_id       Attachment ID.
+		 * @param string $extracted_dir Extraction hash/directory for the attachment.
+		 * @return string Preview URL.
+		 */
+		$preview_url = (string) apply_filters( 'exelearning_preview_url', $preview_url, $file_id, $extracted_dir );
+
+		$html = $this->render_preview( $title, $preview_url, $height, $file_url, $teacher_mode_visible, $download_html );
+
+		/**
+		 * Filters the final shortcode HTML before it is returned.
+		 *
+		 * Receives the already-rendered, escaped HTML and lets themes or
+		 * integrations wrap or modify it. The default output is unchanged when no
+		 * callback is attached. Any HTML added by a callback is its own
+		 * responsibility to keep safe.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $html    Rendered shortcode HTML.
+		 * @param int    $file_id Attachment ID.
+		 * @param array  $atts    Shortcode attributes used to render the output.
+		 * @return string Shortcode HTML.
+		 */
+		return apply_filters( 'exelearning_shortcode_output', $html, $file_id, $atts );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -25,3 +25,4 @@ For more information, see the [full documentation on GitHub](https://github.com/
 
 = 0.0.0 =
 * Initial release
+* Add developer lifecycle hooks (actions and filters) for ELPX extraction, metadata, REST saves, shortcode rendering, styles, and static editor installation. See docs/HOOKS.md.

--- a/tests/unit/DeveloperHooksTest.php
+++ b/tests/unit/DeveloperHooksTest.php
@@ -1,0 +1,491 @@
+<?php
+/**
+ * Tests for the developer lifecycle hooks (actions and filters).
+ *
+ * @package Exelearning
+ */
+
+/**
+ * Class DeveloperHooksTest.
+ *
+ * Exercises the public hook surface added for third-party integrations:
+ * the ELPX metadata filter, the metadata-saved action, the shortcode
+ * presentation filters, the style lifecycle actions/filter, and the static
+ * editor install actions. Each test asserts both that a hook fires and that
+ * the plugin's defensive validation cannot be subverted by a callback.
+ */
+class DeveloperHooksTest extends WP_UnitTestCase {
+
+	/**
+	 * Paths created during a test that must be removed on tear down.
+	 *
+	 * @var string[]
+	 */
+	private $cleanup_paths = array();
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->cleanup_paths = array();
+		delete_option( ExeLearning_Styles_Service::OPTION_REGISTRY );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tear_down() {
+		foreach ( $this->cleanup_paths as $path ) {
+			$this->recursive_delete( $path );
+		}
+		delete_option( ExeLearning_Styles_Service::OPTION_REGISTRY );
+		$storage = ExeLearning_Styles_Service::get_storage_dir();
+		if ( is_dir( $storage ) ) {
+			ExeLearning_Styles_Service::recursive_delete( $storage );
+		}
+		parent::tear_down();
+	}
+
+	/* -------------------------------------------------------------------- */
+	/* ELPX metadata filter                                                 */
+	/* -------------------------------------------------------------------- */
+
+	/**
+	 * The metadata filter is invoked and can enrich the array.
+	 */
+	public function test_elpx_metadata_filter_enriches() {
+		add_filter(
+			'exelearning_elpx_metadata',
+			static function ( $metadata ) {
+				$metadata['_exelearning_custom'] = 'enriched';
+				return $metadata;
+			}
+		);
+
+		$result = ExeLearning_Elp_File_Service::filter_metadata( $this->sample_metadata(), '/tmp/example.elpx', null );
+
+		$this->assertSame( 'enriched', $result['_exelearning_custom'] );
+		// Required keys are still present.
+		$this->assertSame( 'Sample', $result['_exelearning_title'] );
+		$this->assertArrayHasKey( '_exelearning_extracted', $result );
+	}
+
+	/**
+	 * A non-array return value is discarded and required keys are restored.
+	 */
+	public function test_elpx_metadata_filter_non_array_is_safe() {
+		add_filter(
+			'exelearning_elpx_metadata',
+			static function () {
+				return 'not an array';
+			}
+		);
+
+		$result = ExeLearning_Elp_File_Service::filter_metadata( $this->sample_metadata(), '', null );
+
+		$this->assertIsArray( $result );
+		foreach ( ExeLearning_Elp_File_Service::REQUIRED_META_KEYS as $key ) {
+			$this->assertArrayHasKey( $key, $result, "Required key {$key} must survive a bad filter." );
+		}
+		$this->assertSame( 'Sample', $result['_exelearning_title'] );
+	}
+
+	/**
+	 * A callback cannot drop or overwrite required internal keys.
+	 */
+	public function test_elpx_metadata_filter_cannot_corrupt_required_keys() {
+		add_filter(
+			'exelearning_elpx_metadata',
+			static function () {
+				// Try to wipe everything and forge the extraction hash.
+				return array( '_exelearning_extracted' => 'forged-hash' );
+			}
+		);
+
+		$result = ExeLearning_Elp_File_Service::filter_metadata( $this->sample_metadata(), '', null );
+
+		// The trusted pre-filter value wins.
+		$this->assertSame( 'deadbeef', $result['_exelearning_extracted'] );
+		$this->assertSame( 'Sample', $result['_exelearning_title'] );
+	}
+
+	/* -------------------------------------------------------------------- */
+	/* Metadata saved action (real flow via the reprocessor)                */
+	/* -------------------------------------------------------------------- */
+
+	/**
+	 * The saved action fires after metadata is persisted, with the right args.
+	 */
+	public function test_after_elpx_metadata_saved_fires() {
+		$captured = array();
+		add_action(
+			'exelearning_after_elpx_metadata_saved',
+			static function ( $attachment_id, $metadata ) use ( &$captured ) {
+				$captured[] = array( $attachment_id, $metadata );
+			},
+			10,
+			2
+		);
+
+		$fixture = $this->make_elpx_attachment();
+		$id      = $fixture['id'];
+
+		( new ExeLearning_Reprocessor() )->reprocess( $id );
+		$this->cleanup_paths[] = $this->extraction_dir( get_post_meta( $id, '_exelearning_extracted', true ) );
+
+		$this->assertGreaterThan( 0, did_action( 'exelearning_after_elpx_metadata_saved' ) );
+		$this->assertSame( $id, $captured[0][0] );
+		$this->assertIsArray( $captured[0][1] );
+		$this->assertArrayHasKey( '_exelearning_extracted', $captured[0][1] );
+	}
+
+	/**
+	 * The metadata filter is wired into the real persistence flow.
+	 */
+	public function test_elpx_metadata_filter_persists_enrichment() {
+		add_filter(
+			'exelearning_elpx_metadata',
+			static function ( $metadata ) {
+				$metadata['_exelearning_custom'] = 'lms-42';
+				return $metadata;
+			}
+		);
+
+		$fixture = $this->make_elpx_attachment();
+		$id      = $fixture['id'];
+
+		( new ExeLearning_Reprocessor() )->reprocess( $id );
+		$this->cleanup_paths[] = $this->extraction_dir( get_post_meta( $id, '_exelearning_extracted', true ) );
+
+		$this->assertSame( 'lms-42', get_post_meta( $id, '_exelearning_custom', true ) );
+	}
+
+	/* -------------------------------------------------------------------- */
+	/* Shortcode filters                                                    */
+	/* -------------------------------------------------------------------- */
+
+	/**
+	 * The atts filter can change a presentation attribute.
+	 */
+	public function test_shortcode_atts_filter_changes_height() {
+		add_filter(
+			'exelearning_shortcode_atts',
+			static function ( $atts ) {
+				$atts['height'] = 900;
+				return $atts;
+			}
+		);
+
+		$result = ( new ExeLearning_Shortcodes() )->display_exelearning( array( 'id' => $this->previewable_attachment() ) );
+
+		$this->assertStringContainsString( '900px', $result );
+	}
+
+	/**
+	 * Unsafe values returned by the atts filter are re-sanitized.
+	 */
+	public function test_shortcode_atts_filter_values_are_resanitized() {
+		add_filter(
+			'exelearning_shortcode_atts',
+			static function ( $atts ) {
+				$atts['height'] = 'evil"><script>alert(1)</script>';
+				return $atts;
+			}
+		);
+
+		$result = ( new ExeLearning_Shortcodes() )->display_exelearning( array( 'id' => $this->previewable_attachment() ) );
+
+		$this->assertStringNotContainsString( '<script>alert(1)', $result );
+		// absint() of the unsafe value collapses to 0px.
+		$this->assertStringContainsString( '0px', $result );
+	}
+
+	/**
+	 * The output filter can wrap the final HTML.
+	 */
+	public function test_shortcode_output_filter_wraps_html() {
+		add_filter(
+			'exelearning_shortcode_output',
+			static function ( $html ) {
+				return '<div class="wrap-marker">' . $html . '</div>';
+			}
+		);
+
+		$result = ( new ExeLearning_Shortcodes() )->display_exelearning( array( 'id' => $this->previewable_attachment() ) );
+
+		$this->assertStringContainsString( 'wrap-marker', $result );
+		$this->assertStringContainsString( 'exelearning-iframe', $result );
+	}
+
+	/* -------------------------------------------------------------------- */
+	/* Style lifecycle                                                      */
+	/* -------------------------------------------------------------------- */
+
+	/**
+	 * The installed action fires with the slug and entry.
+	 */
+	public function test_after_style_installed_fires() {
+		$captured = array();
+		add_action(
+			'exelearning_after_style_installed',
+			static function ( $slug, $entry ) use ( &$captured ) {
+				$captured[] = array( $slug, $entry );
+			},
+			10,
+			2
+		);
+
+		ExeLearning_Styles_Service::install_from_zip( $this->make_style_zip( 'acme' ), 'acme.zip' );
+
+		$this->assertSame( 'acme', $captured[0][0] );
+		$this->assertIsArray( $captured[0][1] );
+		$this->assertArrayHasKey( 'css_files', $captured[0][1] );
+	}
+
+	/**
+	 * The registry-entry filter can enrich the entry while required keys hold.
+	 */
+	public function test_style_registry_entry_filter_enriches_and_protects() {
+		add_filter(
+			'exelearning_style_registry_entry',
+			static function ( $entry ) {
+				$entry['category'] = 'institutional';
+				// Attempt to strip a protected key and forge another.
+				unset( $entry['css_files'] );
+				$entry['enabled'] = 'tampered';
+				return $entry;
+			}
+		);
+
+		ExeLearning_Styles_Service::install_from_zip( $this->make_style_zip( 'lab' ), 'lab.zip' );
+
+		$registry = ExeLearning_Styles_Service::get_registry();
+		$entry    = $registry['uploaded']['lab'];
+
+		$this->assertSame( 'institutional', $entry['category'] );
+		// Protected keys are restored from the trusted entry.
+		$this->assertArrayHasKey( 'css_files', $entry );
+		$this->assertTrue( $entry['enabled'] );
+	}
+
+	/**
+	 * The deleted action fires with the slug.
+	 */
+	public function test_after_style_deleted_fires() {
+		$captured = array();
+		add_action(
+			'exelearning_after_style_deleted',
+			static function ( $slug ) use ( &$captured ) {
+				$captured[] = $slug;
+			}
+		);
+
+		ExeLearning_Styles_Service::install_from_zip( $this->make_style_zip( 'bye' ), 'bye.zip' );
+		ExeLearning_Styles_Service::delete_uploaded( 'bye' );
+
+		$this->assertSame( array( 'bye' ), $captured );
+	}
+
+	/**
+	 * The enabled-changed action fires with the slug and boolean state.
+	 */
+	public function test_after_style_enabled_changed_fires() {
+		$captured = array();
+		add_action(
+			'exelearning_after_style_enabled_changed',
+			static function ( $slug, $enabled ) use ( &$captured ) {
+				$captured[] = array( $slug, $enabled );
+			},
+			10,
+			2
+		);
+
+		ExeLearning_Styles_Service::install_from_zip( $this->make_style_zip( 'toggle' ), 'toggle.zip' );
+		ExeLearning_Styles_Service::set_uploaded_enabled( 'toggle', false );
+
+		$this->assertSame( 'toggle', $captured[0][0] );
+		$this->assertFalse( $captured[0][1] );
+	}
+
+	/* -------------------------------------------------------------------- */
+	/* Static editor install                                                */
+	/* -------------------------------------------------------------------- */
+
+	/**
+	 * On a failed install the before and failed actions fire, but not after.
+	 */
+	public function test_editor_install_before_and_failed_actions_fire() {
+		$before = array();
+		$failed = array();
+		add_action(
+			'exelearning_before_editor_install',
+			static function ( $version ) use ( &$before ) {
+				$before[] = $version;
+			}
+		);
+		add_action(
+			'exelearning_editor_install_failed',
+			static function ( $error ) use ( &$failed ) {
+				$failed[] = $error;
+			}
+		);
+
+		$installer = new class() extends ExeLearning_Static_Editor_Installer {
+			/**
+			 * Pretend a version was resolved so the install proceeds.
+			 *
+			 * @return string
+			 */
+			public function discover_latest_version() {
+				return '9.9.9';
+			}
+
+			/**
+			 * Force the download step to fail.
+			 *
+			 * @param string $url Asset URL.
+			 * @return WP_Error
+			 */
+			public function download_asset( $url ) {
+				return new WP_Error( 'download_failed', 'Simulated download failure.' );
+			}
+		};
+
+		$result = $installer->install_latest_editor();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( array( '9.9.9' ), $before );
+		$this->assertCount( 1, $failed );
+		$this->assertInstanceOf( WP_Error::class, $failed[0] );
+		$this->assertSame( 0, did_action( 'exelearning_after_editor_install' ) );
+	}
+
+	/* -------------------------------------------------------------------- */
+	/* Helpers                                                              */
+	/* -------------------------------------------------------------------- */
+
+	/**
+	 * A representative metadata array as built before persistence.
+	 *
+	 * @return array
+	 */
+	private function sample_metadata() {
+		return array(
+			'_exelearning_title'         => 'Sample',
+			'_exelearning_description'   => 'Desc',
+			'_exelearning_license'       => 'CC-BY',
+			'_exelearning_language'      => 'en',
+			'_exelearning_resource_type' => 'lesson',
+			'_exelearning_extracted'     => 'deadbeef',
+			'_exelearning_version'       => 3,
+			'_exelearning_has_preview'   => '1',
+		);
+	}
+
+	/**
+	 * Create an attachment with extraction metadata pointing at a fake hash so
+	 * the shortcode renders its preview iframe (no files required).
+	 *
+	 * @return int Attachment ID.
+	 */
+	private function previewable_attachment() {
+		$attachment_id = $this->factory->attachment->create();
+		update_post_meta( $attachment_id, '_exelearning_extracted', str_repeat( 'a', 40 ) );
+		update_post_meta( $attachment_id, '_exelearning_has_preview', '1' );
+		return $attachment_id;
+	}
+
+	/**
+	 * Create an attachment backed by a valid previewable .elpx file on disk.
+	 *
+	 * @return array { id: int, path: string }
+	 */
+	private function make_elpx_attachment() {
+		$user_id       = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$attachment_id = $this->factory->attachment->create(
+			array(
+				'post_mime_type' => 'application/zip',
+				'post_author'    => $user_id,
+				'post_title'     => 'Hook ELP',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$upload_dir = wp_upload_dir();
+		$file_path  = $upload_dir['basedir'] . '/hooks-' . $attachment_id . '.elpx';
+
+		$zip = new ZipArchive();
+		$zip->open( $file_path, ZipArchive::CREATE );
+		$zip->addFromString( 'content.xml', '<package></package>' );
+		$zip->addFromString( 'index.html', '<html><body>Preview</body></html>' );
+		$zip->close();
+
+		$this->cleanup_paths[] = $file_path;
+		update_attached_file( $attachment_id, $file_path );
+
+		return array(
+			'id'   => $attachment_id,
+			'path' => $file_path,
+		);
+	}
+
+	/**
+	 * Build a minimal valid eXeLearning style ZIP on disk.
+	 *
+	 * @param string $name Theme/slug name.
+	 * @return string Absolute path to the created ZIP.
+	 */
+	private function make_style_zip( $name ) {
+		$path = wp_tempnam( 'hooks-style.zip' );
+		wp_delete_file( $path );
+		$zip = new ZipArchive();
+		$zip->open( $path, ZipArchive::CREATE );
+		$zip->addFromString(
+			'config.xml',
+			'<?xml version="1.0"?><theme>'
+				. '<name>' . esc_html( $name ) . '</name>'
+				. '<title>' . esc_html( ucfirst( $name ) ) . '</title>'
+				. '<version>1.0.0</version>'
+				. '<author>Test</author>'
+				. '<license>CC-BY-SA</license>'
+				. '<description>Test theme.</description>'
+				. '</theme>'
+		);
+		$zip->addFromString( 'style.css', 'body { color: red; }' );
+		$zip->close();
+		$this->cleanup_paths[] = $path;
+		return $path;
+	}
+
+	/**
+	 * Absolute path to the extraction directory for a hash.
+	 *
+	 * @param string $hash Extraction hash.
+	 * @return string
+	 */
+	private function extraction_dir( $hash ) {
+		$upload_dir = wp_upload_dir();
+		return trailingslashit( $upload_dir['basedir'] ) . 'exelearning/' . $hash . '/';
+	}
+
+	/**
+	 * Recursively delete a path.
+	 *
+	 * @param string $dir Path.
+	 */
+	private function recursive_delete( $dir ) {
+		if ( ! file_exists( $dir ) ) {
+			return;
+		}
+		if ( is_file( $dir ) || is_link( $dir ) ) {
+			unlink( $dir ); // phpcs:ignore
+			return;
+		}
+		$files = array_diff( scandir( $dir ), array( '.', '..' ) );
+		foreach ( $files as $file ) {
+			$this->recursive_delete( $dir . DIRECTORY_SEPARATOR . $file );
+		}
+		rmdir( $dir ); // phpcs:ignore
+	}
+}


### PR DESCRIPTION
## Summary

- Adds lifecycle **actions** for ELPX extraction, metadata persistence, REST saves, styles, and static editor installation.
- Adds presentation **filters** for shortcode attributes, preview URLs, and final shortcode output, plus a metadata-enrichment filter and a style-registry filter.
- Adds defensive validation around every filter's return value (required internal keys are always restored from trusted values).
- Documents the new developer hooks in `docs/HOOKS.md` and a "Developer hooks" section in the README.

All hook names are prefixed with `exelearning_` and carry complete docblocks with `@since 1.0.0`.

### Hooks added

| Area | Hooks |
|------|-------|
| ELPX extraction | `exelearning_before_elpx_extract`, `exelearning_after_elpx_extract` |
| Metadata | `exelearning_elpx_metadata` (filter), `exelearning_after_elpx_metadata_saved` |
| REST save | `exelearning_before_elpx_save`, `exelearning_after_elpx_save` |
| Shortcode | `exelearning_shortcode_atts`, `exelearning_preview_url`, `exelearning_shortcode_output` (filters) |
| Styles | `exelearning_after_style_installed`, `exelearning_after_style_deleted`, `exelearning_after_style_enabled_changed`, `exelearning_style_registry_entry` (filter) |
| Static editor | `exelearning_before_editor_install`, `exelearning_after_editor_install`, `exelearning_editor_install_failed` |

## Security

The new hooks do not allow bypassing validation, archive safety checks, capability checks, nonce checks, path-traversal protections, CSP headers, checksum/digest verification, or trusted-directory restrictions. They are limited to observation and presentation/metadata enrichment:

- No filters were added for skipping validation, changing trusted directories, or supplying arbitrary editor download URLs.
- `exelearning_elpx_metadata` and `exelearning_style_registry_entry` discard non-array returns and restore required internal keys, so a callback can enrich but never drop or forge the extraction hash or style integrity fields.
- Shortcode attribute values are re-sanitized after `exelearning_shortcode_atts`; the preview URL stays behind the content proxy and is escaped at output time.
- Existing default behavior is unchanged when no callbacks are registered.

## Testing

- Added `tests/unit/DeveloperHooksTest.php` (13 tests, 39 assertions) covering: the metadata filter (enrichment, non-array handling, required-key protection, real-flow persistence), the metadata-saved action, the shortcode `atts`/`output` filters (including re-sanitization of unsafe values), the style install/delete/enable actions and registry filter, and the editor install before/failed actions.
- `make test FILTER=DeveloperHooks` → **OK (13 tests, 39 assertions)**.
- `make lint` → clean (WordPress Coding Standards).
- Full `make test` → all pass **except** the pre-existing `StaticEditorInstallerTest::test_is_editor_installed_returns_false_when_missing`, which fails only because `dist/static/` is built in this local environment (confirmed it fails identically on a clean tree without these changes; it is unrelated to this PR).

Closes exelearning/exelearning#2049
