### PR TITLE
Ship .l10n.php translations and package with wp dist-archive

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -18,7 +18,9 @@ tests
 /vendor
 wp-content
 
-# Language stuff
+# Language stuff. Only the runtime files ship: .l10n.php (WordPress 6.5+),
+# .mo (fallback for 6.1-6.4) and the JS .json files. The .po/.pot sources stay
+# in the repository.
 languages/*.pot
 languages/*.po
 
@@ -81,6 +83,9 @@ mkdocs.yml
 sonar-project.properties
 test.php
 CHANGELOG.md
-LICENSE.txt
+# Anchored on purpose: an unanchored "LICENSE.txt" also matches the licence
+# files bundled with the static editor (matching is case-insensitive, so it
+# even catches dist/static/libs/tinymce_5/js/tinymce/license.txt).
+/LICENSE.txt
 phpmd.baseline.xml
 *.elpx

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ artifacts/
 
 # Generated runtime translation files
 languages/*.mo
+languages/*.l10n.php
 languages/exelearning-*-*.json
 
 # Ignore Sass source maps

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -17,6 +17,10 @@
     <exclude-pattern type="relative">^wp-content/uploads/exelearning/*</exclude-pattern>
     <!-- Standalone developer CLI tooling; not shipped (see .distignore). -->
     <exclude-pattern>/bin/*</exclude-pattern>
+    <!-- Generated runtime translations. `wp i18n make-php` emits .l10n.php
+         files that PHPCS would otherwise scan as source. type="relative" for
+         the same reason as the uploads pattern above. -->
+    <exclude-pattern type="relative">^languages/*</exclude-pattern>
 
     <arg name="extensions" value="php"/>
     <arg name="colors"/>

--- a/Makefile
+++ b/Makefile
@@ -433,6 +433,12 @@ po:
 mo:
 	composer make-mo
 
+# Generate .l10n.php files from .po files.
+# WordPress 6.5+ loads these instead of the .mo when both are present; the .mo
+# stays as the fallback for the 6.1-6.4 range declared in readme.txt.
+l10n-php:
+	composer make-php
+
 # Regenerate the JavaScript translation JSON files from the .po files
 json:
 	composer clean-json
@@ -479,7 +485,7 @@ check-untranslated:
 	composer check-untranslated
 
 # Generate and validate runtime translation files for packaging.
-package-translations: mo json
+package-translations: mo l10n-php json
 	composer validate-translations
 	@set -e; \
 	found=0; \
@@ -489,8 +495,13 @@ package-translations: mo json
 		locale="$${po#languages/exelearning-}"; \
 		locale="$${locale%.po}"; \
 		mo="$${po%.po}.mo"; \
+		l10n="$${po%.po}.l10n.php"; \
 		if [ ! -s "$$mo" ]; then \
 			echo "Error: Missing or empty generated translation file: $$mo" >&2; \
+			exit 1; \
+		fi; \
+		if [ ! -s "$$l10n" ]; then \
+			echo "Error: Missing or empty generated translation file: $$l10n" >&2; \
 			exit 1; \
 		fi; \
 		json_found=0; \
@@ -537,12 +548,14 @@ package: package-translations
 	$(SED_INPLACE) "s/define( 'EXELEARNING_VERSION', '[^']*'/define( 'EXELEARNING_VERSION', '$(VERSION)'/" exelearning.php
 	$(SED_INPLACE) "s/^Stable tag:.*/Stable tag: $(VERSION)/" readme.txt
 
-	# Create the ZIP package with proper folder structure
-	rm -rf /tmp/exelearning-package
-	mkdir -p /tmp/exelearning-package/exelearning
-	rsync -av --exclude-from=.distignore ./ /tmp/exelearning-package/exelearning/
-	cd /tmp/exelearning-package && zip -r "$(CURDIR)/exelearning-$(VERSION).zip" exelearning
-	rm -rf /tmp/exelearning-package
+	@# Create the ZIP package with proper folder structure.
+	@# `wp dist-archive` reads .distignore straight from the working tree, so the
+	@# generated files that .gitignore keeps out of the repository (dist/static/
+	@# and the runtime translations) are packaged like any other file.
+	@# --plugin-dirname is what makes the archive extract as exelearning/ even
+	@# though the development checkout is named wp-exelearning.
+	./vendor/bin/wp dist-archive . "$(CURDIR)/exelearning-$(VERSION).zip" \
+		--plugin-dirname=exelearning --force
 
 	# Restore the version in exelearning.php & readme.txt
 	$(SED_INPLACE) "s/^ \* Version:.*/ * Version:           0.0.0/" exelearning.php
@@ -600,8 +613,9 @@ help:
 	@echo "  pot                - Generate the .pot file (editable source template)"
 	@echo "  po                 - Update .po files from the .pot file"
 	@echo "  mo                 - Generate .mo runtime files from .po files"
+	@echo "  l10n-php           - Generate .l10n.php runtime files (WordPress 6.5+) from .po files"
 	@echo "  json               - Regenerate the JS translation JSON files from .po files"
-	@echo "  translations       - Full deterministic build: pot, po, mo and json"
+	@echo "  translations       - Full deterministic build: pot, po, mo, l10n.php and json"
 	@echo "  check-translations - Validate translation artifacts are complete and up to date"
 	@echo "  i18n-audit         - Run the WordPress i18n audit on the codebase"
 	@echo ""

--- a/bin/validate-translations.php
+++ b/bin/validate-translations.php
@@ -14,7 +14,11 @@
  *   - the locale in the filename matches the locale inside the JSON;
  *   - every JavaScript source containing translatable strings has one JSON per
  *     shipped locale (no missing files);
- *   - there are no unexpected or orphaned JSON files.
+ *   - there are no unexpected or orphaned JSON files;
+ *   - every shipped locale has an .l10n.php file (the format WordPress 6.5+
+ *     loads in preference to the .mo), returning a non-empty message array for
+ *     the plugin's own text domain and matching locale;
+ *   - there are no orphaned .l10n.php files.
  *
  * Exits 0 when the contract holds, 1 otherwise (printing every problem).
  *
@@ -186,13 +190,74 @@ foreach ( (array) glob( $languages . '/*.json' ) as $file ) {
 	}
 }
 
+/**
+ * Load a generated .l10n.php file without leaking anything into this scope.
+ *
+ * @param string $file Absolute path to the PHP translation file.
+ * @return mixed Whatever the file returns.
+ */
+function exe_load_l10n_php( $file ) {
+	return include $file;
+}
+
+// Every shipped locale must have a PHP translation file.
+foreach ( $locales as $locale ) {
+	$name = 'exelearning-' . $locale . '.l10n.php';
+	if ( ! is_file( $languages . '/' . $name ) ) {
+		$errors[] = sprintf( 'Missing PHP translation file for locale "%s" (expected %s).', $locale, $name );
+	}
+}
+
+// Every PHP translation file present must be expected and well-formed.
+foreach ( (array) glob( $languages . '/*.l10n.php' ) as $file ) {
+	$name = basename( $file );
+
+	if ( ! preg_match( '/^exelearning-(.+)\.l10n\.php$/', $name, $parts ) ) {
+		$errors[] = sprintf( 'Unexpected PHP translation file does not match the generated-file convention: %s', $name );
+		continue;
+	}
+
+	$filename_locale = $parts[1];
+
+	if ( ! in_array( $filename_locale, $locales, true ) ) {
+		$errors[] = sprintf( 'Orphaned PHP translation file (no matching PO source): %s', $name );
+	}
+
+	$data = exe_load_l10n_php( $file );
+	if ( ! is_array( $data ) ) {
+		$errors[] = sprintf( 'PHP translation file %s does not return an array.', $name );
+		continue;
+	}
+
+	// WordPress keys the loaded data by the plugin's own text domain.
+	if ( ! isset( $data['domain'] ) || 'exelearning' !== $data['domain'] ) {
+		$errors[] = sprintf( 'PHP translation file %s does not declare the "exelearning" text domain.', $name );
+	}
+
+	// The locale in the filename must match the locale inside the file.
+	$file_locale = isset( $data['language'] ) ? $data['language'] : '';
+	if ( $file_locale !== $filename_locale ) {
+		$errors[] = sprintf(
+			'PHP translation file %s locale mismatch: filename locale "%s" but declared language "%s".',
+			$name,
+			$filename_locale,
+			$file_locale
+		);
+	}
+
+	if ( empty( $data['messages'] ) || ! is_array( $data['messages'] ) ) {
+		$errors[] = sprintf( 'PHP translation file %s contains no messages.', $name );
+	}
+}
+
 if ( empty( $errors ) ) {
 	fwrite(
 		STDOUT,
 		sprintf(
-			"Translation contract OK: %d JavaScript source(s) x %d locale(s).\n",
+			"Translation contract OK: %d JavaScript source(s) x %d locale(s), %d PHP translation file(s).\n",
 			count( $js_sources ),
-			count( $locales )
+			count( $locales ),
+			count( (array) glob( $languages . '/*.l10n.php' ) )
 		)
 	);
 	exit( 0 );

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
         "phpcompatibility/phpcompatibility-wp": "*",
         "phpunit/phpunit": "*",
         "squizlabs/php_codesniffer": "*",
+        "wp-cli/dist-archive-command": "^3.1",
         "wp-cli/i18n-command": "*",
         "wp-coding-standards/wpcs": "*",
         "yoast/phpunit-polyfills": "*",
@@ -17,6 +18,7 @@
         "pot-remove-ctime": "sed -i.bak '/POT-Creation-Date:/d' languages/exelearning.pot && rm languages/exelearning.pot.bak",
         "po": "@php bin/po-update.php",
         "make-mo": "wp i18n make-mo languages/ languages/",
+        "make-php": "wp i18n make-php languages/ languages/",
         "clean-json": "@php bin/clean-json.php",
         "make-json": "wp i18n make-json languages/ languages/ --pretty-print",
         "make-translations": [
@@ -25,6 +27,7 @@
             "@po",
             "@untranslated",
             "@make-mo",
+            "@make-php",
             "@clean-json",
             "@make-json"
         ],
@@ -36,7 +39,8 @@
             "@pot-remove-ctime",
             "@po",
             "@untranslated",
-            "@make-mo"
+            "@make-mo",
+            "@make-php"
         ]
     },
     "config": {


### PR DESCRIPTION
## Why

Two things, both in the packaging path.

**`.l10n.php`** — since WordPress 6.5, a `.l10n.php` file next to a `.mo` is loaded *instead* of it, and it is [meaningfully faster and lighter](https://make.wordpress.org/core/2024/02/27/i18n-improvements-6-5-performant-translations/). Plugins on wordpress.org receive those files through the language packs. This plugin is distributed as a GitHub release, so it only ever has what it bundles — we were leaving the improvement on the table for every locale we ship.

**`wp dist-archive`** — the release ZIP was assembled with a `/tmp` staging directory, `rsync --exclude-from=.distignore` and a manual `zip`. That is a perfectly legitimate approach (it is what `10up/action-wordpress-plugin-deploy` does internally), but WP-CLI has a command built for exactly this, reading exactly the same `.distignore`.

Compiled translations stay out of the repository — they are derived 1:1 from the `.po` sources, and `make check-translations` already guarantees they are complete and reproducible.

## What changed

- `wp i18n make-php` runs as part of `make translations` / `make package`; new `make l10n-php` target.
- `languages/*.l10n.php` is gitignored, like the `.mo` and JS `.json` runtime files.
- `package-translations` fails if any locale is missing its `.l10n.php`; `bin/validate-translations.php` additionally checks each file returns a non-empty message array for the right text domain and locale, and flags orphans.
- `make package` now calls `wp dist-archive . <zip> --plugin-dirname=exelearning --force`.
- PHPCS excludes `languages/`.
- `.distignore`: `LICENSE.txt` → `/LICENSE.txt`.

`.mo` files keep shipping as the fallback for the 6.1–6.4 range in `readme.txt`.

## Two things worth a closer look

**PHPCS would have broken CI.** `wp i18n make-php` emits `.php` files into `languages/`, and CI runs `make check-translations` *before* the lint step — so PHPCS would have scanned the generated files as source and failed with 559 violations. Hence the new exclude pattern, using `type="relative"` for the same reason documented on the uploads pattern above it.

**`dist-archive` was silently dropping a licence file.** It matches paths case-insensitively (`inmarelibero/gitignore-checker` compiles every rule with the `i` flag), so the unanchored `LICENSE.txt` rule also matched `dist/static/libs/tinymce_5/js/tinymce/license.txt` — rsync, being case-sensitive, had always kept it. Dropping a bundled third-party licence from a redistributed package is not something to ship, so the rule is now anchored to the repository root, which is what it always meant. Both packagers now agree.

`wp-cli/dist-archive-command` is pinned to `^3.1`: 3.2+ requires `wp-cli ^2.13`, which has no stable release yet. A fresh CI-style resolve (no lock is committed) backtracks to v3.1.0 and leaves wp-cli at v2.12.0; the constraint picks up 3.2 automatically once 2.13 lands. v3.1.0 shells out to the `zip` binary rather than needing `ext-zip`.

## Verification

- **Package contents unchanged.** The file list of the `dist-archive` ZIP is identical to the previous rsync output — 3920 entries, zero additions, zero removals — with the TinyMCE licence restored. Confirmed present: 10 `.l10n.php`, 10 `.mo`, 10 `.json`, `dist/static/`. Confirmed absent: `.env`, `vendor/`, `tests/`, `node_modules/`, `.git/`, `*.po`, `*.pot`.
- **WordPress really loads the `.l10n.php`.** On WP 7.0.2 with the plugin active and locale `es_ES`: with both files present the string resolves; with the `.mo` removed and only the `.l10n.php` left it *still* resolves; with both removed it falls back to English. The third case is the control — it proves the test can fail.
- **Validator fails when it should:** missing file, locale mismatch between filename and contents, and orphaned locale each produce a distinct error and exit 1.
- `make check-translations` passes (deterministic, no drift, no untracked files).
- PHPCS clean over the full tree (34 files scanned, no `.l10n.php` among them).
- PHPUnit: 801 tests, 1717 assertions, all passing.

## Follow-up, not in this PR

`make package` `sed`s the real version into `exelearning.php` / `readme.txt`, builds, then `sed`s it back. If the build fails in between, it leaves the working tree dirty with a version that was never meant to be committed. Doing the substitution on the staged copy instead would remove the failure mode.