### PR TITLE
docs(architecture): add ADR and SDD workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,41 @@ These are natural-language guidelines for agents to follow when developing the E
 - Keep plugin bootstrap file small (`exelearning.php`), modularize into separate files/classes with specific responsibility.
 - Keep the reference docs under `docs/` in sync with the code: `docs/SHORTCODES.md` documents the `[exelearning]` shortcode and all its attributes (including `teacher_mode` and `screenshot`), and `docs/HOOKS.md` documents the developer actions and filters. When you add or change a shortcode attribute or a hook, update the matching doc in the same change.
 
+## Architecture decisions and design documents
+
+Significant technical work is documented alongside the code under
+[`docs/architecture/`](docs/architecture/README.md). Full policy:
+[ADR guide](docs/architecture/adr/README.md),
+[SDD guide](docs/architecture/sdd/README.md).
+
+- Before implementing a significant architectural change, check
+  [`docs/architecture/adr/records.md`](docs/architecture/adr/records.md) and
+  [`docs/architecture/sdd/records.md`](docs/architecture/sdd/records.md).
+- **Create or update an SDD** for large changes, cross-cutting features,
+  security-sensitive changes, data/storage changes, REST API changes,
+  shortcode/block contract changes, build/distribution changes, or changes
+  affecting the embedded editor install flow. SDDs live under
+  `docs/architecture/sdd/`.
+- **Create an ADR** for durable technical decisions with long-term consequences
+  (storage layout, ELPX validation/extraction, content-proxy security model,
+  style registry, capability/nonce boundaries, REST/shortcode/block contracts).
+  ADRs live under `docs/architecture/adr/`.
+- Templates: `docs/architecture/adr/template.md`,
+  `docs/architecture/sdd/template.md`. IDs are monotonic and never reused.
+- Keep **accepted ADRs append-only** — supersede them with a new ADR
+  (`supersedes` / `superseded_by`) instead of rewriting history. Preserve
+  **implemented SDDs** as historical records; fix only typos/links.
+- When both exist, **link the SDD and the ADR** (the SDD's *ADRs required or
+  referenced* table and the ADR's `related.sdds`).
+- Record AI assistance in the frontmatter (`ai_assistance.tool` /
+  `ai_assistance.model`; `none` if not used). Use issue/PR links for
+  attribution — no people's names in frontmatter or templates.
+- **Do not** create ADRs/SDDs for trivial fixes, copy edits, translation-only or
+  test-only changes, or straightforward bug fixes that do not change
+  architecture.
+- Keep all architecture docs in English. For plugin code, continue following
+  WPCS and the existing testing/linting rules above.
+
 ## Aider-specific usage
 
 - Always load `AGENTS.md` as conventions file: e.g. `/read AGENTS.md` or via config.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -54,3 +54,9 @@
 - Ensure that all classes, methods, and functions are well-documented with PHPDoc.
 - The `README.txt` should provide a detailed overview, including installation instructions, usage, and a changelog.
 
+## Architecture Decisions & Design Documents
+- Significant design or architecture changes use the ADR/SDD workflow in [`docs/architecture/`](docs/architecture/README.md).
+- **ADRs** ([`docs/architecture/adr/`](docs/architecture/adr/README.md)) document durable decisions and their rationale; once accepted they are append-only and superseded rather than rewritten.
+- **SDDs** ([`docs/architecture/sdd/`](docs/architecture/sdd/README.md)) document substantial feature designs, their impact, and acceptance criteria; when an SDD contains a durable decision, link it to an ADR.
+- See the [ADR guide](docs/architecture/adr/README.md) and [SDD guide](docs/architecture/sdd/README.md) for templates, IDs and statuses.
+

--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ make lint        # Check code style
 make fix         # Auto-fix code style
 ```
 
+### Architecture documentation
+
+Durable architecture decisions and significant designs are recorded under
+[`docs/architecture/`](docs/architecture/README.md): Architecture Decision
+Records ([ADRs](docs/architecture/adr/README.md)) and Software Design Documents
+([SDDs](docs/architecture/sdd/README.md)). Review these before proposing a
+significant architectural or design change.
+
 ## Requirements
 
 - WordPress 6.1 or higher

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,61 @@
+# Architecture Documentation
+
+This directory holds the **architecture records** for the `wp-exelearning`
+WordPress plugin: durable decisions and significant designs that future
+contributors should be able to read long after the pull request that introduced
+them has scrolled out of view.
+
+## Operational docs vs architecture records
+
+The plugin keeps two different kinds of documentation, and they answer different
+questions:
+
+| Kind | Lives in | Answers |
+|------|----------|---------|
+| **Operational docs** | [`docs/SHORTCODES.md`](../SHORTCODES.md), [`docs/HOOKS.md`](../HOOKS.md), `README.md`, `readme.txt` | *How do I use this?* — the current shortcode attributes, hooks, install steps. Always describes the code as it is **now**. |
+| **Architecture records** | `docs/architecture/` (this directory) | *Why is it built this way?* and *what are we about to build?* — the reasoning behind durable decisions and the design of significant changes. |
+
+Operational docs are updated in place to match the code. Architecture records are
+kept as a history: accepted decisions are not rewritten, they are superseded.
+
+## What lives here
+
+- **[Architecture Decision Records (ADR)](adr/README.md)** — one durable
+  decision per record, with the context, the options, the evidence and the
+  consequences. ADRs answer *"why is it built this way?"*
+- **[Software Design Documents (SDD)](sdd/README.md)** — the design gate for
+  significant changes: goals, non-goals, the proposed design, and how it will be
+  validated. SDDs answer *"what are we about to build, and how?"*
+
+## When to use each
+
+- Reach for an **[ADR](adr/README.md)** when a change locks in a decision that
+  future contributors should not have to re-litigate — a storage layout, a
+  security boundary, a compatibility guarantee.
+- Reach for an **[SDD](sdd/README.md)** when a change is large enough to deserve
+  a design review before implementation — a new feature, a cross-cutting
+  refactor, a change touching uploads, extraction, the REST API, or the embedded
+  editor.
+- A large change often starts with an SDD; the durable decisions inside it are
+  extracted into ADRs and linked, instead of being buried in the design prose.
+
+See each guide for the exact rules on when a record is required, recommended, or
+unnecessary.
+
+## Relationship to the main eXeLearning repository
+
+The main [eXeLearning](https://github.com/exelearning/exelearning) repository
+adopted this ADR/SDD workflow in
+[`exelearning/exelearning#2149`](https://github.com/exelearning/exelearning/pull/2149),
+following the proposal in
+[`exelearning/exelearning#2148`](https://github.com/exelearning/exelearning/issues/2148),
+where the records live under `doc/architecture/`.
+
+`wp-exelearning` adapts the **same lightweight approach** to a WordPress plugin.
+Because this repository already stores its documentation under `docs/`, the
+records live under `docs/architecture/` instead. The templates and guidance are
+tailored to plugin concerns — WordPress capabilities and nonces, ELPX
+upload/extraction, the embedded editor install flow, shortcode and block
+rendering, the style registry, and the content proxy — rather than the main
+repository's server, collaboration and export internals. The two repositories
+keep separate, independent record histories.

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -1,0 +1,198 @@
+# Architecture Decision Records
+
+## Purpose
+
+An **Architecture Decision Record (ADR)** captures a single durable architectural
+decision together with the reasoning behind it: the context, the problem, the
+options that were considered, the evidence that informed the choice, the decision
+itself, and the consequences that follow.
+
+ADRs exist so that `wp-exelearning` contributors — human and AI — can answer
+*"why is it built this way?"* long after the fact, without archaeology through
+pull request threads or chat logs. A decision recorded only inside a PR
+description is easy to lose; an ADR is a first-class, long-lived document.
+
+Guiding principles:
+
+- **Evidence before preference.** Prefer a verifiable source over an assertion.
+- **No technical claim without a source.** Cite a repository path + commit,
+  official WordPress documentation, a benchmark, a reproducible experiment, an
+  issue, a PR, an SDD, or a previous ADR.
+- **Separate facts, interpretation and decision.** Say what is observed, what it
+  means, and what was decided — in that order.
+- **Stable, monotonic IDs.** IDs are never reused.
+- **Append-only.** Accepted decisions are not rewritten; they are superseded.
+
+## ADRs vs SDDs
+
+ADRs and [Software Design Documents (SDDs)](../sdd/README.md) are complementary,
+not competing.
+
+| Artifact | Answers | Lifetime |
+|----------|---------|----------|
+| **SDD** | *What* will be built and *how* a significant change will be implemented | May become historical once implemented |
+| **ADR** | *Which* durable decision was made and *why* | Long-lived, append-only |
+| **PR** | The concrete code/doc changes under review | Historical review record |
+| **Issue** | The problem, proposal or discussion being coordinated | Historical coordination record |
+
+A large change usually starts with an SDD that describes the design and the
+implementation plan. Inside that SDD, the decisions that will outlive the change
+itself — a storage layout, a file-format guarantee, a security boundary — should
+be extracted into ADRs or linked to existing ones. The SDD records the design;
+the ADR records the decision and its rationale. Do **not** copy the whole SDD
+into an ADR.
+
+## An ADR is not…
+
+- **…an implementation plan.** That is what an [SDD](../sdd/README.md) is for.
+- **…an issue summary.** The issue already coordinates the discussion; the ADR
+  records the durable conclusion.
+- **…a changelog entry.** Use `readme.txt` for user-facing release notes.
+
+## When an ADR is required
+
+Create or update an ADR when a change **introduces or modifies a durable
+architectural decision** — one that future contributors should not have to
+re-litigate. In this plugin that typically includes decisions affecting:
+
+- the storage model for ELPX packages and their metadata (attachment post meta,
+  the `wp-content/uploads/exelearning/` extraction layout, checksums);
+- ELPX validation and extraction (ZIP handling, path-traversal protection,
+  size limits);
+- the embedded editor installation/build flow and where its assets are stored;
+- the content proxy and the security model around serving extracted content;
+- the style registry and where uploaded style packages are stored;
+- WordPress integration boundaries: capabilities, nonces, REST API contracts,
+  shortcode/block attribute contracts, Media Library integration;
+- backward-compatibility guarantees for shortcodes, blocks, hooks, or stored
+  metadata;
+- any AI-assisted generation workflow or policy.
+
+If in doubt, prefer writing a short ADR over losing the reasoning.
+
+## When an ADR is recommended
+
+An ADR is worth writing, even when not strictly required, when a change would
+otherwise leave reviewers guessing *why* a non-obvious approach was chosen — for
+example picking one WordPress API over another, or accepting a trade-off that a
+later contributor might be tempted to "fix".
+
+## When an ADR is not needed
+
+Do **not** write an ADR for:
+
+- bug fixes that restore intended behavior;
+- routine refactors with no externally observable decision;
+- dependency bumps, lint/format changes, copy edits;
+- translation-only or test-only changes;
+- purely local implementation details with no cross-cutting impact.
+
+If a change is significant enough to need a design but does not yet lock a
+durable decision, start with an [SDD](../sdd/README.md) instead.
+
+## Location and naming
+
+- ADRs live in `docs/architecture/adr/`.
+- Filenames follow: `ADR-NNNN-short-kebab-case-title.md` — for example
+  `ADR-0001-store-elpx-extractions-by-sha1.md`.
+- IDs are zero-padded, monotonic and never reused. The next ID is
+  `max(existing) + 1`, starting at `ADR-0001`.
+- [`template.md`](template.md) is the canonical template. Copy it to a new file
+  and assign the next ID.
+- [`records.md`](records.md) lists every ADR. The index is maintained by hand.
+
+## Status values
+
+| Status | Meaning |
+|--------|---------|
+| `Proposed` | Under discussion; not yet agreed. |
+| `Accepted` | Agreed and in force. |
+| `Rejected` | Considered and declined. Kept for the record. |
+| `Superseded` | Replaced by a later ADR (see `superseded_by`). |
+
+A decision that is still being debated stays `Proposed`. It becomes `Accepted`
+only after reviewer approval on the PR.
+
+## Evidence and traceability
+
+Every technical claim in an ADR should cite a verifiable source. Acceptable
+evidence includes:
+
+- a repository path plus commit (e.g. `includes/class-elp-file-service.php` @ `abc1234`);
+- official WordPress documentation or a specification;
+- a benchmark or a reproducible experiment (numbers + how to reproduce);
+- a linked issue, PR, SDD, or prior ADR.
+
+Keep the evidence **inside** the ADR. This repository does not maintain a
+separate `sources/` or `experiments/` tree.
+
+## Recording alternatives and consequences
+
+- **Alternatives considered** — list the realistic options, with their pros and
+  cons, so a reader can see the decision was a choice and not an accident.
+- **Consequences** — state the positive, negative and neutral effects honestly.
+  A decision with no downsides is usually a decision that was not examined
+  closely enough.
+
+## AI-assisted ADRs
+
+If an AI tool helped draft or research an ADR, disclose it in the frontmatter:
+
+```yaml
+ai_assistance:
+  tool: "Claude Code"        # tool / interface used
+  model: "claude-opus-4-8"   # model, when relevant
+```
+
+If no AI tool was involved, set both fields to `none`. Disclosure is about
+traceability, not judgement: it records how the document was produced so the
+evidence can be weighed accordingly. The frontmatter deliberately records tools
+and links, **not** the names of people — use issue and PR links for attribution.
+
+## Superseding an ADR
+
+Accepted ADRs are **append-only**. Do not rewrite them except to fix typos or
+broken links.
+
+To change an accepted decision:
+
+1. Create a new ADR with the next ID.
+2. Set `supersedes: [ADR-XXXX]` in the new ADR's frontmatter.
+3. Set `status: Superseded` and `superseded_by: [ADR-YYYY]` in the old ADR.
+4. Update [`records.md`](records.md).
+
+This keeps the decision history intact and readable in order.
+
+## Linking ADRs and SDDs
+
+- List related SDDs under `related.sdds` in the ADR frontmatter and in the
+  References section.
+- From an SDD, list the ADR in the *ADRs required or referenced* table.
+- Refer to ADRs by their ID so links stay stable:
+  - **From code / comments:** `// See ADR-0001 for why extractions are keyed by SHA1.`
+  - **From docs:** `[ADR-0001](ADR-0001-....md)` (adjust the relative path).
+  - **From a PR or issue:** mention `ADR-0001` in the description and link the file.
+
+## Workflow
+
+1. Identify a durable decision (see *When an ADR is required*).
+2. Copy [`template.md`](template.md) to `ADR-NNNN-short-title.md` with the next
+   ID.
+3. Fill in context, problem, alternatives, evidence, decision and consequences.
+   Start at `status: Proposed`.
+4. Add the ADR to [`records.md`](records.md).
+5. Open (or reference) a PR. Reviewers discuss and, if agreed, the status moves
+   to `Accepted`.
+6. If a later change reverses the decision, supersede it — never edit the
+   accepted record.
+
+## Review checklist
+
+- [ ] The ADR has a unique, monotonic ID and a kebab-case title.
+- [ ] Context, problem, alternatives, decision and consequences are all present.
+- [ ] Every technical claim cites a verifiable source.
+- [ ] Positive, negative and neutral consequences are stated honestly.
+- [ ] `status` reflects reality (`Proposed` while under discussion).
+- [ ] `ai_assistance` is filled in (values or `none`).
+- [ ] Superseding ADRs set `supersedes` / the old ADR sets `superseded_by`.
+- [ ] [`records.md`](records.md) is updated.

--- a/docs/architecture/adr/records.md
+++ b/docs/architecture/adr/records.md
@@ -1,0 +1,28 @@
+# ADR Index
+
+This page lists the Architecture Decision Records for `wp-exelearning`. See the
+[ADR guide](README.md) for the policy and [`template.md`](template.md) for the
+starting point.
+
+The index is maintained by hand. When an ADR is added, superseded, or changes
+status, update the table and the per-status lists below.
+
+| ID | Title | Status | Date | Related SDD |
+|----|-------|--------|------|-------------|
+| _None yet_ | | | | |
+
+> No ADRs have been recorded yet. The first numbered ADR (`ADR-0001`) will be
+> created by the first change that locks in a durable architecture decision.
+> Copy [`template.md`](template.md) to `ADR-0001-short-title.md` to start it.
+
+## Proposed ADRs
+
+_No proposed ADRs yet._
+
+## Accepted ADRs
+
+_No accepted ADRs yet._
+
+## Superseded ADRs
+
+_No superseded ADRs yet._

--- a/docs/architecture/adr/template.md
+++ b/docs/architecture/adr/template.md
@@ -1,0 +1,112 @@
+---
+id: ADR-0000
+title: "Short decision title"
+status: Proposed
+date: YYYY-MM-DD
+related:
+  issues: []
+  prs: []
+  sdds: []
+  adrs: []
+supersedes: []
+superseded_by: []
+ai_assistance:
+  tool: ""
+  model: ""
+---
+
+<!--
+How to use this template:
+1. Copy this file to `ADR-NNNN-short-kebab-case-title.md` with the next free ID.
+2. Update the frontmatter above (id, title, date, related links).
+3. Fill every section below. Delete guidance comments before submitting.
+4. Keep the file at `status: Proposed` until reviewers accept it.
+5. Cite a verifiable source for each technical claim (repo path + commit,
+   WordPress documentation, benchmark, experiment, issue, PR, SDD, or prior ADR).
+6. Record AI assistance in `ai_assistance` (values, or `none` if not used).
+7. Use issue/PR links for attribution — do not add people's names.
+See ../README.md for the full policy.
+-->
+
+# ADR-0000: Short decision title
+
+## Status
+
+Proposed
+
+<!-- One of: Proposed | Accepted | Rejected | Superseded. Keep it in sync with
+the frontmatter `status`. If superseded, link the replacement ADR. -->
+
+## Context
+
+<!-- The situation that forces a decision. What is happening, what constraints
+apply (WordPress version support, PHP version, plugin-review rules), and why now.
+State facts, not opinions. -->
+
+## Problem
+
+<!-- The specific question this ADR answers, phrased so a chosen option resolves
+it. -->
+
+## Decision drivers
+
+<!-- The forces that matter: security, backward compatibility, performance,
+accessibility, internationalization, maintainability, WordPress Coding Standards,
+plugin-review constraints, implementation effort. -->
+
+- Driver 1
+- Driver 2
+
+## Alternatives considered
+
+### Option 1: ...
+
+<!-- Describe the option, then its pros and cons. -->
+
+### Option 2: ...
+
+### Option 3: ...
+
+## Evidence
+
+<!-- The verifiable basis for the decision. Prefer:
+- repository path + commit (e.g. `includes/class-elp-file-service.php` @ `abc1234`)
+- official WordPress documentation or a specification (link)
+- a benchmark or reproducible experiment (numbers + how to reproduce)
+- a linked issue, PR, SDD, or prior ADR
+No technical claim without a source. -->
+
+## Decision
+
+<!-- The option that was chosen, stated plainly. "We will ...". -->
+
+## Consequences
+
+### Positive
+
+- ...
+
+### Negative
+
+- ...
+
+### Neutral
+
+- ...
+
+## Risks
+
+<!-- What could go wrong, and how likely / severe. -->
+
+## Validation
+
+<!-- How we will know the decision was correct: PHPUnit/Playwright tests,
+metrics, a follow-up review date, an experiment to run. -->
+
+## Follow-up work
+
+<!-- Concrete next steps this decision creates. Link issues/PRs when they exist. -->
+
+## References
+
+<!-- All sources cited above, plus related issues, PRs, SDDs and ADRs. -->

--- a/docs/architecture/sdd/README.md
+++ b/docs/architecture/sdd/README.md
@@ -1,0 +1,179 @@
+# Software Design Documents
+
+## Purpose
+
+A **Software Design Document (SDD)** describes *what* a significant change will
+build, *why*, *how* it will be validated, and *how* it affects the plugin. It is
+the design gate for large work: the place to agree on goals, non-goals, the
+proposed design, data/storage impact, security, accessibility,
+internationalization, backward compatibility, testing and rollout **before**
+implementation starts.
+
+An SDD makes a big change reviewable as a whole, instead of arriving as a large
+pull request that reviewers must reverse-engineer.
+
+## SDDs vs ADRs
+
+| Artifact | Answers | Lifetime |
+|----------|---------|----------|
+| **SDD** | *What* will be built and *how* it will be implemented | May become historical once implemented |
+| **ADR** | *Which* durable decision was made and *why* | Long-lived, append-only |
+
+An SDD is a **design**; an [ADR](../adr/README.md) is a **decision**. A single
+SDD often contains several durable decisions (a storage choice, a compatibility
+guarantee, a security boundary). Those belong in ADRs so they outlive the feature
+work — the SDD then links to them instead of burying them in prose.
+
+An SDD is **not a substitute for an ADR**: when a design introduces a long-lived
+technical decision, capture that decision in an ADR (existing or newly proposed)
+and link it from the SDD's *ADRs required or referenced* table.
+
+> Every significant proposal may start with an SDD. Every durable architectural
+> decision inside that SDD should either link to an existing ADR or propose a new
+> one.
+
+## When an SDD is required
+
+Write an SDD for work that needs a design gate before implementation:
+
+- significant new features;
+- major refactors or rewrites of a subsystem;
+- cross-cutting changes (ELPX upload/extraction, the embedded editor install
+  flow, the content proxy, the style registry, Media Library integration);
+- security-sensitive changes (upload validation, path-traversal protection,
+  checksums, capabilities, nonces, the content-proxy security model);
+- data or storage changes (attachment post meta, the
+  `wp-content/uploads/exelearning/` layout, uploaded style storage);
+- REST API changes, or changes to shortcode/block attribute contracts;
+- build or distribution changes (packaging, the editor build/install flow);
+- proposals with multiple implementation phases.
+
+## When an SDD is recommended
+
+An SDD is worth writing, even when not strictly required, when a change is small
+in code but wide in impact — for example a new hook contract other plugins will
+depend on, or a change that alters how existing ELPX packages are stored or
+served.
+
+## When an SDD is not needed
+
+Skip the SDD for:
+
+- bug fixes and small enhancements;
+- localized changes with an obvious implementation;
+- translation-only or test-only changes;
+- work already fully covered by an existing, current SDD.
+
+A durable decision that needs no full design can go straight to an
+[ADR](../adr/README.md).
+
+## Location and naming
+
+- SDDs live in `docs/architecture/sdd/`.
+- Filenames follow: `SDD-NNNN-short-kebab-case-title.md` — for example
+  `SDD-0001-elpx-upload-validation.md`.
+- IDs are zero-padded, monotonic and never reused. The next ID is
+  `max(existing) + 1`, starting at `SDD-0001`.
+- [`template.md`](template.md) is the canonical template.
+- [`records.md`](records.md) lists every SDD. The index is maintained by hand.
+
+## Status values
+
+| Status | Meaning |
+|--------|---------|
+| `Draft` | Being written; not yet ready for review. |
+| `In Review` | Under review; open for feedback. |
+| `Accepted` | Design agreed; implementation may start. |
+| `Implemented` | The design has shipped. Kept as a historical record. |
+| `Superseded` | Replaced by a newer SDD (see `superseded_by`). |
+| `Abandoned` | Dropped before implementation. Kept for the record. |
+
+An SDD can be edited freely while it is `Draft` or `In Review`. Once
+`Implemented`, avoid rewriting it except for typo/link fixes. If the design
+changes substantially, create a new SDD or mark the previous one `Superseded`.
+Implemented SDDs are **preserved as historical design records** — do not delete
+them.
+
+## Recording tests, validation, rollout and compatibility
+
+Every SDD must address, or explicitly mark as not-applicable:
+
+- **Testing strategy** — which PHPUnit suites and, where relevant, Playwright
+  specs will cover the change; how coverage is verified.
+- **Backward compatibility** — impact on existing ELPX packages, stored meta,
+  shortcodes, blocks and hooks; whether a migration is needed.
+- **Migration/rollout** — order of merges, feature gating, and rollback.
+- **Security, privacy, accessibility and internationalization** — the
+  cross-cutting concerns a WordPress plugin must not skip.
+
+## Evidence and traceability
+
+As with ADRs, technical claims should cite a verifiable source: a repository path
+plus commit, official WordPress documentation, a benchmark, a reproducible
+experiment, or a linked issue, PR or ADR. Keep the evidence inside the SDD.
+
+## AI-assisted SDDs
+
+If an AI tool helped draft or research an SDD, disclose it in the frontmatter:
+
+```yaml
+ai_assistance:
+  tool: "Claude Code"        # tool / interface used
+  model: "claude-opus-4-8"   # model, when relevant
+```
+
+If no AI tool was involved, set both fields to `none`. The frontmatter records
+tools and links, **not** the names of people — use issue and PR links for
+attribution.
+
+## Linking SDDs and ADRs
+
+Every SDD template includes an **ADRs required or referenced** table. Use it to:
+
+- link durable decisions to existing ADRs; or
+- flag decisions that still need an ADR (`ADR needed`).
+
+Do not duplicate a full SDD inside an ADR. The ADR records the decision and its
+rationale; the SDD records the implementation design. An ADR may, in turn,
+reference one or more SDDs.
+
+## Superseding or abandoning an SDD
+
+- **Substantial design change:** create a new SDD (or set the old one to
+  `Superseded` with `superseded_by`).
+- **Design dropped before implementation:** set `status: Abandoned` and note why.
+- **Shipped:** set `status: Implemented`. Keep it as a historical design record;
+  do not delete it.
+
+## Referencing SDDs
+
+Refer to SDDs by their ID so links stay stable:
+
+- **From a PR or issue:** mention `SDD-0001` and link the file.
+- **From an ADR:** list the SDD under `related.sdds` and in the References.
+- **From docs / code:** `[SDD-0001](SDD-0001-....md)` (adjust the relative path).
+
+## Workflow
+
+1. Copy [`template.md`](template.md) to `SDD-NNNN-short-title.md` with the next
+   ID. Start at `status: Draft`.
+2. Fill in the design: problem, goals, non-goals, proposed design, affected
+   areas, data/storage impact, security, accessibility, internationalization,
+   compatibility, testing, rollout and acceptance criteria.
+3. List durable decisions in the *ADRs required or referenced* table; create or
+   link ADRs for them.
+4. Add the SDD to [`records.md`](records.md) and open (or reference) a PR. Move
+   to `In Review`.
+5. On approval, set `Accepted` and implement. When it ships, set `Implemented`.
+
+## Review checklist
+
+- [ ] The SDD has a unique, monotonic ID and a kebab-case title.
+- [ ] Goals and non-goals are explicit.
+- [ ] Data/storage, security, privacy, accessibility, i18n, compatibility and
+      testing are addressed (or marked not-applicable).
+- [ ] Durable decisions are captured in the *ADRs required or referenced* table.
+- [ ] Every technical claim cites a verifiable source.
+- [ ] `status` reflects reality (`Draft`/`In Review` while under discussion).
+- [ ] `ai_assistance` is filled in (values or `none`).
+- [ ] [`records.md`](records.md) is updated.

--- a/docs/architecture/sdd/records.md
+++ b/docs/architecture/sdd/records.md
@@ -1,0 +1,36 @@
+# SDD Index
+
+This page lists the Software Design Documents for `wp-exelearning`. See the
+[SDD guide](README.md) for the policy and [`template.md`](template.md) for the
+starting point.
+
+The index is maintained by hand. When an SDD is added or changes status, update
+the table and the per-status lists below.
+
+| ID | Title | Status | Date | Related ADRs |
+|----|-------|--------|------|--------------|
+| _None yet_ | | | | |
+
+> No SDDs have been recorded yet. The first numbered SDD (`SDD-0001`) will be
+> created by the first change that needs a design gate before implementation.
+> Copy [`template.md`](template.md) to `SDD-0001-short-title.md` to start it.
+
+## Draft SDDs
+
+_No draft SDDs yet._
+
+## In Review SDDs
+
+_No SDDs in review yet._
+
+## Accepted SDDs
+
+_No accepted SDDs yet._
+
+## Implemented SDDs
+
+_No implemented SDDs yet._
+
+## Superseded SDDs
+
+_No superseded SDDs yet._

--- a/docs/architecture/sdd/template.md
+++ b/docs/architecture/sdd/template.md
@@ -1,0 +1,192 @@
+---
+id: SDD-0000
+title: "Short design title"
+status: Draft
+date: YYYY-MM-DD
+related:
+  issues: []
+  prs: []
+  adrs: []
+  sdds: []
+supersedes: []
+superseded_by: []
+ai_assistance:
+  tool: ""
+  model: ""
+---
+
+<!--
+How to use this template:
+1. Copy this file to `SDD-NNNN-short-kebab-case-title.md` with the next free ID.
+2. Update the frontmatter above (id, title, date, related links).
+3. Fill the relevant sections. Mark sections that truly do not apply as
+   "Not applicable" (with a one-line reason) rather than deleting them, and
+   delete these guidance comments before submitting.
+4. Use an SDD for significant proposals, not small fixes.
+5. Cite a verifiable source for each technical claim (repo path + commit,
+   WordPress documentation, benchmark, experiment, issue, PR, or ADR).
+6. Capture durable decisions in "ADRs required or referenced" — link an existing
+   ADR or mark it "ADR needed".
+7. Record AI assistance in `ai_assistance` (values, or `none` if not used).
+8. Use issue/PR links for attribution — do not add people's names.
+Editing is free while Draft / In Review. Once Implemented, only fix typos/links.
+See ../README.md for the full policy.
+-->
+
+# SDD-0000: Short design title
+
+## Status
+
+Draft
+
+<!-- One of: Draft | In Review | Accepted | Implemented | Superseded | Abandoned.
+Keep it in sync with the frontmatter `status`. -->
+
+## Summary
+
+<!-- One or two paragraphs: what this changes and why it matters. -->
+
+## Context
+
+<!-- The background a reviewer needs: how the relevant part of the plugin works
+today at a high level, and what prompted this design. -->
+
+## Problem statement
+
+<!-- The problem being solved, and who has it (site admins, content authors,
+developers integrating with the hooks). -->
+
+## Goals
+
+<!-- What success looks like. Make these testable where possible. -->
+
+## Non-goals
+
+<!-- What this design explicitly does not attempt. -->
+
+## Current behavior
+
+<!-- How things work today, in detail. Cite repository paths + commits
+(e.g. `includes/class-elp-upload-handler.php`). -->
+
+## Proposed design
+
+<!-- The design at a high level, then the detail. Diagrams welcome. Name the
+classes/files that will change or be added under includes/, admin/, public/. -->
+
+## Affected areas
+
+<!-- Check/keep the areas this change touches; remove the rest. -->
+
+- [ ] PHP plugin classes (`includes/`)
+- [ ] Admin UI (`admin/`)
+- [ ] Public rendering (`public/`)
+- [ ] Gutenberg block / block assets (`assets/`, `includes/class-elp-upload-block.php`)
+- [ ] Shortcode (`public/class-shortcodes.php`)
+- [ ] REST endpoints (`includes/class-exelearning-rest-api.php`)
+- [ ] Media Library integration (`includes/integrations/`)
+- [ ] ELPX upload/extraction (`includes/class-elp-file-service.php`, `includes/class-elp-upload-handler.php`)
+- [ ] Content proxy (`includes/class-content-proxy.php`)
+- [ ] Embedded editor install/build flow (`includes/class-static-editor-installer.php`, `admin/views/editor-bootstrap.php`, `assets/js/wp-exe-bridge.js`)
+- [ ] Style registry (`includes/class-styles-service.php`, `includes/class-style-package.php`)
+- [ ] Build / packaging (`Makefile`, distribution)
+
+## Data model or storage impact
+
+<!-- New/changed attachment post meta keys, the
+`wp-content/uploads/exelearning/{sha1}/` extraction layout, uploaded style
+storage under `wp-content/uploads/exelearning-styles/`, options, transients, or
+any on-disk structure. Note new keys and how existing data is handled. -->
+
+## WordPress hooks/filters impact
+
+<!-- New or changed actions/filters (all prefixed `exelearning_`). Keep
+`docs/HOOKS.md` in sync when this ships. Note any hook whose contract other
+plugins may depend on. -->
+
+## REST API impact
+
+<!-- New/changed endpoints under the `exelearning/v1` namespace, their methods,
+capabilities, nonce/permission callbacks, request/response shapes, and backward
+compatibility. Mark "Not applicable" if the design adds no REST surface. -->
+
+## Shortcode/block impact
+
+<!-- New/changed `[exelearning]` attributes or block attributes, defaults, and
+backward compatibility. Keep `docs/SHORTCODES.md` in sync when this ships.
+Mark "Not applicable" if untouched. -->
+
+## Security considerations
+
+<!-- Upload validation, ZIP/path-traversal protection, checksum verification,
+capability checks, nonces, output escaping, input sanitization/unslashing, and
+the content-proxy security model. State the trust boundaries this change crosses. -->
+
+## Privacy considerations
+
+<!-- Any personal data handled, stored, logged or exposed; retention; and how
+uninstall (`uninstall.php`) treats it. Mark "Not applicable" if none. -->
+
+## Accessibility considerations
+
+<!-- Keyboard operation, screen-reader labels, focus management, contrast, and
+the embedded editor / preview surfaces. -->
+
+## Internationalization considerations
+
+<!-- New user-facing strings wrapped in `__()`/`esc_html__()` etc. with the
+`exelearning` text domain, `/* translators: */` comments for placeholders,
+JS/block strings via `wp_set_script_translations`, and updating `.pot`/`.po`/`.mo`
+(`make pot`, `make po`, `make mo`). Add translations for every shipped locale. -->
+
+## Backward compatibility
+
+<!-- Impact on existing ELPX packages, stored attachment meta, shortcodes,
+blocks and hooks. What keeps working unchanged, and what does not. -->
+
+## Migration/rollout
+
+<!-- Data migration (e.g. reprocessing existing extractions), order of merges,
+feature gating, staged enablement, and rollback. -->
+
+## Testing strategy
+
+<!-- Unit (PHPUnit) and, where relevant, E2E (Playwright) coverage. Which flows
+get a test, how to run them (`make test`, `make test-e2e`), and the WordPress
+Coding Standards / PHPMD / untranslated-string checks (`make lint`, `make phpmd`,
+`make check-untranslated`). -->
+
+## Acceptance criteria
+
+<!-- Concrete, checkable conditions for "done". -->
+
+- [ ] ...
+
+## Open questions
+
+<!-- Unresolved points that reviewers should weigh in on. -->
+
+## ADRs required or referenced
+
+<!-- List durable decisions. Link an existing ADR, or mark it "ADR needed". -->
+
+| Decision | ADR | Status |
+|----------|-----|--------|
+| Example durable decision | ADR-XXXX | Proposed |
+
+## Evidence
+
+<!-- The verifiable basis for the design: repo paths + commits, WordPress docs,
+benchmarks, reproducible experiments, issues, PRs, ADRs. No technical claim
+without a source. -->
+
+## Follow-up tasks
+
+<!-- The steps to build it, roughly in order, plus any deferred work. Link
+issues/PRs when they exist. -->
+
+- [ ] ...
+
+## References
+
+<!-- All sources cited above, plus related issues, PRs, ADRs and SDDs. -->


### PR DESCRIPTION
## What this does

Adds a lightweight Architecture Decision Record (ADR) and Software Design Document (SDD) workflow to `wp-exelearning`, adapted from the main eXeLearning repository workflow.

The plugin repository uses `docs/`, so this PR stores the workflow under:

- `docs/architecture/adr/`
- `docs/architecture/sdd/`

## Why

The main eXeLearning repository introduced ADR/SDD conventions in exelearning/exelearning#2149, based on the proposal in exelearning/exelearning#2148.

`wp-exelearning` has its own architecture-sensitive areas: ELPX upload/extraction, WordPress capabilities and nonces, embedded editor installation, Gutenberg/shortcode rendering, style management, content proxying, and public package delivery. Keeping durable decisions and significant designs in the repo will make future changes easier to review and maintain.

## Scope

- Adds ADR and SDD guide pages.
- Adds reusable ADR and SDD templates.
- Adds ADR and SDD records index pages.
- Adds concise agent/developer guidance where the repository already has convention files (`AGENTS.md`, `CONVENTIONS.md`) and a small link in `README.md`.
- Does not change production plugin behavior.
- Does not add dependencies.
- Does not introduce any documentation-site generator.

## What's included

```
docs/architecture/README.md          # Architecture docs overview (operational vs records)
docs/architecture/adr/README.md      # ADR guide (purpose, when required, statuses, superseding)
docs/architecture/adr/template.md    # ADR template (person-free frontmatter)
docs/architecture/adr/records.md     # ADR index (empty-state)
docs/architecture/sdd/README.md      # SDD guide (purpose, when required, statuses)
docs/architecture/sdd/template.md    # SDD template (WordPress-plugin-specific, person-free)
docs/architecture/sdd/records.md     # SDD index (empty-state)
```

Updated files: `AGENTS.md`, `CONVENTIONS.md`, `README.md`.

## Workflow summary

- ADRs document durable architecture decisions and their consequences. Statuses: `Proposed`, `Accepted`, `Rejected`, `Superseded`.
- SDDs document significant feature designs, validation plans, and acceptance criteria. Statuses: `Draft`, `In Review`, `Accepted`, `Implemented`, `Superseded`, `Abandoned`.
- SDDs link to ADRs when a feature introduces long-lived technical decisions.
- Accepted ADRs are append-only and superseded by later ADRs instead of rewritten.
- Implemented SDDs remain as historical design records.
- IDs are zero-padded and monotonic (`ADR-NNNN`, `SDD-NNNN`), never reused. No numbered ADR/SDD is created yet — the first one is created by the first change that needs it.
- Frontmatter records AI assistance (`ai_assistance.tool` / `ai_assistance.model`) and links issues/PRs/ADRs/SDDs. It contains no named people, deciders, or maintainers — attribution is via issue/PR links.
- The SDD template is tailored to the plugin: affected areas (`includes/`, `admin/`, `public/`, block/shortcode assets), attachment-meta/storage impact, WordPress hooks/filters, REST API, shortcode/block contracts, security (upload validation, path traversal, checksums, capabilities, nonces, content proxy), privacy, accessibility, i18n, backward compatibility and testing (PHPUnit/Playwright).

## Testing

Documentation-only change (no PHP/JS/CSS/build/test logic touched). Commands run locally:

```text
make lint                 # EXIT 0 — PHPCS clean
make phpmd                # EXIT 0 — no violations (only host phpmd/pdepend PHP deprecation notices)
make check-untranslated   # EXIT 0 — Success (regenerated language files were reverted as unrelated)
make test                 # 730/731 pass; 1 pre-existing environment failure (see below)
```

Additional documentation checks:

- Relative-link check across all new/updated docs: 43/43 real links resolve. (Two illustrative `ADR-0001-....md` / `SDD-0001-....md` examples are inline-code placeholders, not real links.)
- Placeholder/forbidden-word scan: `ADR-0000` / `SDD-0000` / `YYYY-MM-DD` appear only inside the `template.md` files; no `deciders` / `owner` / `maintainer` / person-metadata frontmatter keys; no documentation-site-generator references.

The single `make test` failure is pre-existing and unrelated to this change:

```text
Static Editor Installer
 ✘ Is editor installed returns false when missing
   Failed asserting that true is false.
   tests/unit/StaticEditorInstallerTest.php:54
```

`test_is_editor_installed_returns_false_when_missing()` assumes a checkout without the built editor. This local working copy already has `dist/static/index.html` (from `make build-editor`), so `is_editor_installed()` returns `true`. CI runs on a fresh checkout without the built editor, where the test passes. This PR adds no PHP and does not touch that code path.

## Related

Refs exelearning/exelearning#2148
Refs exelearning/exelearning#2149
