### PR TITLE
Fix plugin header metadata: minimum WordPress version and supported format

### DIFF
--- a/exelearning.php
+++ b/exelearning.php
@@ -10,6 +10,7 @@
  * Plugin URI:        https://github.com/exelearning/wp-exelearning
  * Description:       Plugin to support eXeLearning .elp files in WordPress. Upload, manage and embed eXeLearning content.
  * Version:           0.0.0
+ * Requires at least: 6.1
  * Author:            INTEF
  * Author URI:        https://exelearning.net/
  * License:           AGPL-3.0+

--- a/exelearning.php
+++ b/exelearning.php
@@ -8,7 +8,7 @@
  * @wordpress-plugin
  * Plugin Name:       eXeLearning
  * Plugin URI:        https://github.com/exelearning/wp-exelearning
- * Description:       Plugin to support eXeLearning .elp files in WordPress. Upload, manage and embed eXeLearning content.
+ * Description:       Plugin to support eXeLearning .elpx files in WordPress. Upload, manage and embed eXeLearning content.
  * Version:           0.0.0
  * Requires at least: 6.1
  * Author:            INTEF

--- a/languages/exelearning-ca.po
+++ b/languages/exelearning-ca.po
@@ -29,16 +29,16 @@ msgstr "https://github.com/exelearning/wp-exelearning"
 
 #. Description of the plugin
 #: exelearning.php:11
-msgid "Plugin to support eXeLearning .elp files in WordPress. Upload, manage and embed eXeLearning content."
-msgstr "Connector per gestionar fitxers .elp d'eXeLearning a WordPress. Puja, gestiona i incrusta contingut d'eXeLearning."
+msgid "Plugin to support eXeLearning .elpx files in WordPress. Upload, manage and embed eXeLearning content."
+msgstr "Connector per gestionar fitxers .elpx d'eXeLearning a WordPress. Puja, gestiona i incrusta contingut d'eXeLearning."
 
 #. Author of the plugin
-#: exelearning.php:13
+#: exelearning.php:14
 msgid "INTEF"
 msgstr "INTEF"
 
 #. Author URI of the plugin
-#: exelearning.php:14
+#: exelearning.php:15
 msgid "https://exelearning.net/"
 msgstr "https://exelearning.net/"
 

--- a/languages/exelearning-ca_valencia.po
+++ b/languages/exelearning-ca_valencia.po
@@ -29,16 +29,16 @@ msgstr "https://github.com/exelearning/wp-exelearning"
 
 #. Description of the plugin
 #: exelearning.php:11
-msgid "Plugin to support eXeLearning .elp files in WordPress. Upload, manage and embed eXeLearning content."
-msgstr "Connector per a gestionar fitxers .elp d'eXeLearning en WordPress. Puja, gestiona i incrusta contingut d'eXeLearning."
+msgid "Plugin to support eXeLearning .elpx files in WordPress. Upload, manage and embed eXeLearning content."
+msgstr "Connector per a gestionar fitxers .elpx d'eXeLearning en WordPress. Puja, gestiona i incrusta contingut d'eXeLearning."
 
 #. Author of the plugin
-#: exelearning.php:13
+#: exelearning.php:14
 msgid "INTEF"
 msgstr "INTEF"
 
 #. Author URI of the plugin
-#: exelearning.php:14
+#: exelearning.php:15
 msgid "https://exelearning.net/"
 msgstr "https://exelearning.net/"
 

--- a/languages/exelearning-de_DE.po
+++ b/languages/exelearning-de_DE.po
@@ -29,16 +29,16 @@ msgstr "https://github.com/exelearning/wp-exelearning"
 
 #. Description of the plugin
 #: exelearning.php:11
-msgid "Plugin to support eXeLearning .elp files in WordPress. Upload, manage and embed eXeLearning content."
-msgstr "Plugin zur Unterstützung von eXeLearning .elp-Dateien in WordPress. Hochladen, Verwalten und Einbetten von eXeLearning-Inhalten."
+msgid "Plugin to support eXeLearning .elpx files in WordPress. Upload, manage and embed eXeLearning content."
+msgstr "Plugin zur Unterstützung von eXeLearning .elpx-Dateien in WordPress. Hochladen, Verwalten und Einbetten von eXeLearning-Inhalten."
 
 #. Author of the plugin
-#: exelearning.php:13
+#: exelearning.php:14
 msgid "INTEF"
 msgstr "INTEF"
 
 #. Author URI of the plugin
-#: exelearning.php:14
+#: exelearning.php:15
 msgid "https://exelearning.net/"
 msgstr "https://exelearning.net/"
 

--- a/languages/exelearning-eo.po
+++ b/languages/exelearning-eo.po
@@ -29,16 +29,16 @@ msgstr "https://github.com/exelearning/wp-exelearning"
 
 #. Description of the plugin
 #: exelearning.php:11
-msgid "Plugin to support eXeLearning .elp files in WordPress. Upload, manage and embed eXeLearning content."
-msgstr "Kromprogramo por subteni eXeLearning .elp-dosierojn en WordPress. Alŝutu, administru kaj enkorpigu eXeLearning-enhavon."
+msgid "Plugin to support eXeLearning .elpx files in WordPress. Upload, manage and embed eXeLearning content."
+msgstr "Kromprogramo por subteni eXeLearning .elpx-dosierojn en WordPress. Alŝutu, administru kaj enkorpigu eXeLearning-enhavon."
 
 #. Author of the plugin
-#: exelearning.php:13
+#: exelearning.php:14
 msgid "INTEF"
 msgstr "INTEF"
 
 #. Author URI of the plugin
-#: exelearning.php:14
+#: exelearning.php:15
 msgid "https://exelearning.net/"
 msgstr "https://exelearning.net/"
 

--- a/languages/exelearning-es_ES.po
+++ b/languages/exelearning-es_ES.po
@@ -29,16 +29,16 @@ msgstr "https://github.com/exelearning/wp-exelearning"
 
 #. Description of the plugin
 #: exelearning.php:11
-msgid "Plugin to support eXeLearning .elp files in WordPress. Upload, manage and embed eXeLearning content."
-msgstr "Plugin para gestionar archivos .elp de eXeLearning en WordPress. Sube, gestiona e incrusta contenido de eXeLearning."
+msgid "Plugin to support eXeLearning .elpx files in WordPress. Upload, manage and embed eXeLearning content."
+msgstr "Plugin para gestionar archivos .elpx de eXeLearning en WordPress. Sube, gestiona e incrusta contenido de eXeLearning."
 
 #. Author of the plugin
-#: exelearning.php:13
+#: exelearning.php:14
 msgid "INTEF"
 msgstr "INTEF"
 
 #. Author URI of the plugin
-#: exelearning.php:14
+#: exelearning.php:15
 msgid "https://exelearning.net/"
 msgstr "https://exelearning.net/"
 

--- a/languages/exelearning-eu.po
+++ b/languages/exelearning-eu.po
@@ -29,16 +29,16 @@ msgstr "https://github.com/exelearning/wp-exelearning"
 
 #. Description of the plugin
 #: exelearning.php:11
-msgid "Plugin to support eXeLearning .elp files in WordPress. Upload, manage and embed eXeLearning content."
-msgstr "eXeLearning .elp fitxategiak WordPressen kudeatzeko plugina. Igo, kudeatu eta txertatu eXeLearning edukiak."
+msgid "Plugin to support eXeLearning .elpx files in WordPress. Upload, manage and embed eXeLearning content."
+msgstr "eXeLearning .elpx fitxategiak WordPressen kudeatzeko plugina. Igo, kudeatu eta txertatu eXeLearning edukiak."
 
 #. Author of the plugin
-#: exelearning.php:13
+#: exelearning.php:14
 msgid "INTEF"
 msgstr "INTEF"
 
 #. Author URI of the plugin
-#: exelearning.php:14
+#: exelearning.php:15
 msgid "https://exelearning.net/"
 msgstr "https://exelearning.net/"
 

--- a/languages/exelearning-gl_ES.po
+++ b/languages/exelearning-gl_ES.po
@@ -29,16 +29,16 @@ msgstr "https://github.com/exelearning/wp-exelearning"
 
 #. Description of the plugin
 #: exelearning.php:11
-msgid "Plugin to support eXeLearning .elp files in WordPress. Upload, manage and embed eXeLearning content."
-msgstr "Complemento para xestionar ficheiros .elp de eXeLearning en WordPress. Sube, xestiona e incrusta contido de eXeLearning."
+msgid "Plugin to support eXeLearning .elpx files in WordPress. Upload, manage and embed eXeLearning content."
+msgstr "Complemento para xestionar ficheiros .elpx de eXeLearning en WordPress. Sube, xestiona e incrusta contido de eXeLearning."
 
 #. Author of the plugin
-#: exelearning.php:13
+#: exelearning.php:14
 msgid "INTEF"
 msgstr "INTEF"
 
 #. Author URI of the plugin
-#: exelearning.php:14
+#: exelearning.php:15
 msgid "https://exelearning.net/"
 msgstr "https://exelearning.net/"
 

--- a/languages/exelearning-it_IT.po
+++ b/languages/exelearning-it_IT.po
@@ -29,16 +29,16 @@ msgstr "https://github.com/exelearning/wp-exelearning"
 
 #. Description of the plugin
 #: exelearning.php:11
-msgid "Plugin to support eXeLearning .elp files in WordPress. Upload, manage and embed eXeLearning content."
-msgstr "Plugin per gestire i file .elp di eXeLearning in WordPress. Carica, gestisci e incorpora contenuti eXeLearning."
+msgid "Plugin to support eXeLearning .elpx files in WordPress. Upload, manage and embed eXeLearning content."
+msgstr "Plugin per gestire i file .elpx di eXeLearning in WordPress. Carica, gestisci e incorpora contenuti eXeLearning."
 
 #. Author of the plugin
-#: exelearning.php:13
+#: exelearning.php:14
 msgid "INTEF"
 msgstr "INTEF"
 
 #. Author URI of the plugin
-#: exelearning.php:14
+#: exelearning.php:15
 msgid "https://exelearning.net/"
 msgstr "https://exelearning.net/"
 

--- a/languages/exelearning-pt_PT.po
+++ b/languages/exelearning-pt_PT.po
@@ -29,16 +29,16 @@ msgstr "https://github.com/exelearning/wp-exelearning"
 
 #. Description of the plugin
 #: exelearning.php:11
-msgid "Plugin to support eXeLearning .elp files in WordPress. Upload, manage and embed eXeLearning content."
-msgstr "Plugin para gerir ficheiros .elp do eXeLearning no WordPress. Carregue, gira e incorpore conteúdo eXeLearning."
+msgid "Plugin to support eXeLearning .elpx files in WordPress. Upload, manage and embed eXeLearning content."
+msgstr "Plugin para gerir ficheiros .elpx do eXeLearning no WordPress. Carregue, gira e incorpore conteúdo eXeLearning."
 
 #. Author of the plugin
-#: exelearning.php:13
+#: exelearning.php:14
 msgid "INTEF"
 msgstr "INTEF"
 
 #. Author URI of the plugin
-#: exelearning.php:14
+#: exelearning.php:15
 msgid "https://exelearning.net/"
 msgstr "https://exelearning.net/"
 

--- a/languages/exelearning-ro_RO.po
+++ b/languages/exelearning-ro_RO.po
@@ -29,16 +29,16 @@ msgstr "https://github.com/exelearning/wp-exelearning"
 
 #. Description of the plugin
 #: exelearning.php:11
-msgid "Plugin to support eXeLearning .elp files in WordPress. Upload, manage and embed eXeLearning content."
-msgstr "Plugin pentru gestionarea fișierelor .elp eXeLearning în WordPress. Încărcați, gestionați și încorporați conținut eXeLearning."
+msgid "Plugin to support eXeLearning .elpx files in WordPress. Upload, manage and embed eXeLearning content."
+msgstr "Plugin pentru gestionarea fișierelor .elpx eXeLearning în WordPress. Încărcați, gestionați și încorporați conținut eXeLearning."
 
 #. Author of the plugin
-#: exelearning.php:13
+#: exelearning.php:14
 msgid "INTEF"
 msgstr "INTEF"
 
 #. Author URI of the plugin
-#: exelearning.php:14
+#: exelearning.php:15
 msgid "https://exelearning.net/"
 msgstr "https://exelearning.net/"
 

--- a/languages/exelearning.pot
+++ b/languages/exelearning.pot
@@ -28,16 +28,16 @@ msgstr ""
 
 #. Description of the plugin
 #: exelearning.php:11
-msgid "Plugin to support eXeLearning .elp files in WordPress. Upload, manage and embed eXeLearning content."
+msgid "Plugin to support eXeLearning .elpx files in WordPress. Upload, manage and embed eXeLearning content."
 msgstr ""
 
 #. Author of the plugin
-#: exelearning.php:13
+#: exelearning.php:14
 msgid "INTEF"
 msgstr ""
 
 #. Author URI of the plugin
-#: exelearning.php:14
+#: exelearning.php:15
 msgid "https://exelearning.net/"
 msgstr ""
 


### PR DESCRIPTION
Two corrections to the plugin file header, the block WordPress actually reads.

## 1. The declared minimum WordPress version was never enforced

`readme.txt` has declared `Requires at least: 6.1` all along, but `validate_plugin_requirements()` reads `RequiresWP` from the **plugin file header** via `get_plugin_data()` — `readme.txt` is only consulted by wordpress.org, where this plugin is not listed. `exelearning.php` had no such header, so the minimum was documentation rather than a gate: a site on 5.x could install and activate the plugin, then fail in whatever way it failed.

Verified on WP 7.0.2: `RequiresWP` now reports `6.1` (it was empty), `is_wp_version_compatible()` returns `true` against current WordPress, and a 6.0 site would be turned away with WordPress's own message rather than an obscure downstream failure.

This does not change what the plugin supports. It changes whether the claim we already make is enforced.

## 2. The description advertised the wrong file format

The header said "Plugin to support eXeLearning **.elp** files". But `.elp` is the eXeLearning **v2 source** format, which this plugin explicitly cannot render — `class-media-library.php` says so to the user's face:

> This is an eXeLearning v2 source file (.elp). To view the content, open it in eXeLearning and export it as HTML.

What the plugin actually handles is `.elpx`. It is the only extension registered as a MIME type (`$mimes['elpx'] = 'application/zip'`; there is no `$mimes['elp']`), and `readme.txt` already described the plugin correctly — tags include `elpx`, and the short description already read ".elpx files". Only the plugin header was out of sync, and that is precisely the string WordPress renders on the Plugins screen.

### Translation impact

The description is a translatable string (`#. Description of the plugin`), so the change propagates to the POT and to all ten locales. Every existing translation already carried the extension as a literal token, so each `msgstr` needed the same single-character edit — no wording was reinterpreted and no translation was invented:

```
-msgstr "Plugin para gestionar archivos .elp de eXeLearning en WordPress. …"
+msgstr "Plugin para gestionar archivos .elpx de eXeLearning en WordPress. …"
```

The regenerated files also pick up the `#: exelearning.php:NN` references that shifted by one when the `Requires at least` header was added. That shift is what failed the translation gate on the first push — the gate working exactly as intended.

## Verification

- `make check-translations` passes: regenerated twice, byte-stable, no drift, no untranslated strings, no untracked files.
- PHPCS clean over the full tree.
- Translation diff is only the `.elpx` msgid/msgstr plus the one-line reference shift — no fuzzy entries.
- Plugin lists as `active` on WP 7.0.2 after the header change.

## Deliberately left alone

`get_plugin_data()` also reports `RequiresPHP` as empty, though `readme.txt` declares `Requires PHP: 8.0` — the identical gap. I did not add that header, because unlike the WordPress one I found no evidence the code needs PHP 8.0: no `match`, no nullsafe operator, no `str_contains`/`str_starts_with`/`str_ends_with`, no constructor promotion. Adding it would block PHP 7.4 sites that may run fine today — a support decision, not a correctness fix. Either confirm 8.0 is genuinely required and add the header, or correct `readme.txt` to what is actually supported.

Several internal docblocks still say `.elp` where they mean `.elpx`. Those are comments, not behaviour, and belong in their own sweep.

## Relationship to #81

Independent. #81 is packaging (`.l10n.php` + `dist-archive`); this is plugin metadata. They touch disjoint files, do not conflict, and can merge in either order. The CI failure here was caused by this branch's own line-number shift, not by anything missing from #81.