### PR TITLE
fix(playground): keep blueprint editor version in sync with .editor-version

### DIFF
--- a/.github/workflows/check-editor-releases.yml
+++ b/.github/workflows/check-editor-releases.yml
@@ -78,11 +78,19 @@ jobs:
       - name: Update editor version marker
         if: steps.check.outputs.found == 'true'
         run: |
-          echo "${{ steps.check.outputs.tag }}" > .editor-version
+          TAG="${{ steps.check.outputs.tag }}"
+          echo "$TAG" > .editor-version
+          # Keep the playground blueprint's editor URL in sync with .editor-version,
+          # otherwise the preview stays pinned to the hardcoded version.
+          sed -i -E \
+            -e "s#(release=)v[0-9][0-9A-Za-z.-]*#\1$TAG#g" \
+            -e "s#(releases/download/)v[0-9][0-9A-Za-z.-]*#\1$TAG#g" \
+            -e "s#(exelearning-static-)v[0-9][0-9A-Za-z.-]*(\.zip)#\1$TAG\2#g" \
+            blueprint.json
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .editor-version
-          git commit -m "Update editor version to ${{ steps.check.outputs.tag }}"
+          git add .editor-version blueprint.json
+          git commit -m "Update editor version to $TAG"
           git push
 
       - name: Build Playground URL for this release

--- a/blueprint.json
+++ b/blueprint.json
@@ -27,7 +27,7 @@
       "path": "/tmp/exe-editor.zip",
       "data": {
         "resource": "url",
-        "url": "https://github-proxy.exelearning.dev/?repo=exelearning/exelearning&release=v4.0.0&asset=exelearning-static-v4.0.0.zip"
+        "url": "https://github-proxy.exelearning.dev/?repo=exelearning/exelearning&release=v4.0.1&asset=exelearning-static-v4.0.1.zip"
       }
     },
     {


### PR DESCRIPTION
## Problem

The playground booted with eXeLearning editor **v4.0.0** even though the latest upstream release — and this repo's `.editor-version` — is **v4.0.1**.

Root cause: there are two sources of truth for the editor version, and only one was kept current.

- `.editor-version` — bumped automatically every day by `check-editor-releases.yml`.
- `blueprint.json` — a **hardcoded** editor download URL that the workflow never touched.

So `.editor-version` advanced to v4.0.1 while `blueprint.json` stayed pinned at v4.0.0, and the playground / PR-preview kept serving the old editor. Production plugin releases were unaffected (they bake the editor from `.editor-version`); only the playground demo drifted.

## Fix

- **Catch-up:** bump the editor URL in `blueprint.json` to v4.0.1 so it matches `.editor-version`.
- **Durable:** `check-editor-releases.yml` now rewrites the blueprint's editor URL (via `sed`) whenever it bumps `.editor-version`, and commits both files together, so they can never drift apart again.

The `sed` only rewrites the editor asset reference (`release=`, `releases/download/`, `exelearning-static-*.zip`); the plugin source URL and content fixtures are left untouched. Verified against plain version tags and RC-suffixed tags (e.g. `v4.0.0-rc3`).

## Verification

- `blueprint.json` now resolves the same version as `.editor-version` (v4.0.1).
- Dry-run of the workflow `sed` rewrites only the editor URL on a simulated bump.
- `blueprint.json` is valid JSON and the workflow is valid YAML.
