### PR TITLE
docs: point issue tracking to centralized exelearning/exelearning repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 ![License: AGPL v3](https://img.shields.io/badge/License-AGPLv3-blue.svg)
 ![Downloads](https://img.shields.io/github/downloads/exelearning/wp-exelearning/total)
 ![Last Commit](https://img.shields.io/github/last-commit/exelearning/wp-exelearning)
-![Open Issues](https://img.shields.io/github/issues/exelearning/wp-exelearning)
 
 WordPress plugin for eXeLearning content management. Upload, manage and embed eXeLearning `.elpx` files directly in your WordPress site.
 
@@ -150,6 +149,14 @@ make fix         # Auto-fix code style
 
 - WordPress 6.1 or higher
 - PHP 8.0 or higher
+
+## Issues and Support
+
+Issue tracking for this plugin is centralized in the main
+[`exelearning/exelearning`](https://github.com/exelearning/exelearning) repository.
+Please [open new issues there](https://github.com/exelearning/exelearning/issues/new),
+and browse [existing `wordpress`-labeled issues](https://github.com/exelearning/exelearning/issues?q=is%3Aissue+label%3Awordpress)
+before reporting a bug or requesting a feature.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Removes the stale "Open Issues" badge from the README, since Issues are now disabled on this repo.
- Adds an "Issues and Support" section pointing contributors to the centralized tracker in `exelearning/exelearning`, filtered by the `wordpress` label.

This is a follow-up to the issue centralization effort: all 10 existing issues from this repo were transferred to `exelearning/exelearning` and labeled `wordpress`, and Issues were disabled here.

Related to exelearning/exelearning#1861

## Test plan
- [x] Verified README renders correctly with the new section and without the removed badge.