### PR TITLE
fix(proxy): redirect stale content URLs to the latest ELPX extraction

### DIFF
--- a/docs/architecture/adr/ADR-0001-obsolete-hash-alias-storage.md
+++ b/docs/architecture/adr/ADR-0001-obsolete-hash-alias-storage.md
@@ -6,7 +6,8 @@ date: 2026-07-10
 related:
   issues:
     - https://github.com/exelearning/exelearning/issues/2150
-  prs: []
+  prs:
+    - https://github.com/exelearning/wp-exelearning/pull/68
   sdds:
     - SDD-0001
   adrs: []

--- a/docs/architecture/adr/ADR-0001-obsolete-hash-alias-storage.md
+++ b/docs/architecture/adr/ADR-0001-obsolete-hash-alias-storage.md
@@ -1,0 +1,173 @@
+---
+id: ADR-0001
+title: "Resolve obsolete extraction hashes through attachment post meta aliases"
+status: Accepted
+date: 2026-07-10
+related:
+  issues:
+    - https://github.com/exelearning/exelearning/issues/2150
+  prs: []
+  sdds:
+    - SDD-0001
+  adrs: []
+supersedes: []
+superseded_by: []
+ai_assistance:
+  tool: "Claude Code"
+  model: "claude-fable-5"
+---
+
+# ADR-0001: Resolve obsolete extraction hashes through attachment post meta aliases
+
+## Status
+
+Accepted
+
+## Context
+
+Extracted eXeLearning packages are served through public hash-based REST URLs
+(`exelearning/v1/content/{hash}/{file}`). Saving an edited `.elpx` attachment
+generates a fresh random extraction hash, commits it to the
+`_exelearning_extracted` attachment post meta, and deletes the previous
+extraction directory (`includes/class-exelearning-rest-api.php:375-495`,
+`includes/class-elp-reprocessor.php:52-109` @ `50f0ed5`). Every previously
+published URL for that attachment then returns `file_not_found` permanently.
+The plugin stores all per-package state in attachment post meta by design
+(`CLAUDE.md`, "Data Storage") and has no custom tables.
+
+## Problem
+
+Where and how should the relationship "this retired hash belonged to that
+attachment" be persisted so the content proxy can redirect stale URLs to the
+attachment's current extraction — durably, without redirect chains, without
+unbounded growth, and with safe cleanup when attachments are deleted?
+
+## Decision drivers
+
+- Zero cost on successful content requests (public, high-traffic endpoint).
+- Automatic cleanup when an attachment is permanently deleted.
+- No redirect chains after multiple sequential saves; no loops.
+- Legacy shared (content-derived) hashes must never be hijacked or deleted
+  while still referenced.
+- WordPress conventions: the plugin keeps all per-attachment state in post
+  meta; plugin-review friction of custom tables is unjustified for a 40-byte
+  relation.
+- No autoloaded global state.
+
+## Alternatives considered
+
+### Option 1: Multi-value attachment post meta (`_exelearning_obsolete_hash`) — chosen
+
+One meta row per retired hash on the owning attachment. Resolution finds the
+owner by meta query (only on the proxy's 404 fallback path) and reads the
+owner's current `_exelearning_extracted`.
+
+- Pros: aliases resolve *through the attachment identity* to its single
+  current hash — chains are structurally impossible; rows die with the
+  attachment (core deletes post meta on `wp_delete_attachment()`); matches the
+  plugin's storage model; trivially testable with attachment factories.
+- Cons: resolution is a meta query rather than a keyed lookup (acceptable —
+  it runs only after a request has already 404ed).
+
+### Option 2: One non-autoloaded option per obsolete hash
+
+`exelearning_alias_{hash}` → attachment ID.
+
+- Pros: O(1) lookup by option name.
+- Cons: no automatic cleanup — attachment deletion would need a reverse sweep
+  over the options table; options-table growth; risk of autoload regressions;
+  per-attachment state living outside the attachment contradicts the plugin's
+  data model.
+
+### Option 3: Old-hash → new-hash chain map
+
+- Pros: append-only writes.
+- Cons: N saves produce `a → b → c` chains that need walking and cycle
+  detection; losing the attachment identity makes shared-hash ambiguity
+  unresolvable; orphaned tails on deletion. Rejected.
+
+### Option 4: Keep every historical extraction directory
+
+- Pros: no redirect logic at all.
+- Cons: unbounded disk growth on every save; stale content keeps being served
+  as if current; contradicts the existing cleanup design. Rejected.
+
+### Option 5: Custom database table
+
+- Pros: purpose-built indexes.
+- Cons: schema creation/migration/uninstall maintenance and plugin-review
+  friction for a single 40-byte relation; contradicts the "no custom
+  storage" architecture. Rejected.
+
+A single autoloaded option holding a global alias map was excluded outright:
+it would load on every request and its read-modify-write cycle races under
+concurrent saves.
+
+## Evidence
+
+- Save transaction: `includes/class-exelearning-rest-api.php:375-495` @ `50f0ed5`.
+- Random per-extraction hash: `includes/class-elp-reprocessor.php:301-305` @ `50f0ed5`.
+- Post meta deleted with the attachment: https://developer.wordpress.org/reference/functions/wp_delete_attachment/
+- Data-storage convention: repository `CLAUDE.md` ("Data Storage") @ `50f0ed5`.
+- Full design and evaluation matrix: [SDD-0001](../sdd/SDD-0001-stale-content-url-redirects.md).
+
+## Decision
+
+We will persist each retired extraction hash as a **multi-value attachment
+post meta row** (`_exelearning_obsolete_hash`) on the attachment that retired
+it, written only after a successful save and verified before the old
+extraction directory is deleted. The public content endpoint answers a
+verified obsolete hash with a **temporary (`302`) same-origin redirect** to
+the equivalent validated path under the attachment's current
+`_exelearning_extracted` hash. Hashes still current for any attachment are
+never aliased, never redirected, and their directories are never deleted by a
+sharing attachment's save.
+
+## Consequences
+
+### Positive
+
+- Published content URLs survive edits; redirects always land on the latest
+  extraction in one hop.
+- Alias data cannot outlive its attachment; no new cleanup surface.
+- Zero overhead on successful content requests.
+- The save transaction fails open for availability: if alias persistence
+  fails, the old directory is retained instead of breaking URLs.
+
+### Negative
+
+- Resolution costs one bounded meta query on the 404 fallback path.
+- Legacy identically-content-hashed attachments that were *both* edited leave
+  their shared old hash unresolvable (safe 404) — fixing that would require
+  changing the public URL contract.
+
+### Neutral
+
+- `wp_postmeta` grows by one small row per successful hash-changing save.
+
+## Risks
+
+- Meta rows manipulated out-of-band (direct SQL) could create ambiguous
+  aliases — resolution refuses multi-owner and current-hash aliases, degrading
+  to the safe 404.
+- A very large number of saves accumulates alias rows; volume is small
+  (40-byte values) and bounded per attachment by edit count.
+
+## Validation
+
+- PHPUnit suites `ContentHashAliasesTest`, `StaleContentRedirectTest`, plus
+  `ReprocessorTest`/`RestApiTest` extensions (see SDD-0001, Testing strategy).
+- Manual verification steps recorded in the implementing PR.
+
+## Follow-up work
+
+- Implement per SDD-0001 (issue
+  https://github.com/exelearning/exelearning/issues/2150).
+- Possible follow-up: reference-check the `delete_attachment` directory
+  cleanup for legacy shared hashes.
+
+## References
+
+- [SDD-0001](../sdd/SDD-0001-stale-content-url-redirects.md)
+- https://github.com/exelearning/exelearning/issues/2150
+- https://developer.wordpress.org/reference/functions/wp_delete_attachment/

--- a/docs/architecture/adr/records.md
+++ b/docs/architecture/adr/records.md
@@ -9,11 +9,7 @@ status, update the table and the per-status lists below.
 
 | ID | Title | Status | Date | Related SDD |
 |----|-------|--------|------|-------------|
-| _None yet_ | | | | |
-
-> No ADRs have been recorded yet. The first numbered ADR (`ADR-0001`) will be
-> created by the first change that locks in a durable architecture decision.
-> Copy [`template.md`](template.md) to `ADR-0001-short-title.md` to start it.
+| [ADR-0001](ADR-0001-obsolete-hash-alias-storage.md) | Resolve obsolete extraction hashes through attachment post meta aliases | Accepted | 2026-07-10 | [SDD-0001](../sdd/SDD-0001-stale-content-url-redirects.md) |
 
 ## Proposed ADRs
 
@@ -21,7 +17,8 @@ _No proposed ADRs yet._
 
 ## Accepted ADRs
 
-_No accepted ADRs yet._
+- [ADR-0001](ADR-0001-obsolete-hash-alias-storage.md) — Resolve obsolete
+  extraction hashes through attachment post meta aliases.
 
 ## Superseded ADRs
 

--- a/docs/architecture/sdd/SDD-0001-stale-content-url-redirects.md
+++ b/docs/architecture/sdd/SDD-0001-stale-content-url-redirects.md
@@ -1,0 +1,525 @@
+---
+id: SDD-0001
+title: "Stale content URL redirects to the latest ELPX extraction"
+status: Accepted
+date: 2026-07-10
+related:
+  issues:
+    - https://github.com/exelearning/exelearning/issues/2150
+  prs: []
+  adrs:
+    - ADR-0001
+  sdds: []
+supersedes: []
+superseded_by: []
+ai_assistance:
+  tool: "Claude Code"
+  model: "claude-fable-5"
+---
+
+# SDD-0001: Stale content URL redirects to the latest ELPX extraction
+
+## Status
+
+Accepted
+
+## Summary
+
+Extracted eXeLearning content is served through hash-based REST URLs
+(`/wp-json/exelearning/v1/content/{hash}/{file}`). Saving an edited `.elpx`
+attachment generates a new extraction hash and deletes the previous extraction
+directory, so every previously shared or embedded URL becomes a permanent
+`file_not_found` dead link.
+
+This design records each retired extraction hash as attachment post meta and
+teaches the content proxy to answer requests for a known obsolete hash with a
+temporary (`302 Found`) redirect to the equivalent file path under the
+attachment's **current** extraction hash, preserving the requested relative
+path and query parameters. Unknown hashes, malformed data, traversal attempts
+and deleted attachments keep failing exactly as they do today.
+
+## Context
+
+The plugin stores `.elpx` files as WordPress attachments and extracts them to
+`wp-content/uploads/exelearning/{hash}/`
+(`includes/class-elp-reprocessor.php` @ `50f0ed5`). The extraction hash is
+**random per extraction** — `sha1( $file_path . microtime( true ) . wp_rand() )`
+(`includes/class-elp-reprocessor.php:304` @ `50f0ed5`) — and is stored in the
+`_exelearning_extracted` attachment post meta. Historical extractions (before
+the unique-hash change) used a content-derived sha1, so two attachments with
+identical content **may** share one hash in legacy data.
+
+The content proxy (`includes/class-content-proxy.php` @ `50f0ed5`) serves
+`GET exelearning/v1/content/(?P<hash>[a-f0-9]{40})(?:/(?P<file>.*))?`
+(route registered in `includes/class-exelearning-rest-api.php:44-66`) with a
+public `permission_callback` and only ever resolves the requested hash
+directory on disk.
+
+## Problem statement
+
+Content authors publish or embed proxy URLs (LMS embeds, links shared with
+learners). After the author edits the package in the embedded editor and
+saves, all those URLs break with `file_not_found`. A URL that once identified
+an eXeLearning resource must keep working after the resource is edited.
+
+## Goals
+
+- Preserve previously published content URLs after an ELPX save: a request for
+  a retired hash returns a temporary redirect instead of `file_not_found`.
+- Redirect an obsolete hash to the attachment's **latest** extraction, never to
+  an intermediate hash (no redirect chains).
+- Preserve the requested relative file path in the redirect target.
+- Preserve the request's query parameters (e.g. `?exe-teacher=1`).
+- Use `302 Found` with `Cache-Control: no-cache, must-revalidate` so the
+  mutable destination is never cached permanently.
+- Preserve all existing proxy validation, error codes and security headers for
+  every non-redirect outcome.
+- Never create aliases during failed or partial saves; never delete the old
+  extraction when alias persistence fails (fail *open* for availability, not
+  for security).
+- Handle permanent attachment deletion safely: aliases disappear with the
+  attachment and stale requests return the normal safe 404.
+- Never redirect a hash that is still the current extraction of any attachment
+  (legacy shared hashes).
+
+## Non-goals
+
+- Replacing the existing hash-based URL format or introducing a new public
+  attachment-ID content route.
+- Retaining historical extraction directories (disk usage stays bounded to one
+  extraction per attachment).
+- Redirecting arbitrary or unknown hashes: only hashes recorded during a
+  successful save of a known attachment redirect.
+- Changing the `delete_attachment` extraction cleanup
+  (`includes/class-elp-upload-handler.php:234` @ `50f0ed5`) or any other
+  media-library / editor behavior.
+- Solving the legacy shared-hash ambiguity beyond safe refusal (see
+  "Shared-hash ambiguity").
+
+## Current behavior
+
+Save flow (`ExeLearning_REST_API::save_elp_file_locked()`,
+`includes/class-exelearning-rest-api.php:375-495` @ `50f0ed5`), executed under
+a per-attachment lock (`acquire_save_lock()`, lines 524-537):
+
+1. Read the old hash from `_exelearning_extracted` (line 377).
+2. Fire `exelearning_before_elpx_save` (line 392).
+3. Route the upload through `wp_handle_upload()` (line 412).
+4. Validate + extract the new project to a fresh directory
+   (`ExeLearning_Reprocessor::extract_to_new_dir()`, line 427). Any failure
+   returns before anything else is touched.
+5. Copy over the original `.elpx` and verify the copied size (lines 437-457);
+   failure deletes the *new* extraction and returns.
+6. Commit metadata — `apply_elp_metadata()` sets `_exelearning_extracted` to
+   the new hash (line 463).
+7. **Delete the old extraction directory** when `$old_hash` differs from the
+   new hash (lines 466-468) — this is what kills published URLs.
+8. Update the attachment modified dates (line 471).
+9. Fire `exelearning_after_elpx_save` (line 492) and return (line 494).
+
+`ExeLearning_Reprocessor::reprocess()` (lines 52-109 @ `50f0ed5`) performs the
+same commit-then-delete sequence for the reprocess flow, so it creates the
+same dead links.
+
+The proxy (`ExeLearning_Content_Proxy::serve_content()`,
+`includes/class-content-proxy.php:93-112` @ `50f0ed5`) validates the hash
+format, sanitizes the path (traversal-safe), then returns
+`file_not_found` (404) when the file does not exist under the requested hash.
+
+## Proposed design
+
+Three cooperating pieces, all under `includes/`:
+
+### 1. `ExeLearning_Content_Hash_Aliases` (new class,
+`includes/class-content-hash-aliases.php`)
+
+A small repository for obsolete-hash → attachment relationships stored as
+**multi-value attachment post meta** under the key
+`_exelearning_obsolete_hash` (one meta row per retired hash).
+
+- `register( $attachment_id, $old_hash ): bool` — validates the attachment
+  (exists, `post_type === 'attachment'`) and the hash format
+  (`/^[a-f0-9]{40}$/i`); refuses self-aliases (hash equals the attachment's
+  current `_exelearning_extracted`); refuses hashes that are the **current**
+  hash of any attachment; refuses hashes already registered as an alias of
+  a *different* attachment (ambiguity guard); is idempotent for re-registration
+  on the same attachment; persists with `add_post_meta()` and **verifies** the
+  row by reading it back before returning `true`.
+- `resolve( $hash ): int` — returns the owning attachment ID only when the
+  hash (a) is format-valid, (b) is **not** the current hash of any attachment
+  (current content always wins), and (c) is registered as an alias of exactly
+  one attachment. Returns `0` otherwise.
+- `is_current_hash( $hash ): bool` — whether any attachment's
+  `_exelearning_extracted` equals the hash.
+
+Lookups use bounded meta queries on the `attachment` post type
+(`fields => ids`, `posts_per_page => 2`, `no_found_rows => true`). They run
+**only** on the save path and on the proxy's `file_not_found` fallback path —
+never on a successful content request.
+
+### 2. Retirement primitive in `ExeLearning_Reprocessor`
+
+`retire_extraction( $attachment_id, $old_hash, $new_hash ): void`, called
+after metadata commit by both the REST save and `reprocess()` (replacing their
+duplicated "cleanup old hash" blocks):
+
+1. Return immediately when `$old_hash` is empty or equals `$new_hash`
+   (unchanged hash ⇒ no alias, no deletion, no self-reference).
+2. Return **without deleting and without registering** when the old hash is
+   still the current hash of any attachment (legacy shared hash — the other
+   attachment keeps serving it).
+3. `register()` the alias. If registration fails or is refused, **keep the old
+   extraction directory** — the old URL keeps serving the previous content
+   rather than becoming a dead link.
+4. Only after the alias is persisted and verified, delete the old extraction
+   directory (`cleanup_by_hash()`).
+
+### 3. Redirect fallback in `ExeLearning_Content_Proxy`
+
+`serve_content()` keeps its exact current ordering — hash format validation,
+then path sanitation/containment — and only when the result is the
+`file_not_found` error (never `invalid_hash`, `invalid_path` or
+`access_denied`) consults the alias repository:
+
+1. Re-sanitize the requested path (defense in depth).
+2. `resolve()` the hash to an attachment; bail to the original 404 on `0`.
+3. Read the attachment's `_exelearning_extracted`; bail unless it is a valid
+   40-hex hash **different** from the requested hash (loop guard).
+4. Validate the destination with the existing `validate_file_path()` against
+   the current hash — the target file must exist and be contained in the
+   current extraction directory; bail to the original 404 otherwise (no
+   redirects to known-dead targets).
+5. Build the `Location` from `ExeLearning_Content_Proxy::get_proxy_url()`
+   (same generator as every other proxy URL, including the optional isolated
+   content origin) and append the request's query parameters encoded with
+   `http_build_query( …, PHP_QUERY_RFC3986 )`, dropping the plain-permalink
+   routing argument `rest_route`.
+6. Return a `WP_REST_Response` with status `302`, the `Location` header, and
+   `Cache-Control: no-cache, must-revalidate`.
+
+Because step 4 guarantees the destination file exists under the *current*
+hash, the redirect target is always served directly — a chain
+`hash-a → hash-b → hash-c` is impossible by construction, and repeated saves
+leave every retired hash resolving through the attachment to its single
+current hash.
+
+## Affected areas
+
+- [x] PHP plugin classes (`includes/`)
+- [x] REST endpoints (`includes/class-exelearning-rest-api.php`)
+- [x] Content proxy (`includes/class-content-proxy.php`)
+- [x] ELPX upload/extraction (`includes/class-elp-reprocessor.php`)
+
+## Data model or storage impact
+
+New attachment post meta key, `_exelearning_obsolete_hash`:
+
+- **Multi-value**: one row per retired hash, added only on a successful save
+  that changed the hash.
+- **Not autoloaded**: post meta is loaded with the post's meta cache on
+  demand, never on every page load (unlike autoloaded options).
+- **Lifecycle**: rows are removed automatically when the attachment is
+  permanently deleted (`wp_delete_attachment()` deletes all post meta —
+  WordPress core behavior), so no orphaned alias can outlive its attachment.
+- **Growth**: bounded by the number of successful saves per attachment; each
+  row stores a 40-byte hash. No global map, no options-table growth.
+
+No change to the `wp-content/uploads/exelearning/{hash}/` layout. Existing
+extractions and metadata keep working unchanged; attachments saved before
+this change simply have no aliases (their already-dead URLs stay 404, which is
+the current behavior).
+
+### Storage alternatives evaluated
+
+| Criterion | **1. Post meta per obsolete hash (chosen)** | 2. Non-autoloaded option per hash | 3. Old→new hash chains | 4. Keep all old directories | 5. Custom table |
+|---|---|---|---|---|---|
+| Lookup cost | One bounded meta query, only on the 404 path | O(1) by option name | O(chain length), multiple reads | None (no redirect at all) | One indexed query |
+| Cleanup on attachment deletion | **Automatic** (core deletes post meta) | Manual reverse lookup over options | Manual chain walking | Manual directory sweep | Manual `DELETE` + uninstall handling |
+| Multiple sequential saves | Each retired hash resolves through the attachment to the single current hash | Same, if the option stores the attachment ID | Produces `a → b → c` chains | N/A | Same as meta |
+| Redirect-loop prevention | Structural: resolution reads current meta, self/current refusals | Same, with extra bookkeeping | Requires cycle detection | N/A | Same as meta |
+| WordPress conventions | Matches the plugin's "everything in attachment meta" model (`CLAUDE.md`, Data Storage) | Options are for site-wide state, not per-attachment data | No precedent | N/A | Overkill for a 40-byte relation; plugin-review friction |
+| DB growth | `wp_postmeta`, bounded per attachment | `wp_options` growth; risk of accidental autoload on rewrite | Same as options | Unbounded **disk** growth | New schema to migrate/maintain |
+| Autoload impact | None | None if flags never regress; each row must stay `autoload=no` | None | None | None |
+| Shared extraction hashes | Refusals implementable in `register()`/`resolve()` with the same meta queries | Needs a value format carrying the attachment + collision policy | Ambiguity unresolvable (hash → hash loses the attachment) | N/A | Same as meta |
+| Testability | Trivial with `WP_UnitTestCase` attachment factories | Requires option-key discipline in tests | Chain fixtures awkward | N/A | Requires schema setup in tests |
+
+A single unbounded autoloaded option holding every alias was ruled out up
+front (memory on every request, race-prone read-modify-write). Option 2 is the
+closest runner-up but loses on deletion cleanup and uninstall complexity;
+option 3 is rejected because chains recreate the loop/chain problems this
+design must prevent; option 4 trades a bug for unbounded disk usage; option 5
+adds schema maintenance the data volume does not justify.
+
+The preferred property from the issue — obsolete hashes resolve **through the
+attachment identity** to its current `_exelearning_extracted` value — is
+exactly what post meta provides, and it is correct for the current data model
+because `_exelearning_extracted` is the single source of truth for an
+attachment's live extraction (`includes/class-elp-reprocessor.php:347`).
+
+## Shared-hash ambiguity
+
+The public URL carries only an extraction hash, not an attachment ID. Newly
+generated hashes are unique per extraction
+(`includes/class-elp-reprocessor.php:301-305` @ `50f0ed5`), but legacy
+extractions used content-derived hashes, so two attachments **may** both point
+at one hash/directory.
+
+Defined behavior when attachment A (sharing hash `H` with attachment B) is
+saved:
+
+- `retire_extraction()` detects that `H` is still the current hash of B and
+  **neither deletes the `H` directory nor registers an alias**. B's URLs keep
+  serving; A's old URLs under `H` keep serving B-identical content from the
+  still-present directory. (Today's code would delete `H` and break B — the
+  new reference check also fixes that latent data-loss bug for saves.)
+- `resolve()` refuses any hash that is the current hash of *any* attachment,
+  so alias data can never hijack a live hash.
+- `resolve()` refuses a hash registered as an alias of more than one
+  attachment (possible only through manual meta manipulation), returning the
+  safe 404 rather than silently choosing an attachment.
+- `register()` refuses to double-register a hash owned by another attachment.
+
+**Documented limitation**: once A and B genuinely shared `H` and both are
+later edited, requests for `H` cannot be attributed to either attachment
+without changing the public URL contract (embedding an attachment ID). Such
+requests return the current safe 404. The `delete_attachment` directory
+cleanup (`includes/class-elp-upload-handler.php:234`) can still remove a
+legacy shared directory when one owner is deleted; changing that flow is out
+of scope here and would belong to a follow-up.
+
+## Save ordering
+
+Precise ordering inside `save_elp_file_locked()` (unchanged steps cited from
+`includes/class-exelearning-rest-api.php` @ `50f0ed5`):
+
+1. Validate and extract the new ELPX to a fresh directory (line 427).
+2. Replace the source `.elpx`, verify the copied size (lines 437-457).
+3. Commit `_exelearning_extracted` to the new hash via `apply_elp_metadata()`
+   (line 463).
+4. **New:** `retire_extraction( $attachment_id, $old_hash, $new_hash )`:
+   1. Skip everything when the old hash is empty or unchanged.
+   2. Skip deletion *and* aliasing when the old hash is still current for any
+      attachment (shared hash).
+   3. Persist the obsolete-hash relationship (`register()`), which verifies
+      the stored row by reading it back.
+   4. Delete the old extraction **only after** the verified registration;
+      on registration failure the directory is retained, so the old URL keeps
+      serving the previous content instead of recreating the dead-link bug.
+5. Update the attachment modified dates (line 471).
+6. Fire `exelearning_after_elpx_save` (line 492).
+7. Return the REST response (line 494).
+
+Failure in steps 1–2 returns before the commit: no metadata change, no alias,
+no deletion — identical to today's transactional behavior. The per-attachment
+save lock (lines 348-361) already serializes concurrent saves around the whole
+sequence and is not modified.
+
+`ExeLearning_Reprocessor::reprocess()` adopts the same `retire_extraction()`
+call in place of its duplicated cleanup block, keeping every entry point
+consistent (the class's stated purpose, lines 5-11).
+
+## WordPress hooks/filters impact
+
+None. No new hooks; `exelearning_before_elpx_save` /
+`exelearning_after_elpx_save` keep their exact timing and signatures
+(`docs/HOOKS.md` unchanged).
+
+## REST API impact
+
+No new routes. The existing public
+`GET exelearning/v1/content/{hash}/{file}` endpoint gains one new outcome:
+
+- **Redirect** — `302 Found` with `Location` and
+  `Cache-Control: no-cache, must-revalidate`, only when the requested hash is
+  a verified obsolete alias, the owning attachment exists, its current hash is
+  valid and different, and the equivalent file exists inside the current
+  extraction directory.
+- **`Location` construction** — `ExeLearning_Content_Proxy::get_proxy_url()`
+  (the same generator used for every proxy URL, including the
+  `exelearning_content_origin` isolated-origin rewrite,
+  `includes/class-content-proxy.php:597-641`) plus the request's remaining
+  query parameters encoded with `http_build_query(…, PHP_QUERY_RFC3986)`.
+  No component of the URL originates from user input except the validated
+  40-hex hash, the sanitized relative path, and RFC3986-encoded query values —
+  the redirect can never leave the site (or configured content) origin.
+- **Query-string preservation** — all request query parameters are carried
+  over except `rest_route` (the plain-permalink routing argument, which the
+  freshly generated target URL already carries when needed); works with both
+  pretty and plain permalinks because `rest_url()` handles both.
+- **Unchanged outcomes** — invalid hash (`invalid_hash`), traversal
+  (`invalid_path` / `access_denied`), unknown hash, malformed or ambiguous
+  alias data, deleted attachment, missing destination file: all return exactly
+  the current safe errors. Successful direct serving is untouched — the
+  fallback runs only after `file_not_found`.
+- **Loop prevention** — a redirect is only emitted toward a hash whose file is
+  verified present, and never toward the requested hash itself; the
+  destination therefore serves directly (no chains, no loops).
+
+## Shortcode/block impact
+
+Not applicable — shortcode and block embed by attachment ID and always render
+the current hash.
+
+## Security considerations
+
+- **Ordering**: the redirect decision happens strictly *after* the same hash
+  and path validation as a normal request, and reuses
+  `validate_file_path()` (realpath containment + traversal-safe
+  `sanitize_path()`) against the destination hash. Traversal attempts keep
+  returning `invalid_path`/`access_denied` and are never converted into
+  redirects.
+- **Validated inputs**: old hash format (route regex + `validate_hash()`),
+  current hash format (explicit 40-hex re-check on the stored meta),
+  attachment existence and post type (in `resolve()`), alias↔attachment
+  relationship (meta row read-back), requested relative path
+  (`sanitize_path()`), destination existence and containment
+  (`validate_file_path()`), and same-origin URL construction
+  (`get_proxy_url()` + RFC3986-encoded query args only).
+- **No open redirect**: no user-controlled origin, host, or scheme ever enters
+  the `Location` value; query values are percent-encoded, and WordPress's
+  `WP_REST_Server` header handling plus PHP's `header()` reject CR/LF
+  injection as a second layer.
+- **No permission change**: the endpoint stays public exactly as today; the
+  redirect discloses only the current hash of content that the same public
+  endpoint already serves.
+- **No new SQL on the hot path**: successful content requests execute zero
+  additional queries; alias lookups run only after a request already failed
+  with `file_not_found`.
+- **Save transaction**: the existing lock and validate-extract-commit order
+  are untouched; alias persistence failures degrade to "keep the old
+  directory", never to weakened validation.
+
+## Privacy considerations
+
+Not applicable — the meta stores only random extraction hashes the plugin
+itself generated; no personal data. `uninstall.php` currently removes no
+plugin data (repo `uninstall.php` @ `50f0ed5`), so no uninstall change is
+introduced here.
+
+## Accessibility considerations
+
+Not applicable — HTTP-level redirect with no UI surface; browsers and
+assistive technologies follow `302` transparently.
+
+## Internationalization considerations
+
+No new user-facing strings: every failure path reuses the existing translated
+`WP_Error` messages, and the redirect response has no body. `.pot`/`.po`
+files stay untouched (`make check-untranslated` must remain green).
+
+## Backward compatibility
+
+- Existing valid URLs serve exactly as before (fallback only runs on
+  `file_not_found`).
+- URLs already dead before this change stay 404 (no retroactive alias data
+  exists) — no migration is attempted.
+- Stored meta, shortcodes, blocks, hooks: unchanged.
+- Legacy shared-hash extractions gain a strictly safer behavior: a save no
+  longer deletes a directory another attachment still references.
+
+## Migration/rollout
+
+Single PR, no data migration, no feature flag. Aliases accumulate organically
+from the first post-deploy save. Rollback (reverting the PR) leaves only inert
+`_exelearning_obsolete_hash` meta rows behind; the proxy simply stops
+consulting them and behavior returns to today's.
+
+## Testing strategy
+
+TDD: the tests below are committed and demonstrably failing before any
+production code changes.
+
+- **`tests/unit/ContentHashAliasesTest.php`** (new) — direct repository
+  coverage: registration + verification, resolution, duplicate registration
+  (same and different attachments), multiple aliases per attachment, invalid
+  hash/attachment values, self-alias refusal, current-hash refusal, ambiguity
+  refusal, automatic cleanup on permanent attachment deletion, and that no
+  autoloaded option is created.
+- **`tests/unit/StaleContentRedirectTest.php`** (new) — proxy behavior through
+  `serve_content()` with `WP_REST_Request` fixtures and WordPress attachment
+  factories: basic `index.html` redirect (status, `Location`, cache header),
+  nested paths, query-parameter preservation (`?exe-teacher=1`), multiple
+  sequential saves redirecting every retired hash directly to the latest one,
+  unknown hash → `file_not_found`, invalid hash → `invalid_hash`, raw and
+  encoded traversal → `invalid_path` (never a redirect, even with an alias
+  registered), missing destination file → safe 404, malformed stored aliases
+  (bad attachment, bad current hash, self-reference, non-attachment post) → no
+  redirect, deleted attachment → 404 with meta removed, and shared-hash
+  refusals.
+- **`tests/unit/ReprocessorTest.php`** (extended) — `retire_extraction()`
+  ordering: alias persisted before deletion, unchanged hash creates neither
+  alias nor deletion, shared current hash blocks deletion and aliasing,
+  failed reprocess leaves the old extraction, meta and alias state untouched,
+  sequential `reprocess()` runs leave all retired hashes redirecting to the
+  latest extraction.
+- **`tests/unit/RestApiTest.php`** (extended) — failed REST saves create no
+  alias and keep the old extraction directory.
+- Known harness limitation (pre-existing): successful file serving calls
+  `serve_file()` + `exit`
+  (`includes/class-content-proxy.php:110-111` @ `50f0ed5`) and therefore
+  cannot be exercised inside PHPUnit — current-content precedence is enforced
+  structurally (the fallback only runs on the `file_not_found` error) and
+  covered by the `resolve()`-refuses-current-hash unit tests.
+- Quality gates: `composer phpcbf`, `composer phpcs`, `make test`,
+  `make phpmd`, `make check-untranslated`, `git diff --check`.
+
+## Acceptance criteria
+
+- [ ] Requesting a retired hash returns `302 Found` to the same relative path
+      under the attachment's current hash, with query parameters preserved and
+      `Cache-Control: no-cache, must-revalidate`.
+- [ ] After N sequential saves every retired hash redirects directly to the
+      latest hash (no chains).
+- [ ] Invalid hashes, unknown hashes, traversal attempts, malformed aliases,
+      deleted attachments and missing destination files return the same safe
+      errors as before, never a redirect.
+- [ ] A failed save creates no alias and deletes nothing.
+- [ ] A hash still current for another attachment is neither deleted nor
+      redirected when a sharing attachment is saved.
+- [ ] Permanently deleting an attachment removes its aliases and stops its
+      redirects without PHP warnings.
+- [ ] All quality gates pass.
+
+## Open questions
+
+None blocking. The `delete_attachment` shared-directory cleanup (see
+"Shared-hash ambiguity") is noted as possible follow-up work.
+
+## ADRs required or referenced
+
+| Decision | ADR | Status |
+|----------|-----|--------|
+| Obsolete extraction hashes are stored as attachment post meta and resolved through the attachment's current extraction; the public content endpoint answers verified obsolete hashes with a temporary same-origin redirect | ADR-0001 | Accepted |
+
+An ADR is required by repository policy: this change alters the persistent
+storage layout (a new attachment meta key) and the public REST contract of the
+content proxy — both listed as durable-decision territory in
+`AGENTS.md` ("Architecture decisions and design documents") and
+`docs/architecture/adr/README.md`.
+
+## Evidence
+
+- Save transaction and cleanup: `includes/class-exelearning-rest-api.php:375-495` @ `50f0ed5`.
+- Random unique extraction hash: `includes/class-elp-reprocessor.php:301-305` @ `50f0ed5`.
+- Reprocess flow with the same cleanup: `includes/class-elp-reprocessor.php:52-109` @ `50f0ed5`.
+- Proxy validation and 404: `includes/class-content-proxy.php:93-193` @ `50f0ed5`.
+- Route registration and public permission callback: `includes/class-exelearning-rest-api.php:44-66` @ `50f0ed5`.
+- Deletion hook removing the current extraction: `includes/class-elp-upload-handler.php:55,234-245` @ `50f0ed5`.
+- Attachment meta lifecycle on deletion: WordPress core `wp_delete_attachment()` deletes all post meta (https://developer.wordpress.org/reference/functions/wp_delete_attachment/).
+- Isolated content origin URL generation: `includes/class-content-proxy.php:597-658` @ `50f0ed5`.
+- Issue: https://github.com/exelearning/exelearning/issues/2150.
+
+## Follow-up tasks
+
+- [ ] Implement per this design (tests first): `ExeLearning_Content_Hash_Aliases`,
+      `ExeLearning_Reprocessor::retire_extraction()`, proxy fallback.
+- [ ] Optional follow-up (separate issue): reference-check the
+      `delete_attachment` directory cleanup for legacy shared hashes.
+
+## References
+
+- https://github.com/exelearning/exelearning/issues/2150
+- [ADR-0001](../adr/ADR-0001-obsolete-hash-alias-storage.md)
+- `docs/architecture/sdd/README.md`, `docs/architecture/adr/README.md`
+- https://developer.wordpress.org/reference/functions/wp_delete_attachment/
+- https://developer.wordpress.org/rest-api/

--- a/docs/architecture/sdd/SDD-0001-stale-content-url-redirects.md
+++ b/docs/architecture/sdd/SDD-0001-stale-content-url-redirects.md
@@ -6,7 +6,8 @@ date: 2026-07-10
 related:
   issues:
     - https://github.com/exelearning/exelearning/issues/2150
-  prs: []
+  prs:
+    - https://github.com/exelearning/wp-exelearning/pull/68
   adrs:
     - ADR-0001
   sdds: []

--- a/docs/architecture/sdd/records.md
+++ b/docs/architecture/sdd/records.md
@@ -9,11 +9,7 @@ the table and the per-status lists below.
 
 | ID | Title | Status | Date | Related ADRs |
 |----|-------|--------|------|--------------|
-| _None yet_ | | | | |
-
-> No SDDs have been recorded yet. The first numbered SDD (`SDD-0001`) will be
-> created by the first change that needs a design gate before implementation.
-> Copy [`template.md`](template.md) to `SDD-0001-short-title.md` to start it.
+| [SDD-0001](SDD-0001-stale-content-url-redirects.md) | Stale content URL redirects to the latest ELPX extraction | Accepted | 2026-07-10 | [ADR-0001](../adr/ADR-0001-obsolete-hash-alias-storage.md) |
 
 ## Draft SDDs
 
@@ -25,7 +21,8 @@ _No SDDs in review yet._
 
 ## Accepted SDDs
 
-_No accepted SDDs yet._
+- [SDD-0001](SDD-0001-stale-content-url-redirects.md) — Stale content URL
+  redirects to the latest ELPX extraction.
 
 ## Implemented SDDs
 

--- a/exelearning.php
+++ b/exelearning.php
@@ -74,6 +74,7 @@ require_once EXELEARNING_PLUGIN_DIR . 'includes/class-elp-reprocessor.php';
 require_once EXELEARNING_PLUGIN_DIR . 'includes/class-exelearning-editor.php';
 require_once EXELEARNING_PLUGIN_DIR . 'includes/class-export-bootstrap.php';
 require_once EXELEARNING_PLUGIN_DIR . 'includes/class-exelearning-rest-api.php';
+require_once EXELEARNING_PLUGIN_DIR . 'includes/class-content-hash-aliases.php';
 require_once EXELEARNING_PLUGIN_DIR . 'includes/class-content-proxy.php';
 require_once EXELEARNING_PLUGIN_DIR . 'includes/class-static-editor-installer.php';
 

--- a/includes/class-content-hash-aliases.php
+++ b/includes/class-content-hash-aliases.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Obsolete extraction hash aliases for eXeLearning content.
+ *
+ * Saving an edited .elpx generates a new extraction hash and removes the
+ * previous extraction directory, which would turn every published content
+ * URL for the old hash into a dead link. This repository persists each
+ * retired hash as attachment post meta so the content proxy can redirect
+ * stale URLs to the attachment's current extraction (SDD-0001).
+ *
+ * @package Exelearning
+ */
+
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+/**
+ * Class ExeLearning_Content_Hash_Aliases.
+ *
+ * Persists the relationship between retired extraction hashes and the
+ * attachment that retired them, and resolves stale content-proxy requests
+ * back to that attachment. Aliases are stored as multi-value attachment post
+ * meta, so they are removed automatically when the attachment is permanently
+ * deleted, and they resolve through the attachment identity to its single
+ * current hash — redirect chains are impossible by construction.
+ */
+class ExeLearning_Content_Hash_Aliases {
+
+	/**
+	 * Post meta key storing retired extraction hashes (multi-value).
+	 *
+	 * @var string
+	 */
+	const META_KEY = '_exelearning_obsolete_hash';
+
+	/**
+	 * Post meta key storing the current extraction hash.
+	 *
+	 * @var string
+	 */
+	const CURRENT_META_KEY = '_exelearning_extracted';
+
+	/**
+	 * Whether a value is a well-formed extraction hash.
+	 *
+	 * @param mixed $hash Candidate hash.
+	 * @return bool True for a 40-character hexadecimal string.
+	 */
+	public static function is_valid_hash( $hash ) {
+		return is_string( $hash ) && 1 === preg_match( '/^[a-f0-9]{40}$/i', $hash );
+	}
+
+	/**
+	 * Register an obsolete hash as an alias of an attachment.
+	 *
+	 * Refuses malformed hashes, missing or non-attachment posts, hashes that
+	 * are still the current extraction of any attachment (self-aliases and
+	 * legacy shared hashes), and hashes already owned by a different
+	 * attachment (ambiguity guard). Re-registering an alias the attachment
+	 * already owns is an idempotent success. The stored row is read back
+	 * before success is reported, so callers may safely delete the old
+	 * extraction directory only after a true return.
+	 *
+	 * @param int    $attachment_id Attachment retiring the hash.
+	 * @param string $old_hash      Retired extraction hash.
+	 * @return bool True when the alias is persisted (or already present).
+	 */
+	public function register( $attachment_id, $old_hash ) {
+		$attachment_id = (int) $attachment_id;
+		if ( ! self::is_valid_hash( $old_hash ) ) {
+			return false;
+		}
+
+		$attachment = get_post( $attachment_id );
+		if ( ! $attachment || 'attachment' !== $attachment->post_type ) {
+			return false;
+		}
+
+		// Never alias a hash that still serves live content for any
+		// attachment: neither this one (self-reference) nor another one
+		// (legacy shared extraction that must keep working).
+		if ( $this->is_current_hash( $old_hash ) ) {
+			return false;
+		}
+
+		$existing = get_post_meta( $attachment_id, self::META_KEY, false );
+		if ( in_array( $old_hash, (array) $existing, true ) ) {
+			return true;
+		}
+
+		// A hash already owned by a different attachment would become
+		// ambiguous; the resolver refuses those, so never create them.
+		if ( array() !== $this->find_attachments_by_meta( self::META_KEY, $old_hash ) ) {
+			return false;
+		}
+
+		add_post_meta( $attachment_id, self::META_KEY, $old_hash );
+
+		// Verify persistence: the caller deletes content based on this.
+		return in_array( $old_hash, (array) get_post_meta( $attachment_id, self::META_KEY, false ), true );
+	}
+
+	/**
+	 * Resolve an obsolete hash to the attachment that retired it.
+	 *
+	 * Returns 0 for malformed hashes, hashes that are the current extraction
+	 * of any attachment (current content always wins over alias data),
+	 * unknown hashes, and hashes registered on more than one attachment
+	 * (ambiguous — never silently pick one).
+	 *
+	 * @param string $hash Requested extraction hash.
+	 * @return int Owning attachment ID, or 0 when the hash must not redirect.
+	 */
+	public function resolve( $hash ) {
+		if ( ! self::is_valid_hash( $hash ) ) {
+			return 0;
+		}
+
+		if ( $this->is_current_hash( $hash ) ) {
+			return 0;
+		}
+
+		$owners = $this->find_attachments_by_meta( self::META_KEY, $hash );
+		if ( 1 !== count( $owners ) ) {
+			return 0;
+		}
+
+		return (int) $owners[0];
+	}
+
+	/**
+	 * Whether a hash is the current extraction of any attachment.
+	 *
+	 * @param string $hash Extraction hash.
+	 * @return bool
+	 */
+	public function is_current_hash( $hash ) {
+		if ( ! self::is_valid_hash( $hash ) ) {
+			return false;
+		}
+
+		return array() !== $this->find_attachments_by_meta( self::CURRENT_META_KEY, $hash );
+	}
+
+	/**
+	 * Find attachments holding a hash under a meta key.
+	 *
+	 * Bounded lookup (two rows are enough to detect ambiguity) that runs only
+	 * on the save path and on the proxy's file-not-found fallback — never on
+	 * successful content requests.
+	 *
+	 * @param string $meta_key Meta key to match.
+	 * @param string $hash     Hash value to match.
+	 * @return int[] Attachment IDs.
+	 */
+	private function find_attachments_by_meta( $meta_key, $hash ) {
+		$query = new WP_Query(
+			array(
+				'post_type'              => 'attachment',
+				'post_status'            => 'inherit',
+				'posts_per_page'         => 2,
+				'fields'                 => 'ids',
+				'no_found_rows'          => true,
+				'update_post_term_cache' => false,
+				'update_post_meta_cache' => false,
+				'meta_query'             => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Bounded lookup used only on saves and on already-404 proxy requests.
+					array(
+						'key'   => $meta_key,
+						'value' => $hash,
+					),
+				),
+			)
+		);
+
+		return array_map( 'intval', $query->posts );
+	}
+}

--- a/includes/class-content-proxy.php
+++ b/includes/class-content-proxy.php
@@ -103,12 +103,101 @@ class ExeLearning_Content_Proxy {
 		// Validate and resolve file path.
 		$file_result = $this->validate_file_path( $file, $hash );
 		if ( is_wp_error( $file_result ) ) {
+			// Only a genuinely missing file may belong to a retired
+			// extraction: known obsolete hashes redirect to the current one.
+			// Invalid paths and traversal attempts keep their errors.
+			if ( 'file_not_found' === $file_result->get_error_code() ) {
+				$redirect = $this->maybe_redirect_stale_hash( $hash, $file, $request );
+				if ( null !== $redirect ) {
+					return $redirect;
+				}
+			}
 			return $file_result;
 		}
 
 		// Serve the file.
 		$this->serve_file( $file_result['full_path'], $file_result['file'], $hash );
 		exit;
+	}
+
+	/**
+	 * Answer a request for a retired extraction hash with a temporary redirect.
+	 *
+	 * Runs only after the requested hash already failed with file_not_found,
+	 * so successful content delivery and every validation error are
+	 * untouched. A redirect is emitted only when the hash is a verified
+	 * obsolete alias of exactly one attachment, that attachment's current
+	 * hash is well-formed and different from the requested one (loop guard),
+	 * and the equivalent file passes the same path validation inside the
+	 * current extraction directory — never toward a dead or escaping target
+	 * (SDD-0001).
+	 *
+	 * @param string          $hash    Requested (retired) extraction hash.
+	 * @param string          $file    Requested file path.
+	 * @param WP_REST_Request $request Original REST request.
+	 * @return WP_REST_Response|null Redirect response, or null to keep the
+	 *                               original error.
+	 */
+	private function maybe_redirect_stale_hash( $hash, $file, $request ) {
+		$aliases       = new ExeLearning_Content_Hash_Aliases();
+		$attachment_id = $aliases->resolve( $hash );
+		if ( ! $attachment_id ) {
+			return null;
+		}
+
+		$current_hash = get_post_meta( $attachment_id, ExeLearning_Content_Hash_Aliases::CURRENT_META_KEY, true );
+		if ( ! ExeLearning_Content_Hash_Aliases::is_valid_hash( $current_hash )
+			|| strtolower( $current_hash ) === strtolower( $hash ) ) {
+			return null;
+		}
+
+		// The destination must pass the same validation as a direct request
+		// and actually exist inside the current extraction directory.
+		$destination = $this->validate_file_path( $file, $current_hash );
+		if ( is_wp_error( $destination ) ) {
+			return null;
+		}
+
+		$location = self::get_proxy_url( $current_hash, $destination['file'] );
+		$location = $this->add_preserved_query_args( $location, $request );
+
+		$response = new WP_REST_Response( null, 302 );
+		$response->header( 'Location', $location );
+		// The destination changes on every save: never cache it permanently.
+		$response->header( 'Cache-Control', 'no-cache, must-revalidate' );
+
+		return $response;
+	}
+
+	/**
+	 * Append the original request's query parameters to a redirect location.
+	 *
+	 * Parameters are re-encoded (RFC 3986) so no raw user input reaches the
+	 * Location header. The plain-permalink routing argument `rest_route` is
+	 * dropped: the freshly generated target URL already carries its own
+	 * routing when needed.
+	 *
+	 * @param string          $url     Plugin-generated redirect target.
+	 * @param WP_REST_Request $request Original REST request.
+	 * @return string Redirect target with preserved query parameters.
+	 */
+	private function add_preserved_query_args( $url, $request ) {
+		$params = $request->get_query_params();
+		if ( ! is_array( $params ) ) {
+			return $url;
+		}
+		unset( $params['rest_route'] );
+
+		if ( empty( $params ) ) {
+			return $url;
+		}
+
+		$extra = http_build_query( $params, '', '&', PHP_QUERY_RFC3986 );
+		if ( '' === $extra ) {
+			return $url;
+		}
+
+		return $url . ( false === strpos( $url, '?' ) ? '?' : '&' ) . $extra;
 	}
 
 	/**

--- a/includes/class-elp-reprocessor.php
+++ b/includes/class-elp-reprocessor.php
@@ -96,10 +96,10 @@ class ExeLearning_Reprocessor {
 
 		$this->apply_metadata( $attachment_id, $extraction['service'], $extraction['hash'], $extraction['has_preview'] );
 
-		// Drop the previous extraction only after the new one is committed.
-		if ( $old_hash && $old_hash !== $extraction['hash'] ) {
-			$this->cleanup_by_hash( $old_hash );
-		}
+		// Retire the previous extraction only after the new one is committed:
+		// the old hash is preserved as a redirectable alias before its
+		// directory is removed (SDD-0001).
+		$this->retire_extraction( $attachment_id, (string) $old_hash, $extraction['hash'] );
 
 		return array(
 			'attachment_id' => (int) $attachment_id,
@@ -375,6 +375,34 @@ class ExeLearning_Reprocessor {
 		 * @param array $metadata      Final metadata array that was saved.
 		 */
 		do_action( 'exelearning_after_elpx_metadata_saved', $attachment_id, $metadata );
+	}
+
+	/**
+	 * Retire a superseded extraction hash after a successful commit.
+	 *
+	 * Persists the obsolete-hash alias — so the content proxy can redirect
+	 * stale URLs to the attachment's current extraction — and deletes the old
+	 * extraction directory only after the alias is verified as stored. When
+	 * the alias is refused (the hash still serves live content for some
+	 * attachment, is owned by another attachment, or persistence failed) the
+	 * directory is retained, so previously published URLs keep working
+	 * instead of turning into dead links (SDD-0001).
+	 *
+	 * @param int    $attachment_id Attachment whose extraction changed.
+	 * @param string $old_hash      Previous extraction hash ('' if none).
+	 * @param string $new_hash      Newly committed extraction hash.
+	 */
+	public function retire_extraction( $attachment_id, $old_hash, $new_hash ) {
+		if ( empty( $old_hash ) || $old_hash === $new_hash ) {
+			return;
+		}
+
+		$aliases = new ExeLearning_Content_Hash_Aliases();
+		if ( ! $aliases->register( $attachment_id, $old_hash ) ) {
+			return;
+		}
+
+		$this->cleanup_by_hash( $old_hash );
 	}
 
 	/**

--- a/includes/class-exelearning-rest-api.php
+++ b/includes/class-exelearning-rest-api.php
@@ -462,10 +462,10 @@ class ExeLearning_REST_API {
 		// Commit: point metadata at the new extraction.
 		$this->apply_elp_metadata( $attachment_id, $extraction['service'], $extraction['hash'], $extraction['has_preview'] );
 
-		// Clean up old extraction only after the new one is committed.
-		if ( $old_hash && $old_hash !== $extraction['hash'] ) {
-			$this->cleanup_extraction_by_hash( $old_hash );
-		}
+		// Retire the old extraction only after the new one is committed: the
+		// old hash is preserved as a redirectable alias before its directory
+		// is removed, so published content URLs survive the save (SDD-0001).
+		$this->reprocessor->retire_extraction( $attachment_id, (string) $old_hash, $extraction['hash'] );
 
 		// Update attachment modified date.
 		wp_update_post(

--- a/tests/unit/ContentHashAliasesTest.php
+++ b/tests/unit/ContentHashAliasesTest.php
@@ -1,0 +1,274 @@
+<?php
+/**
+ * Tests for ExeLearning_Content_Hash_Aliases class.
+ *
+ * Covers the obsolete-extraction-hash alias repository designed in SDD-0001:
+ * registration (with verification), resolution, duplicate registration,
+ * multiple aliases, invalid values, shared-hash refusals, cleanup on
+ * attachment deletion, and the no-autoloaded-global-map guarantee.
+ *
+ * @package Exelearning
+ */
+
+/**
+ * Class ContentHashAliasesTest.
+ *
+ * @covers ExeLearning_Content_Hash_Aliases
+ */
+class ContentHashAliasesTest extends WP_UnitTestCase {
+
+	/**
+	 * Meta key holding the current extraction hash.
+	 *
+	 * @var string
+	 */
+	const CURRENT_META = '_exelearning_extracted';
+
+	/**
+	 * Meta key holding retired (obsolete) extraction hashes.
+	 *
+	 * @var string
+	 */
+	const ALIAS_META = '_exelearning_obsolete_hash';
+
+	/**
+	 * Test instance.
+	 *
+	 * @var ExeLearning_Content_Hash_Aliases
+	 */
+	private $aliases;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->aliases = new ExeLearning_Content_Hash_Aliases();
+	}
+
+	/**
+	 * Generate a unique, format-valid extraction hash.
+	 *
+	 * @return string 40-char lowercase hex hash.
+	 */
+	private function make_hash() {
+		return sha1( uniqid( 'exe-test-', true ) );
+	}
+
+	/**
+	 * Create an attachment, optionally with a current extraction hash.
+	 *
+	 * @param string|null $current_hash Current extraction hash to store.
+	 * @return int Attachment ID.
+	 */
+	private function make_attachment( $current_hash = null ) {
+		$attachment_id = $this->factory->attachment->create();
+		if ( null !== $current_hash ) {
+			update_post_meta( $attachment_id, self::CURRENT_META, $current_hash );
+		}
+		return $attachment_id;
+	}
+
+	/**
+	 * A registered alias is persisted as attachment post meta and resolves
+	 * back to the owning attachment.
+	 */
+	public function test_register_and_resolve_round_trip() {
+		$attachment_id = $this->make_attachment( $this->make_hash() );
+		$old_hash      = $this->make_hash();
+
+		$this->assertTrue( $this->aliases->register( $attachment_id, $old_hash ) );
+		$this->assertContains( $old_hash, get_post_meta( $attachment_id, self::ALIAS_META ) );
+		$this->assertSame( $attachment_id, $this->aliases->resolve( $old_hash ) );
+	}
+
+	/**
+	 * Multiple aliases can be registered for one attachment and all resolve.
+	 */
+	public function test_multiple_aliases_per_attachment() {
+		$attachment_id = $this->make_attachment( $this->make_hash() );
+		$hash_a        = $this->make_hash();
+		$hash_b        = $this->make_hash();
+
+		$this->assertTrue( $this->aliases->register( $attachment_id, $hash_a ) );
+		$this->assertTrue( $this->aliases->register( $attachment_id, $hash_b ) );
+
+		$this->assertSame( $attachment_id, $this->aliases->resolve( $hash_a ) );
+		$this->assertSame( $attachment_id, $this->aliases->resolve( $hash_b ) );
+	}
+
+	/**
+	 * Re-registering the same alias on the same attachment is idempotent:
+	 * it succeeds and does not duplicate the meta row.
+	 */
+	public function test_duplicate_registration_same_attachment_is_idempotent() {
+		$attachment_id = $this->make_attachment( $this->make_hash() );
+		$old_hash      = $this->make_hash();
+
+		$this->assertTrue( $this->aliases->register( $attachment_id, $old_hash ) );
+		$this->assertTrue( $this->aliases->register( $attachment_id, $old_hash ) );
+
+		$rows = get_post_meta( $attachment_id, self::ALIAS_META );
+		$this->assertCount( 1, array_keys( $rows, $old_hash, true ) );
+	}
+
+	/**
+	 * A hash already registered as an alias of a different attachment is
+	 * refused (ambiguity guard).
+	 */
+	public function test_register_refuses_alias_owned_by_other_attachment() {
+		$owner_id = $this->make_attachment( $this->make_hash() );
+		$other_id = $this->make_attachment( $this->make_hash() );
+		$old_hash = $this->make_hash();
+
+		$this->assertTrue( $this->aliases->register( $owner_id, $old_hash ) );
+		$this->assertFalse( $this->aliases->register( $other_id, $old_hash ) );
+		$this->assertSame( array(), get_post_meta( $other_id, self::ALIAS_META ) );
+	}
+
+	/**
+	 * Malformed hashes are rejected.
+	 */
+	public function test_register_rejects_invalid_hash() {
+		$attachment_id = $this->make_attachment( $this->make_hash() );
+
+		$this->assertFalse( $this->aliases->register( $attachment_id, 'not-a-hash' ) );
+		$this->assertFalse( $this->aliases->register( $attachment_id, 'abc123' ) );
+		$this->assertFalse( $this->aliases->register( $attachment_id, str_repeat( 'g', 40 ) ) );
+		$this->assertFalse( $this->aliases->register( $attachment_id, '' ) );
+		$this->assertSame( array(), get_post_meta( $attachment_id, self::ALIAS_META ) );
+	}
+
+	/**
+	 * Invalid attachments (missing post, wrong post type) are rejected.
+	 */
+	public function test_register_rejects_invalid_attachment() {
+		$this->assertFalse( $this->aliases->register( 0, $this->make_hash() ) );
+		$this->assertFalse( $this->aliases->register( 999999, $this->make_hash() ) );
+
+		$post_id = $this->factory->post->create( array( 'post_type' => 'post' ) );
+		$this->assertFalse( $this->aliases->register( $post_id, $this->make_hash() ) );
+	}
+
+	/**
+	 * The attachment's own current hash cannot become its alias
+	 * (self-reference / loop guard).
+	 */
+	public function test_register_rejects_self_alias() {
+		$current       = $this->make_hash();
+		$attachment_id = $this->make_attachment( $current );
+
+		$this->assertFalse( $this->aliases->register( $attachment_id, $current ) );
+		$this->assertSame( array(), get_post_meta( $attachment_id, self::ALIAS_META ) );
+	}
+
+	/**
+	 * A hash that is the CURRENT extraction of another attachment cannot be
+	 * registered as an alias (legacy shared hash protection).
+	 */
+	public function test_register_rejects_hash_current_for_other_attachment() {
+		$shared_hash = $this->make_hash();
+		$this->make_attachment( $shared_hash );
+		$editing_id = $this->make_attachment( $this->make_hash() );
+
+		$this->assertFalse( $this->aliases->register( $editing_id, $shared_hash ) );
+	}
+
+	/**
+	 * Unknown hashes do not resolve.
+	 */
+	public function test_resolve_unknown_hash_returns_zero() {
+		$this->assertSame( 0, $this->aliases->resolve( $this->make_hash() ) );
+	}
+
+	/**
+	 * Malformed hashes do not resolve.
+	 */
+	public function test_resolve_invalid_hash_returns_zero() {
+		$this->assertSame( 0, $this->aliases->resolve( 'not-a-hash' ) );
+		$this->assertSame( 0, $this->aliases->resolve( '' ) );
+	}
+
+	/**
+	 * A hash that is the current extraction of any attachment never resolves
+	 * as an alias, even when stale alias meta exists for it (current content
+	 * always takes precedence over alias data).
+	 */
+	public function test_resolve_refuses_hash_current_for_an_attachment() {
+		$shared_hash = $this->make_hash();
+		$this->make_attachment( $shared_hash );
+
+		$alias_owner = $this->make_attachment( $this->make_hash() );
+		// Inject stale alias data directly, bypassing register() guards.
+		add_post_meta( $alias_owner, self::ALIAS_META, $shared_hash );
+
+		$this->assertSame( 0, $this->aliases->resolve( $shared_hash ) );
+	}
+
+	/**
+	 * A hash registered (via direct meta manipulation) on two attachments is
+	 * ambiguous and never resolves.
+	 */
+	public function test_resolve_refuses_ambiguous_alias() {
+		$hash = $this->make_hash();
+		$a    = $this->make_attachment( $this->make_hash() );
+		$b    = $this->make_attachment( $this->make_hash() );
+		add_post_meta( $a, self::ALIAS_META, $hash );
+		add_post_meta( $b, self::ALIAS_META, $hash );
+
+		$this->assertSame( 0, $this->aliases->resolve( $hash ) );
+	}
+
+	/**
+	 * Alias meta injected on a non-attachment post never resolves.
+	 */
+	public function test_resolve_ignores_non_attachment_posts() {
+		$hash    = $this->make_hash();
+		$post_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		add_post_meta( $post_id, self::ALIAS_META, $hash );
+
+		$this->assertSame( 0, $this->aliases->resolve( $hash ) );
+	}
+
+	/**
+	 * Permanently deleting the attachment removes its aliases: resolution
+	 * stops and no meta rows survive.
+	 */
+	public function test_aliases_removed_on_attachment_deletion() {
+		$attachment_id = $this->make_attachment( $this->make_hash() );
+		$old_hash      = $this->make_hash();
+		$this->assertTrue( $this->aliases->register( $attachment_id, $old_hash ) );
+
+		wp_delete_attachment( $attachment_id, true );
+
+		$this->assertSame( 0, $this->aliases->resolve( $old_hash ) );
+		$this->assertSame( array(), get_post_meta( $attachment_id, self::ALIAS_META ) );
+	}
+
+	/**
+	 * The repository stores aliases as post meta only: no autoloaded global
+	 * option map is created.
+	 */
+	public function test_no_autoloaded_global_map() {
+		$attachment_id = $this->make_attachment( $this->make_hash() );
+		$old_hash      = $this->make_hash();
+		$this->assertTrue( $this->aliases->register( $attachment_id, $old_hash ) );
+
+		wp_cache_delete( 'alloptions', 'options' );
+		$autoloaded = wp_load_alloptions();
+
+		$this->assertStringNotContainsString( $old_hash, wp_json_encode( $autoloaded ) );
+	}
+
+	/**
+	 * is_current_hash() reports whether any attachment currently uses a hash.
+	 */
+	public function test_is_current_hash() {
+		$current = $this->make_hash();
+		$this->make_attachment( $current );
+
+		$this->assertTrue( $this->aliases->is_current_hash( $current ) );
+		$this->assertFalse( $this->aliases->is_current_hash( $this->make_hash() ) );
+		$this->assertFalse( $this->aliases->is_current_hash( 'not-a-hash' ) );
+	}
+}

--- a/tests/unit/ReprocessorTest.php
+++ b/tests/unit/ReprocessorTest.php
@@ -621,8 +621,12 @@ class ReprocessorTest extends WP_UnitTestCase {
 		// The proxy answers the retired hash with a redirect to the new one.
 		$proxy   = new ExeLearning_Content_Proxy();
 		$request = new WP_REST_Request( 'GET', '/exelearning/v1/content/' . $first['hash'] . '/index.html' );
-		$request->set_param( 'hash', $first['hash'] );
-		$request->set_param( 'file', 'index.html' );
+		$request->set_url_params(
+			array(
+				'hash' => $first['hash'],
+				'file' => 'index.html',
+			)
+		);
 
 		$result = $proxy->serve_content( $request );
 
@@ -638,8 +642,12 @@ class ReprocessorTest extends WP_UnitTestCase {
 
 		foreach ( array( $first['hash'], $second['hash'] ) as $retired ) {
 			$request = new WP_REST_Request( 'GET', '/exelearning/v1/content/' . $retired . '/index.html' );
-			$request->set_param( 'hash', $retired );
-			$request->set_param( 'file', 'index.html' );
+			$request->set_url_params(
+				array(
+					'hash' => $retired,
+					'file' => 'index.html',
+				)
+			);
 
 			$result = $proxy->serve_content( $request );
 

--- a/tests/unit/ReprocessorTest.php
+++ b/tests/unit/ReprocessorTest.php
@@ -507,4 +507,165 @@ class ReprocessorTest extends WP_UnitTestCase {
 		$this->assertNotContains( $plain_zip['id'], $ids );
 		$this->assertNotContains( $image, $ids );
 	}
+
+	/* -------------------------------------------------------------------- */
+	/* Stale-hash retirement (SDD-0001)                                      */
+	/* -------------------------------------------------------------------- */
+
+	/**
+	 * Create an extraction directory on disk for a hash.
+	 *
+	 * @param string $hash Extraction hash.
+	 * @return string Directory path.
+	 */
+	private function make_extraction_dir( $hash ) {
+		$dir = $this->extraction_dir( $hash );
+		wp_mkdir_p( $dir );
+		file_put_contents( $dir . 'index.html', '<html></html>' ); // phpcs:ignore
+		$this->cleanup_paths[] = $dir;
+		return $dir;
+	}
+
+	/**
+	 * retire_extraction() persists the obsolete-hash alias before deleting
+	 * the old extraction directory.
+	 */
+	public function test_retire_extraction_registers_alias_then_deletes() {
+		$old_hash = sha1( uniqid( 'old', true ) );
+		$new_hash = sha1( uniqid( 'new', true ) );
+
+		$attachment_id = $this->factory->attachment->create();
+		update_post_meta( $attachment_id, '_exelearning_extracted', $new_hash );
+		$old_dir = $this->make_extraction_dir( $old_hash );
+
+		$this->reprocessor->retire_extraction( $attachment_id, $old_hash, $new_hash );
+
+		$this->assertContains( $old_hash, get_post_meta( $attachment_id, '_exelearning_obsolete_hash' ) );
+		$this->assertDirectoryDoesNotExist( $old_dir );
+	}
+
+	/**
+	 * An unchanged hash creates neither an alias nor a deletion (no
+	 * self-reference, no data loss).
+	 */
+	public function test_retire_extraction_unchanged_hash_is_noop() {
+		$hash          = sha1( uniqid( 'same', true ) );
+		$attachment_id = $this->factory->attachment->create();
+		update_post_meta( $attachment_id, '_exelearning_extracted', $hash );
+		$dir = $this->make_extraction_dir( $hash );
+
+		$this->reprocessor->retire_extraction( $attachment_id, $hash, $hash );
+
+		$this->assertSame( array(), get_post_meta( $attachment_id, '_exelearning_obsolete_hash' ) );
+		$this->assertDirectoryExists( $dir );
+	}
+
+	/**
+	 * An empty old hash (first save) is a no-op.
+	 */
+	public function test_retire_extraction_empty_old_hash_is_noop() {
+		$attachment_id = $this->factory->attachment->create();
+		$new_hash      = sha1( uniqid( 'new', true ) );
+		update_post_meta( $attachment_id, '_exelearning_extracted', $new_hash );
+
+		$this->reprocessor->retire_extraction( $attachment_id, '', $new_hash );
+
+		$this->assertSame( array(), get_post_meta( $attachment_id, '_exelearning_obsolete_hash' ) );
+	}
+
+	/**
+	 * A hash still current for ANOTHER attachment is neither deleted nor
+	 * aliased (legacy shared hashes stay untouched).
+	 */
+	public function test_retire_extraction_keeps_shared_current_hash() {
+		$shared_hash = sha1( uniqid( 'shared', true ) );
+		$new_hash    = sha1( uniqid( 'new', true ) );
+
+		$other_id = $this->factory->attachment->create();
+		update_post_meta( $other_id, '_exelearning_extracted', $shared_hash );
+
+		$editing_id = $this->factory->attachment->create();
+		update_post_meta( $editing_id, '_exelearning_extracted', $new_hash );
+
+		$shared_dir = $this->make_extraction_dir( $shared_hash );
+
+		$this->reprocessor->retire_extraction( $editing_id, $shared_hash, $new_hash );
+
+		$this->assertDirectoryExists( $shared_dir );
+		$this->assertSame( array(), get_post_meta( $editing_id, '_exelearning_obsolete_hash' ) );
+	}
+
+	/**
+	 * reprocess() retires the previous hash: the old directory is replaced,
+	 * the old hash becomes an alias, and the proxy redirects it to the new
+	 * extraction.
+	 */
+	public function test_reprocess_retires_previous_hash_and_redirects() {
+		$fixture = $this->make_elpx_attachment( true );
+
+		// First processing pass establishes the initial extraction.
+		$first = $this->reprocessor->reprocess( $fixture['id'] );
+		$this->assertIsArray( $first );
+		$this->cleanup_paths[] = $this->extraction_dir( $first['hash'] );
+
+		// Second pass simulates an edit+save: the hash changes.
+		$second = $this->reprocessor->reprocess( $fixture['id'] );
+		$this->assertIsArray( $second );
+		$this->cleanup_paths[] = $this->extraction_dir( $second['hash'] );
+		$this->assertNotSame( $first['hash'], $second['hash'] );
+
+		// The retired hash is aliased and its directory is gone.
+		$this->assertContains( $first['hash'], get_post_meta( $fixture['id'], '_exelearning_obsolete_hash' ) );
+		$this->assertDirectoryDoesNotExist( $this->extraction_dir( $first['hash'] ) );
+
+		// The proxy answers the retired hash with a redirect to the new one.
+		$proxy   = new ExeLearning_Content_Proxy();
+		$request = new WP_REST_Request( 'GET', '/exelearning/v1/content/' . $first['hash'] . '/index.html' );
+		$request->set_param( 'hash', $first['hash'] );
+		$request->set_param( 'file', 'index.html' );
+
+		$result = $proxy->serve_content( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertSame( 302, $result->get_status() );
+		$headers = $result->get_headers();
+		$this->assertStringContainsString( $second['hash'], $headers['Location'] );
+
+		// A third pass leaves BOTH retired hashes redirecting to the latest.
+		$third = $this->reprocessor->reprocess( $fixture['id'] );
+		$this->assertIsArray( $third );
+		$this->cleanup_paths[] = $this->extraction_dir( $third['hash'] );
+
+		foreach ( array( $first['hash'], $second['hash'] ) as $retired ) {
+			$request = new WP_REST_Request( 'GET', '/exelearning/v1/content/' . $retired . '/index.html' );
+			$request->set_param( 'hash', $retired );
+			$request->set_param( 'file', 'index.html' );
+
+			$result = $proxy->serve_content( $request );
+
+			$this->assertInstanceOf( WP_REST_Response::class, $result );
+			$this->assertSame( 302, $result->get_status() );
+			$headers = $result->get_headers();
+			$this->assertStringContainsString( $third['hash'], $headers['Location'] );
+		}
+	}
+
+	/**
+	 * A failed reprocess creates no alias, keeps the previous extraction
+	 * directory, and leaves the extraction meta unchanged.
+	 */
+	public function test_failed_reprocess_creates_no_alias() {
+		$fixture = $this->make_elpx_attachment( true, false ); // Not a real ZIP.
+
+		$old_hash = sha1( uniqid( 'old', true ) );
+		update_post_meta( $fixture['id'], '_exelearning_extracted', $old_hash );
+		$old_dir = $this->make_extraction_dir( $old_hash );
+
+		$result = $this->reprocessor->reprocess( $fixture['id'] );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( array(), get_post_meta( $fixture['id'], '_exelearning_obsolete_hash' ) );
+		$this->assertDirectoryExists( $old_dir );
+		$this->assertSame( $old_hash, get_post_meta( $fixture['id'], '_exelearning_extracted', true ) );
+	}
 }

--- a/tests/unit/RestApiTest.php
+++ b/tests/unit/RestApiTest.php
@@ -2190,4 +2190,60 @@ class RestApiTest extends WP_UnitTestCase {
 
 		$this->assertEquals( 403, $response->get_status() );
 	}
+
+	/**
+	 * A failed save creates no obsolete-hash alias, keeps the previous
+	 * extraction directory, and leaves the extraction meta unchanged
+	 * (SDD-0001).
+	 */
+	public function test_failed_save_creates_no_alias_and_keeps_extraction() {
+		$user_id       = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$attachment_id = $this->factory->attachment->create( array( 'post_author' => $user_id ) );
+		wp_set_current_user( $user_id );
+
+		$upload_dir = wp_upload_dir();
+		$file_path  = $upload_dir['basedir'] . '/stale-save-' . $attachment_id . '.elpx';
+
+		$zip = new ZipArchive();
+		$zip->open( $file_path, ZipArchive::CREATE );
+		$zip->addFromString( 'content.xml', '<package></package>' );
+		$zip->close();
+		update_attached_file( $attachment_id, $file_path );
+
+		$old_hash   = sha1( uniqid( 'stale-save-old', true ) );
+		$old_folder = $upload_dir['basedir'] . '/exelearning/' . $old_hash . '/';
+		wp_mkdir_p( $old_folder );
+		file_put_contents( $old_folder . 'index.html', '<html></html>' );
+		update_post_meta( $attachment_id, '_exelearning_extracted', $old_hash );
+
+		// A garbage upload guarantees the save fails before commit.
+		$_FILES['file'] = array(
+			'name'     => 'broken.elpx',
+			'type'     => 'application/zip',
+			'tmp_name' => tempnam( sys_get_temp_dir(), 'exe' ),
+			'error'    => UPLOAD_ERR_OK,
+			'size'     => 22,
+		);
+		file_put_contents( $_FILES['file']['tmp_name'], 'this is not a zip file' );
+
+		$request = new WP_REST_Request( 'POST', '/exelearning/v1/save/' . $attachment_id );
+		$request->set_param( 'id', $attachment_id );
+
+		$result = $this->rest_api->save_elp_file( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( array(), get_post_meta( $attachment_id, '_exelearning_obsolete_hash' ) );
+		$this->assertSame( $old_hash, get_post_meta( $attachment_id, '_exelearning_extracted', true ) );
+		$this->assertTrue( is_dir( $old_folder ) );
+
+		// Clean up.
+		$this->recursive_delete_test( $old_folder );
+		if ( file_exists( $_FILES['file']['tmp_name'] ) ) {
+			unlink( $_FILES['file']['tmp_name'] );
+		}
+		unset( $_FILES['file'] );
+		if ( file_exists( $file_path ) ) {
+			unlink( $file_path );
+		}
+	}
 }

--- a/tests/unit/StaleContentRedirectTest.php
+++ b/tests/unit/StaleContentRedirectTest.php
@@ -1,0 +1,456 @@
+<?php
+/**
+ * Tests for the stale content URL redirect behavior of the content proxy.
+ *
+ * Covers the redirect fallback designed in SDD-0001: requests for a known
+ * obsolete extraction hash return a temporary same-origin redirect to the
+ * equivalent validated file path under the owning attachment's current
+ * extraction hash, while every invalid, unknown, ambiguous or unsafe case
+ * keeps returning the existing safe errors.
+ *
+ * @package Exelearning
+ */
+
+/**
+ * Class StaleContentRedirectTest.
+ *
+ * @covers ExeLearning_Content_Proxy
+ */
+class StaleContentRedirectTest extends WP_UnitTestCase {
+
+	/**
+	 * Meta key holding the current extraction hash.
+	 *
+	 * @var string
+	 */
+	const CURRENT_META = '_exelearning_extracted';
+
+	/**
+	 * Meta key holding retired (obsolete) extraction hashes.
+	 *
+	 * @var string
+	 */
+	const ALIAS_META = '_exelearning_obsolete_hash';
+
+	/**
+	 * Test instance.
+	 *
+	 * @var ExeLearning_Content_Proxy
+	 */
+	private $proxy;
+
+	/**
+	 * Paths created during a test that must be removed on tear down.
+	 *
+	 * @var string[]
+	 */
+	private $cleanup_paths = array();
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->proxy         = new ExeLearning_Content_Proxy();
+		$this->cleanup_paths = array();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tear_down() {
+		foreach ( $this->cleanup_paths as $path ) {
+			$this->recursive_delete( $path );
+		}
+		parent::tear_down();
+	}
+
+	/**
+	 * Generate a unique, format-valid extraction hash.
+	 *
+	 * @return string 40-char lowercase hex hash.
+	 */
+	private function make_hash() {
+		return sha1( uniqid( 'exe-test-', true ) );
+	}
+
+	/**
+	 * Create an extraction directory for a hash with an index.html and a
+	 * nested asset file.
+	 *
+	 * @param string $hash Extraction hash.
+	 * @return string Directory path.
+	 */
+	private function make_extraction_dir( $hash ) {
+		$upload_dir = wp_upload_dir();
+		$dir        = trailingslashit( $upload_dir['basedir'] ) . 'exelearning/' . $hash . '/';
+		wp_mkdir_p( $dir . 'assets/css' );
+		file_put_contents( $dir . 'index.html', '<html><body>Current</body></html>' ); // phpcs:ignore
+		file_put_contents( $dir . 'assets/css/main.css', 'body{}' ); // phpcs:ignore
+		$this->cleanup_paths[] = $dir;
+		return $dir;
+	}
+
+	/**
+	 * Create an attachment with a current extraction (hash meta + directory).
+	 *
+	 * @return array { id: int, hash: string, dir: string }
+	 */
+	private function make_attachment_with_extraction() {
+		$attachment_id = $this->factory->attachment->create();
+		$current_hash  = $this->make_hash();
+		update_post_meta( $attachment_id, self::CURRENT_META, $current_hash );
+		$dir = $this->make_extraction_dir( $current_hash );
+
+		return array(
+			'id'   => $attachment_id,
+			'hash' => $current_hash,
+			'dir'  => $dir,
+		);
+	}
+
+	/**
+	 * Register an obsolete-hash alias for an attachment.
+	 *
+	 * @param int    $attachment_id Attachment ID.
+	 * @param string $old_hash      Obsolete hash.
+	 */
+	private function register_alias( $attachment_id, $old_hash ) {
+		$aliases = new ExeLearning_Content_Hash_Aliases();
+		$this->assertTrue( $aliases->register( $attachment_id, $old_hash ) );
+	}
+
+	/**
+	 * Dispatch a request through the content proxy.
+	 *
+	 * @param string $hash  Requested hash.
+	 * @param string $file  Requested file path.
+	 * @param array  $query Extra query parameters for the request.
+	 * @return WP_REST_Response|WP_Error Proxy result.
+	 */
+	private function serve( $hash, $file = 'index.html', $query = array() ) {
+		$request = new WP_REST_Request( 'GET', '/exelearning/v1/content/' . $hash . '/' . $file );
+		$request->set_param( 'hash', $hash );
+		$request->set_param( 'file', $file );
+		if ( ! empty( $query ) ) {
+			$request->set_query_params( $query );
+		}
+
+		return $this->proxy->serve_content( $request );
+	}
+
+	/**
+	 * Assert a result is a temporary redirect and return its Location header.
+	 *
+	 * @param mixed $result Proxy result.
+	 * @return string Location header value.
+	 */
+	private function assert_temporary_redirect( $result ) {
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertSame( 302, $result->get_status() );
+
+		$headers = $result->get_headers();
+		$this->assertArrayHasKey( 'Location', $headers );
+		$this->assertArrayHasKey( 'Cache-Control', $headers );
+		$this->assertStringContainsString( 'no-cache', $headers['Cache-Control'] );
+
+		return $headers['Location'];
+	}
+
+	/**
+	 * A known obsolete hash redirects temporarily to index.html under the
+	 * attachment's current hash.
+	 */
+	public function test_stale_hash_redirects_to_current_index() {
+		$fixture  = $this->make_attachment_with_extraction();
+		$old_hash = $this->make_hash();
+		$this->register_alias( $fixture['id'], $old_hash );
+
+		$location = $this->assert_temporary_redirect( $this->serve( $old_hash, 'index.html' ) );
+
+		$this->assertStringContainsString( $fixture['hash'], $location );
+		$this->assertStringContainsString( 'index.html', $location );
+		$this->assertStringNotContainsString( $old_hash, $location );
+	}
+
+	/**
+	 * The requested nested relative path is preserved in the redirect.
+	 */
+	public function test_stale_hash_redirect_preserves_nested_path() {
+		$fixture  = $this->make_attachment_with_extraction();
+		$old_hash = $this->make_hash();
+		$this->register_alias( $fixture['id'], $old_hash );
+
+		$location = $this->assert_temporary_redirect( $this->serve( $old_hash, 'assets/css/main.css' ) );
+
+		$this->assertStringContainsString( $fixture['hash'] . '/assets/css/main.css', $location );
+	}
+
+	/**
+	 * Request query parameters (e.g. ?exe-teacher=1) are preserved in the
+	 * redirect location.
+	 */
+	public function test_stale_hash_redirect_preserves_query_parameters() {
+		$fixture  = $this->make_attachment_with_extraction();
+		$old_hash = $this->make_hash();
+		$this->register_alias( $fixture['id'], $old_hash );
+
+		$location = $this->assert_temporary_redirect(
+			$this->serve( $old_hash, 'index.html', array( 'exe-teacher' => '1' ) )
+		);
+
+		$this->assertStringContainsString( 'exe-teacher=1', $location );
+		$this->assertStringContainsString( $fixture['hash'], $location );
+	}
+
+	/**
+	 * The plain-permalink routing argument of the original request is not
+	 * duplicated into the redirect location.
+	 */
+	public function test_stale_hash_redirect_drops_original_rest_route_param() {
+		$fixture  = $this->make_attachment_with_extraction();
+		$old_hash = $this->make_hash();
+		$this->register_alias( $fixture['id'], $old_hash );
+
+		$location = $this->assert_temporary_redirect(
+			$this->serve(
+				$old_hash,
+				'index.html',
+				array(
+					'rest_route'  => '/exelearning/v1/content/' . $old_hash . '/index.html',
+					'exe-teacher' => '1',
+				)
+			)
+		);
+
+		$this->assertStringContainsString( 'exe-teacher=1', $location );
+		$this->assertStringNotContainsString( $old_hash, $location );
+	}
+
+	/**
+	 * After multiple sequential saves every retired hash redirects directly
+	 * to the latest hash — never through an intermediate hash.
+	 */
+	public function test_sequential_saves_redirect_directly_to_latest() {
+		$fixture = $this->make_attachment_with_extraction();
+		$hash_a  = $this->make_hash();
+		$hash_b  = $this->make_hash();
+		$this->register_alias( $fixture['id'], $hash_a );
+		$this->register_alias( $fixture['id'], $hash_b );
+
+		$location_a = $this->assert_temporary_redirect( $this->serve( $hash_a ) );
+		$location_b = $this->assert_temporary_redirect( $this->serve( $hash_b ) );
+
+		$this->assertStringContainsString( $fixture['hash'], $location_a );
+		$this->assertStringContainsString( $fixture['hash'], $location_b );
+		$this->assertStringNotContainsString( $hash_b, $location_a );
+		$this->assertStringNotContainsString( $hash_a, $location_b );
+	}
+
+	/**
+	 * A syntactically valid but unknown hash keeps returning file_not_found.
+	 */
+	public function test_unknown_hash_still_returns_file_not_found() {
+		$result = $this->serve( $this->make_hash() );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'file_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Malformed hashes keep returning the existing validation error.
+	 */
+	public function test_invalid_hash_still_returns_invalid_hash() {
+		$result = $this->serve( 'invalid-hash' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_hash', $result->get_error_code() );
+	}
+
+	/**
+	 * Raw traversal attempts fail path validation and are never redirected,
+	 * even when an alias exists for the requested hash.
+	 */
+	public function test_traversal_never_redirects() {
+		$fixture  = $this->make_attachment_with_extraction();
+		$old_hash = $this->make_hash();
+		$this->register_alias( $fixture['id'], $old_hash );
+
+		$result = $this->serve( $old_hash, '../../../etc/passwd' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_path', $result->get_error_code() );
+	}
+
+	/**
+	 * Encoded traversal attempts fail path validation and are never
+	 * redirected.
+	 */
+	public function test_encoded_traversal_never_redirects() {
+		$fixture  = $this->make_attachment_with_extraction();
+		$old_hash = $this->make_hash();
+		$this->register_alias( $fixture['id'], $old_hash );
+
+		$result = $this->serve( $old_hash, '%2e%2e/%2e%2e/secret' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_path', $result->get_error_code() );
+	}
+
+	/**
+	 * When the equivalent file does not exist under the current extraction,
+	 * the proxy returns the safe 404 instead of redirecting to a dead target.
+	 */
+	public function test_missing_destination_file_returns_not_found() {
+		$fixture  = $this->make_attachment_with_extraction();
+		$old_hash = $this->make_hash();
+		$this->register_alias( $fixture['id'], $old_hash );
+
+		$result = $this->serve( $old_hash, 'not-in-current-extraction.html' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'file_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * An alias whose attachment has a malformed current hash never redirects.
+	 */
+	public function test_malformed_current_hash_never_redirects() {
+		$attachment_id = $this->factory->attachment->create();
+		update_post_meta( $attachment_id, self::CURRENT_META, 'not-a-valid-hash' );
+		$old_hash = $this->make_hash();
+		add_post_meta( $attachment_id, self::ALIAS_META, $old_hash );
+
+		$result = $this->serve( $old_hash );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'file_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * A self-referencing alias (hash equals the attachment's current hash)
+	 * never redirects — no loop is possible.
+	 */
+	public function test_self_referencing_alias_never_redirects() {
+		$attachment_id = $this->factory->attachment->create();
+		$hash          = $this->make_hash();
+		update_post_meta( $attachment_id, self::CURRENT_META, $hash );
+		// Inject the invalid self-alias directly, bypassing register() guards.
+		add_post_meta( $attachment_id, self::ALIAS_META, $hash );
+
+		$result = $this->serve( $hash );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'file_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Alias meta on a non-attachment post never redirects.
+	 */
+	public function test_alias_on_non_attachment_post_never_redirects() {
+		$post_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$hash    = $this->make_hash();
+		update_post_meta( $post_id, self::CURRENT_META, $this->make_hash() );
+		add_post_meta( $post_id, self::ALIAS_META, $hash );
+
+		$result = $this->serve( $hash );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'file_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * A hash aliased (via direct meta manipulation) to two attachments is
+	 * ambiguous and never redirects.
+	 */
+	public function test_ambiguous_alias_never_redirects() {
+		$fixture_a = $this->make_attachment_with_extraction();
+		$fixture_b = $this->make_attachment_with_extraction();
+		$hash      = $this->make_hash();
+		add_post_meta( $fixture_a['id'], self::ALIAS_META, $hash );
+		add_post_meta( $fixture_b['id'], self::ALIAS_META, $hash );
+
+		$result = $this->serve( $hash );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'file_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * A hash that is still the CURRENT hash of another attachment is never
+	 * redirected, even when stale alias data exists for it (shared legacy
+	 * hashes cannot be hijacked).
+	 */
+	public function test_shared_current_hash_never_redirects() {
+		$shared_hash = $this->make_hash();
+		$owner_id    = $this->factory->attachment->create();
+		update_post_meta( $owner_id, self::CURRENT_META, $shared_hash );
+
+		$editing = $this->make_attachment_with_extraction();
+		add_post_meta( $editing['id'], self::ALIAS_META, $shared_hash );
+
+		// The shared directory is missing (e.g. removed out-of-band): the
+		// request must fail safely instead of redirecting to the editor's
+		// current content.
+		$result = $this->serve( $shared_hash );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'file_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * After the owning attachment is permanently deleted, its stale hashes
+	 * stop redirecting and return the safe 404 without warnings.
+	 */
+	public function test_deleted_attachment_stops_redirecting() {
+		$fixture  = $this->make_attachment_with_extraction();
+		$old_hash = $this->make_hash();
+		$this->register_alias( $fixture['id'], $old_hash );
+
+		// Sanity: redirect works while the attachment exists.
+		$this->assert_temporary_redirect( $this->serve( $old_hash ) );
+
+		wp_delete_attachment( $fixture['id'], true );
+
+		$result = $this->serve( $old_hash );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'file_not_found', $result->get_error_code() );
+		$this->assertSame( array(), get_post_meta( $fixture['id'], self::ALIAS_META ) );
+	}
+
+	/**
+	 * The redirect location stays on the site's own REST origin.
+	 */
+	public function test_redirect_location_is_same_origin() {
+		$fixture  = $this->make_attachment_with_extraction();
+		$old_hash = $this->make_hash();
+		$this->register_alias( $fixture['id'], $old_hash );
+
+		$location = $this->assert_temporary_redirect( $this->serve( $old_hash ) );
+
+		$expected_base = ExeLearning_Content_Proxy::get_proxy_url( $fixture['hash'], 'index.html' );
+		$this->assertStringStartsWith( $expected_base, $location );
+	}
+
+	/**
+	 * Recursively delete a directory.
+	 *
+	 * @param string $dir Directory path.
+	 */
+	private function recursive_delete( $dir ) {
+		if ( ! file_exists( $dir ) ) {
+			return;
+		}
+
+		if ( is_file( $dir ) || is_link( $dir ) ) {
+			unlink( $dir ); // phpcs:ignore
+		} else {
+			$files = array_diff( scandir( $dir ), array( '.', '..' ) );
+			foreach ( $files as $file ) {
+				$this->recursive_delete( $dir . DIRECTORY_SEPARATOR . $file );
+			}
+			rmdir( $dir ); // phpcs:ignore
+		}
+	}
+}

--- a/tests/unit/StaleContentRedirectTest.php
+++ b/tests/unit/StaleContentRedirectTest.php
@@ -130,8 +130,14 @@ class StaleContentRedirectTest extends WP_UnitTestCase {
 	 */
 	private function serve( $hash, $file = 'index.html', $query = array() ) {
 		$request = new WP_REST_Request( 'GET', '/exelearning/v1/content/' . $hash . '/' . $file );
-		$request->set_param( 'hash', $hash );
-		$request->set_param( 'file', $file );
+		// Route parameters land in the URL slot when the REST server routes a
+		// real request; mirror that so query params stay separate.
+		$request->set_url_params(
+			array(
+				'hash' => $hash,
+				'file' => $file,
+			)
+		);
 		if ( ! empty( $query ) ) {
 			$request->set_query_params( $query );
 		}


### PR DESCRIPTION
## Summary

- Preserve previously published hash-based content URLs after an ELPX attachment is edited.
- Resolve known obsolete extraction hashes to the attachment's current extraction.
- Redirect to the equivalent validated file path using a temporary same-origin redirect (`302 Found`, `Cache-Control: no-cache, must-revalidate`).
- Avoid redirect chains by resolving aliases through the current attachment state — every retired hash always points at the single latest hash.
- Preserve existing proxy validation and security behavior: the fallback runs only after the request already failed with `file_not_found`.
- Handle attachment deletion and legacy shared extraction hashes safely.

Fixes exelearning/exelearning#2150

## Problem

Saving an edited ELPX generates a new extraction hash and removes the old extraction directory. URLs containing the previous hash then return `file_not_found` permanently — every shared or embedded link breaks on each edit.

## Design

- **Alias storage**: each retired hash is stored as multi-value attachment post meta (`_exelearning_obsolete_hash`) on the attachment that retired it, via the new `ExeLearning_Content_Hash_Aliases` repository. Post meta resolves the alias *through the attachment identity* to its single current `_exelearning_extracted` value (no chains possible), is deleted automatically by WordPress when the attachment is permanently deleted, matches the plugin's "everything in attachment meta" storage model, and adds zero autoloaded state.
- **Why not hash chains or retained directories**: old→new hash chains need chain-walking and cycle detection and lose the attachment identity (making shared-hash ambiguity unresolvable); keeping every old extraction grows disk usage without bound. A per-hash option loses automatic deletion cleanup. Full evaluation matrix in SDD-0001 / ADR-0001.
- **Save-transaction ordering** (both REST save and reprocess): validate + extract new → replace file → commit metadata → **register alias and verify it persisted → only then delete the old directory**. Failed saves never reach the alias step; failed alias persistence retains the old directory, so the URL keeps serving the previous content instead of dying.
- **Shared hashes** (legacy content-derived extractions): a hash that is still the *current* hash of any attachment is never aliased, never redirected, and its directory is never deleted by a sharing attachment's save (this also fixes a latent data-loss path where a save could delete a directory another attachment still referenced). A hash aliased to more than one attachment never redirects — the proxy returns the safe 404 rather than silently picking an attachment.
- **Redirect status and cache**: `302 Found` with `Cache-Control: no-cache, must-revalidate` — the destination is mutable (the attachment can be edited again), so it must never be cached permanently.
- **Cleanup**: alias meta rows die with the attachment (core `wp_delete_attachment()` behavior); no new cleanup surface, no options-table growth.

## SDD

- `docs/architecture/sdd/SDD-0001-stale-content-url-redirects.md` (Accepted)
- `docs/architecture/adr/ADR-0001-obsolete-hash-alias-storage.md` (Accepted — durable storage/REST-contract decision per repository ADR policy)

## Test-driven development

1. **Tests first** (commit `test(proxy): cover stale content URL redirects`): `ContentHashAliasesTest` (16 tests — registration/resolution/guards/deletion/no-autoload), `StaleContentRedirectTest` (17 tests — redirect behavior plus negative-path guards), `ReprocessorTest` retirement/integration additions, `RestApiTest` failed-save guard.
2. **Captured expected failures before implementation**:
   - `ContentHashAliasesTest`: `Tests: 16, Errors: 16` — `Error: Class "ExeLearning_Content_Hash_Aliases" not found`.
   - `StaleContentRedirectTest`: all redirect tests errored with the missing class, while the negative-path guards (unknown/invalid hash, traversal, malformed alias, shared hash) already passed, pinning current behavior.
   - `ReprocessorTest`: 4 × `Call to undefined method ExeLearning_Reprocessor::retire_extraction()` plus `Failed asserting that an array contains '<hash>'` (reprocess registered no alias).
3. **After implementation** (focused): `ContentHashAliasesTest` OK (16 tests, 38 assertions); `StaleContentRedirectTest` OK (17 tests, 87 assertions); `ReprocessorTest` OK (27 tests, 79 assertions); `RestApiTest` failed-save guard OK (1 test, 4 assertions). **Full suite**: `OK (771 tests, 1629 assertions)`.

## Security

- Redirects are generated only for known obsolete hashes: format-valid, registered as an alias of exactly one existing attachment, not the current hash of any attachment.
- Redirect destinations are generated by the plugin (`ExeLearning_Content_Proxy::get_proxy_url()`, the same generator as every proxy URL, including the `exelearning_content_origin` isolated-origin rewrite) and remain on the configured content origin.
- The requested path is validated before redirecting: the fallback only ever runs after `file_not_found` (never after `invalid_path`/`access_denied`), and the destination is re-validated with the existing `validate_file_path()` (traversal-safe sanitization + realpath containment) against the current hash.
- The target file must exist inside the latest extraction directory — no redirects to dead targets, which also makes chains structurally impossible.
- Unknown hashes and malformed alias data (bad attachment IDs, non-attachment posts, malformed current hashes, self-references, ambiguous multi-owner aliases) continue to fail safely with the existing errors.
- Shared current hashes are never reassigned to an arbitrary attachment; preserved query parameters are re-encoded with `http_build_query(…, PHP_QUERY_RFC3986)` so no raw user input reaches the `Location` header.
- Zero added queries on successful content requests; the per-attachment save lock is unchanged and covers the new retire step.

## Testing

```text
composer phpcbf: PASS (no remaining fixable violations in the change; drive-by
                 reformatting of unrelated test files was discarded)
composer phpcs (repository ruleset, CI-equivalent):
                 ./vendor/bin/phpcs --standard=.phpcs.xml.dist --no-cache -q . → exit 0 (PASS)
                 Note: the raw `composer phpcs` script (plain --standard=WordPress) reports
                 pre-existing WordPress.Files.FileName errors on ~25 existing class files;
                 CI uses .phpcs.xml.dist (ci.yml:98), which excludes that sniff and passes.
make test:       PASS — OK (771 tests, 1629 assertions)
                 (One environment-only failure of StaticEditorInstallerTest occurs when a
                 local gitignored dist/static build is present; suite is fully green without
                 the local artifact and in CI.)
make phpmd:      PASS (exit 0, no violations)
make check-untranslated: PASS (exit 0 — the change introduces no user-facing strings;
                 regenerated .po/.mo timestamp churn was reverted)
git diff --check: PASS (clean)
```

## Manual verification

Verified end-to-end against wp-env (pretty permalinks, `wp-json` URLs):

1. Upload an ELPX attachment (fixture `tests/fixtures/test-content.elpx`).
2. Record its current `/wp-json/exelearning/v1/content/<hash1>/index.html` URL.
3. Edit and save the ELPX so its extraction hash changes (simulated via `ExeLearning_Reprocessor::reprocess()`, which shares the retire path with the REST save) → `<hash2>`, then again → `<hash3>`.
4. `curl -I <hash1 URL>?exe-teacher=1` → `HTTP/1.1 302 Found`, `Location: /wp-json/exelearning/v1/content/<hash3>/index.html?exe-teacher=1`, `Cache-Control: no-cache, must-revalidate`.
5. `curl -I <hash2 URL>` → `302 Found` → `<hash3>` (both retired hashes redirect **directly** to the latest hash, no chain).
6. `curl -L <hash1 URL>` → final `200 OK` on the `<hash3>` URL.
7. Current-hash URL serves `200 OK` with the usual security headers, unchanged.
8. An unknown 40-hex hash still returns `404`.

Plain permalinks (`?rest_route=…`) are covered by the unit tests, which run in an environment where `rest_url()` produces the plain-permalink form; the redirect drops the original `rest_route` argument and preserves the remaining query parameters.

## Changed files

- `includes/class-content-hash-aliases.php` **(new)** — obsolete-hash alias repository: guarded registration with read-back verification, single-owner resolution, current-hash refusals.
- `includes/class-content-proxy.php` — `file_not_found`-only redirect fallback (`maybe_redirect_stale_hash()`, `add_preserved_query_args()`); everything else untouched.
- `includes/class-elp-reprocessor.php` — new `retire_extraction()` (alias-then-delete, fail-open on persistence failure); `reprocess()` now uses it.
- `includes/class-exelearning-rest-api.php` — the locked save transaction retires the old hash via the reprocessor instead of deleting it unconditionally.
- `exelearning.php` — require the new class file.
- `docs/architecture/sdd/SDD-0001-stale-content-url-redirects.md`, `docs/architecture/adr/ADR-0001-obsolete-hash-alias-storage.md`, `docs/architecture/{sdd,adr}/records.md` — design records.
- `tests/unit/ContentHashAliasesTest.php` **(new)**, `tests/unit/StaleContentRedirectTest.php` **(new)**, `tests/unit/ReprocessorTest.php`, `tests/unit/RestApiTest.php` — TDD coverage described above.

## Compatibility

- WordPress: `Requires at least: 6.1`, `Tested up to: 7.0` (readme.txt).
- PHP: `Requires PHP: 8.0` (readme.txt); tests run on the wp-env PHPUnit environment.
- No migration: attachments saved before this change simply have no aliases (their already-dead URLs remain 404, as today). Rollback leaves only inert post meta.

## Independent security review

An adversarial security/regression review of the full diff (open redirect, traversal-to-redirect conversion, malformed metadata, alias loops, deleted attachments, failed saves, shared-hash hijack, cache lifetime, header injection, permalink modes, isolated content origin, save-lock coverage) found **no blocking findings**. Non-blocking notes, all pre-existing behavior or cosmetic, were recorded and intentionally left out of scope: `get_proxy_url()` does not percent-encode path segments (pre-existing; not exploitable — the file must exist on disk and `header()` rejects CR/LF), `reprocess()` has no per-attachment lock (pre-existing; duplicate alias rows on one attachment are cosmetic since resolution counts distinct attachments), and `Cache-Control` could optionally add `private`.

## Known limitation

When two legacy attachments genuinely shared one content-derived hash and **both** are later edited, requests for that shared hash cannot be attributed to either attachment without changing the public URL contract; they return the safe 404. Documented in SDD-0001 (“Shared-hash ambiguity”), together with a possible follow-up for the `delete_attachment` directory cleanup.
