### PR TITLE
Report PHP and JavaScript coverage to Codecov

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -24,6 +24,7 @@ blueprint.json                                             export-ignore
 CHANGELOG.md                                               export-ignore
 CLAUDE.md                                                  export-ignore
 cloudflare-worker/		                                   export-ignore
+codecov.yml                                                export-ignore
 CODE_OF_CONDUCT.md                                         export-ignore
 composer.json                                              export-ignore
 composer.lock                                              export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  # Codecov authenticates with OIDC instead of a token kept as a secret.
+  # Without this permission no identity token can be issued, and uploads from
+  # a protected branch are rejected.
+  id-token: write
 
 env:
   COMPOSER_NO_INTERACTION: 1
@@ -135,6 +139,16 @@ jobs:
       - name: Run JavaScript unit tests
         run: npm run test:js
 
+      - name: Upload JavaScript coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          use_oidc: true
+          files: artifacts/coverage-js/lcov.info
+          flags: javascript
+          # Without this the uploader also sweeps up the PHP reports left in
+          # artifacts/ and files both suites under the same flag.
+          disable_search: true
+
       # === START ENVIRONMENT (with Xdebug for coverage) ===
       - name: Start wp-env with coverage
         run: npx wp-env start --xdebug=coverage
@@ -205,9 +219,14 @@ jobs:
           retention-days: 7
 
       # === UPLOAD COVERAGE TO CODECOV ===
-      - name: Upload coverage to Codecov
+      # OIDC, not a token: no CODECOV_TOKEN secret is configured, and uploads
+      # from the protected main branch are rejected without credentials.
+      - name: Upload PHP coverage to Codecov
         uses: codecov/codecov-action@v7
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           files: artifacts/coverage/clover.xml
-          fail_ci_if_error: false
+          flags: php
+          # The uploader otherwise also picks up artifacts/coverage/coverage.txt,
+          # a human-readable summary it cannot parse as a coverage report.
+          disable_search: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,33 @@
+# Codecov configuration.
+#
+# Statuses are informational: Codecov comments the coverage of every pull
+# request but never marks it as failed. A large part of this plugin can only be
+# exercised with a full WordPress environment loaded, so a blocking threshold
+# would measure what is testable rather than what is well done. The hard gate
+# already lives in `make test-coverage` (MIN_COVERAGE), which does fail the
+# build when PHP coverage drops.
+#
+# To make these blocking, set `informational: false`.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+# PHPUnit runs inside the wp-env container, where the plugin lives under
+# /var/www/html/wp-content/plugins/exelearning, and Clover records those
+# absolute paths. Stripping the prefix maps every entry back onto the
+# repository; without it Codecov cannot match a single file. The JavaScript
+# LCOV report already uses repository-relative paths and needs no fix.
+fixes:
+  - "/var/www/html/wp-content/plugins/exelearning/::"
+
+# Coverage arrives from two suites, each uploaded under its own flag (`php` and
+# `javascript`, set in the workflow). No `paths` are declared for them on
+# purpose: a path list also filters the report, and it would quietly drop the
+# root-level exelearning.php and uninstall.php from the PHP numbers.
+comment:
+  layout: "condensed_header, diff, flags, files"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,72 @@
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@playwright/test": "^1.62.0",
+        "@vitest/coverage-v8": "^4.1.10",
         "@wordpress/env": "^11.11.0",
         "happy-dom": "^20.10.2",
         "jquery": "^3.7.1",
         "nunjucks": "^3.2.4",
         "vitest": "^4.1.8"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -482,12 +543,33 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@kwsites/file-exists": {
       "version": "1.1.1",
@@ -1965,6 +2047,37 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
@@ -2455,6 +2568,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/async-lock": {
@@ -3746,6 +3871,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -3915,6 +4047,45 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -3935,6 +4106,13 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
       "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -4481,6 +4659,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "devDependencies": {
     "@playwright/test": "^1.62.0",
+    "@vitest/coverage-v8": "^4.1.10",
     "@wordpress/env": "^11.11.0",
     "happy-dom": "^20.10.2",
     "jquery": "^3.7.1",
@@ -16,7 +17,7 @@
     "composer": "wp-env run cli --env-cwd=wp-content/plugins/exelearning composer",
     "composer:tests-cli": "wp-env run tests-cli --env-cwd=wp-content/plugins/exelearning composer",
     "test:unit": "wp-env run tests-cli --env-cwd=wp-content/plugins/exelearning ./vendor/bin/phpunit",
-    "test:js": "vitest run",
+    "test:js": "vitest run --coverage",
     "test:e2e": "playwright test",
     "build": "echo 'Use make build-editor instead for static editor build'",
     "package": "npm run package:zip",

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -10,5 +10,15 @@ export default defineConfig( {
 		globals: true,
 		environment: 'happy-dom',
 		include: [ 'tests/js/**/*.test.js' ],
+		coverage: {
+			provider: 'v8',
+			reporter: [ 'text', 'lcov' ],
+			reportsDirectory: 'artifacts/coverage-js',
+			// Everything under assets/js is measured, not only the files that
+			// happen to be under test: most of these scripts drive the browser
+			// and are covered by the E2E suite instead, and hiding them would
+			// report a prettier number rather than a true one.
+			include: [ 'assets/js/**/*.js' ],
+		},
 	},
 } );


### PR DESCRIPTION
## Why

Codecov uploads have been failing on **every** run, without failing CI. From the last run on `main` ([log](https://github.com/exelearning/wp-exelearning/actions/runs/30806598717)):

```
 -> Token length: 0
warning -- No config file could be found. Ignoring config.
info -- Found 2 coverage files to report
info -- > .../artifacts/coverage/coverage.txt
info -- > .../artifacts/coverage/clover.xml
error -- Upload queued for processing failed: {"message":"Token required because branch is protected"}
```

There is no `CODECOV_TOKEN` secret in the repository, so the uploader authenticated with nothing and the report was rejected. The badge in the README has been pointing at a project that receives no data.

This applies the setup used in `wp-autofirma`.

## What changes

- **OIDC instead of a token.** `use_oidc: true` plus `id-token: write`, so uploads are authenticated without a secret anyone has to create and rotate.
- **`codecov.yml`, which did not exist.** Project and patch statuses are `informational`: they comment on the PR but never fail it. The blocking gate stays where it already is — `make test-coverage` fails below `MIN_COVERAGE` (74%).
- **A path fix, needed for the report to map at all.** PHPUnit runs inside the wp-env container, so Clover records `/var/www/html/wp-content/plugins/exelearning/includes/...`. Confirmed by inspecting the HTML report uploaded by the last CI run. The prefix is stripped in `codecov.yml`.
- **JavaScript coverage.** Vitest runs with the v8 provider (`@vitest/coverage-v8`) and writes LCOV to `artifacts/coverage-js/`, uploaded under the `javascript` flag; PHP goes up under `php`.
- **`disable_search: true`.** The uploader was also collecting `artifacts/coverage/coverage.txt`, the human-readable summary, which is not a parseable report.

## Notes

- **The overall number will drop when this lands.** JS coverage is 5.4% today: everything under `assets/js/` is measured, not only the two files with unit tests, because most of these scripts drive the browser and are exercised by the E2E suite instead. Hiding them would report a prettier number rather than a true one. The flags keep the suites separate, and the statuses are informational, so nothing blocks. Narrowing `coverage.include` in `vitest.config.mts` is a one-line change if you prefer the other trade-off.
- `npm run test:js` now runs with `--coverage`, so local runs print the same table CI does.
- `codecov.yml` was already listed in `.distignore`; it is now also `export-ignore`d in `.gitattributes`, so it ships in neither packaging path.

## Verification

- `npm run test:js` — 12 tests pass, LCOV written to `artifacts/coverage-js/lcov.info`.
- `codecov.yml` accepted by `https://codecov.io/validate`.
- `.github/workflows/ci.yml` and `codecov.yml` parse as YAML.
- `git archive HEAD` contains no `codecov.yml`.

The upload path itself can only be verified by the CI run on this PR.