### PR TITLE
feat(playground): auto-load the editor in the WordPress Playground

### DIFF
--- a/.github/workflows/pr-playground-preview.yml
+++ b/.github/workflows/pr-playground-preview.yml
@@ -60,7 +60,7 @@ jobs:
               '',
               `<a href="${playgroundUrl}"><img src="https://raw.githubusercontent.com/${context.repo.owner}/${context.repo.repo}/refs/heads/${context.payload.pull_request.head.ref}/.github/playground-preview-button.svg" alt="Preview in WordPress Playground" width="224"></a>`,
               '',
-              '> ⚠️ The embedded eXeLearning editor is not included in this preview. You can install it from **Settings > eXeLearning** using the "Download & Install Editor" button. All other plugin features (ELP upload, shortcode, Gutenberg block, preview) work normally.',
+              '> ℹ️ The eXeLearning editor is fetched from the shared release and unpacked into the plugin when the playground boots, so the first load may take a few extra seconds. ELP upload, shortcode, Gutenberg block and preview work normally.',
             ].join('\n');
 
             // Find existing comment

--- a/blueprint.json
+++ b/blueprint.json
@@ -23,6 +23,18 @@
       }
     },
     {
+      "step": "writeFile",
+      "path": "/tmp/exe-editor.zip",
+      "data": {
+        "resource": "url",
+        "url": "https://github-proxy.exelearning.dev/?repo=exelearning/exelearning&release=v4.0.0&asset=exelearning-static-v4.0.0.zip"
+      }
+    },
+    {
+      "step": "runPHP",
+      "code": "<?php require_once '/wordpress/wp-load.php'; $dirs = glob(WP_PLUGIN_DIR . '/wp-exelearning*', GLOB_ONLYDIR); if ($dirs) { $dest = rtrim($dirs[0], '/') . '/dist'; if (!is_dir($dest)) { wp_mkdir_p($dest); } $zip = new ZipArchive; if ($zip->open('/tmp/exe-editor.zip') === TRUE) { $zip->extractTo($dest); $zip->close(); } @unlink('/tmp/exe-editor.zip'); } ?>"
+    },
+    {
       "step": "runPHP",
       "code": "<?php require_once '/wordpress/wp-load.php'; global $wp_rewrite; $wp_rewrite->set_permalink_structure('/%postname%/'); $wp_rewrite->flush_rules(true); ?>"
     },


### PR DESCRIPTION
## What

Auto-load the embedded eXeLearning editor in the WordPress Playground so it boots with a working editor instead of requiring the manual **Settings → eXeLearning → Download & Install Editor** button.

Two blueprint steps after `installPlugin`:
1. `writeFile` fetches the shared editor release asset through the github-proxy (CORS) over the **fast JS transport** into `/tmp/exe-editor.zip`.
2. `runPHP` locates the installed plugin dir and extracts the zip into its `dist/`:

```php
$dirs = glob(WP_PLUGIN_DIR . '/wp-exelearning*', GLOB_ONLYDIR);
$zip = new ZipArchive;
$zip->open('/tmp/exe-editor.zip');
$zip->extractTo($dirs[0] . '/dist');   // asset wraps in static/ -> dist/static/
```

## Why

The static editor is byte-identical across all eXeLearning plugins and is already published once at `exelearning/exelearning`. Fetching that shared artifact at blueprint time is the WordPress-Playground-idiomatic pattern (resource `url` + extract), and it keeps the plugin zip lean.

Notes:
- The plugin is installed from the **branch source archive**, so its directory carries a branch suffix (`wp-exelearning-<branch>`); the extract step finds it with a glob, so it works on any PR.
- `ZipArchive` is already used by the fixtures step, so no new runtime dependency.
- The asset's `static/` wrapper means extracting into `dist` yields the `dist/static/` layout the plugin loads from (`EXELEARNING_PLUGIN_DIR . 'dist/static/index.html'`). Pinned to `v4.0.0` to match `.editor-version`.
- `StaticEditorInstaller` is **kept** for production/offline installs; only the playground changes.

> Part of a fleet-wide change unifying how the editor loads in every eXeLearning playground.

## Test

Open the Playground for this branch and confirm the editor loads on boot (no manual step) and a page renders.