### PR TITLE
Cover the editor modal, the viewer filter and three frontend scripts

### DIFF
--- a/tests/js/elp_upload_fullscreen.test.js
+++ b/tests/js/elp_upload_fullscreen.test.js
@@ -1,0 +1,238 @@
+// Unit tests for assets/js/elp-upload-fullscreen.js.
+//
+// The script drives the fullscreen button of the eXeLearning block inside the Gutenberg
+// editor. Gutenberg rebuilds block markup constantly, so the button routinely outlives
+// the preview iframe it points at: the script keeps the two in step through a
+// MutationObserver. A button left enabled with no iframe behind it does nothing when
+// clicked, which reads as a broken editor, so most of what follows is about that pairing.
+//
+// The script is an IIFE with no exports that binds a delegated click listener and one
+// observer on the document. It is imported once for the whole file, exactly as the
+// browser loads it: importing per test would stack a second listener and a second
+// observer on the same document, and every click would be handled twice.
+
+const path = require( 'path' );
+const { pathToFileURL } = require( 'url' );
+
+const SCRIPT = pathToFileURL(
+	path.resolve( __dirname, '../../assets/js/elp-upload-fullscreen.js' )
+).href;
+
+/** Let the MutationObserver callbacks for the current batch run. */
+async function flushMutations() {
+	await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+}
+
+/**
+ * Build the block markup Gutenberg renders for the eXeLearning block.
+ *
+ * @param {Object}  options            Markup options.
+ * @param {boolean} options.withIframe Whether the preview iframe is present.
+ * @param {string}  [options.label]    Button contents.
+ * @return {string} Block HTML.
+ */
+function blockMarkup( { withIframe, label = 'Fullscreen' } ) {
+	return (
+		'<div data-type="exelearning/elp-upload">' +
+			'<div class="exelearning-block-preview">' +
+				( withIframe ? '<iframe src="about:blank"></iframe>' : '' ) +
+			'</div>' +
+			'<button type="button" class="exelearning-fullscreen-btn">' + label + '</button>' +
+		'</div>'
+	);
+}
+
+/**
+ * Record the fullscreen requests made on the preview iframe.
+ *
+ * @param {string|null} api Fullscreen method the browser is said to support, if any.
+ * @return {string[]} Array that collects the names of the methods called.
+ */
+function stubFullscreenApi( api ) {
+	const calls = [];
+	const iframe = document.querySelector( 'iframe' );
+
+	delete iframe.requestFullscreen;
+	delete iframe.webkitRequestFullscreen;
+	delete iframe.msRequestFullscreen;
+
+	if ( api ) {
+		iframe[ api ] = () => calls.push( api );
+	}
+
+	return calls;
+}
+
+/**
+ * Click an element and report whether the default action was prevented.
+ *
+ * @param {Element} element Element to click.
+ * @return {boolean} Whether the click was blocked.
+ */
+function clickAndReportBlocked( element ) {
+	const event = new window.MouseEvent( 'click', { bubbles: true, cancelable: true } );
+	element.dispatchEvent( event );
+	return event.defaultPrevented;
+}
+
+// State of the two buttons present when the script bound, which is the one thing the
+// initial sweep can be observed through -- every later change goes through the observer.
+const atLoad = {};
+
+beforeAll( async () => {
+	document.body.innerHTML =
+		'<div id="with">' + blockMarkup( { withIframe: true } ) + '</div>' +
+		'<div id="without">' + blockMarkup( { withIframe: false } ) + '</div>';
+
+	await import( /* @vite-ignore */ SCRIPT );
+
+	const button = ( id ) => document.querySelector( `#${ id } .exelearning-fullscreen-btn` );
+	atLoad.withPreview = {
+		disabled: button( 'with' ).disabled,
+		aria: button( 'with' ).getAttribute( 'aria-disabled' ),
+	};
+	atLoad.withoutPreview = {
+		disabled: button( 'without' ).disabled,
+		aria: button( 'without' ).getAttribute( 'aria-disabled' ),
+	};
+
+	document.body.innerHTML = '';
+} );
+
+afterEach( () => {
+	document.body.innerHTML = '';
+} );
+
+describe( 'elp-upload-fullscreen: the sweep at load time', () => {
+	it( 'enables a button whose block already has a preview', () => {
+		expect( atLoad.withPreview ).toEqual( { disabled: false, aria: 'false' } );
+	} );
+
+	it( 'disables a button whose block has none', () => {
+		expect( atLoad.withoutPreview ).toEqual( { disabled: true, aria: 'true' } );
+	} );
+} );
+
+describe( 'elp-upload-fullscreen: the button follows its preview', () => {
+	it( 'enables the button once the preview turns up later', async () => {
+		document.body.innerHTML = blockMarkup( { withIframe: false } );
+		await flushMutations();
+
+		document
+			.querySelector( '.exelearning-block-preview' )
+			.appendChild( document.createElement( 'iframe' ) );
+		await flushMutations();
+
+		expect( document.querySelector( '.exelearning-fullscreen-btn' ).disabled ).toBe( false );
+	} );
+
+	it( 'disables the button again when the preview goes away', async () => {
+		document.body.innerHTML = blockMarkup( { withIframe: true } );
+		await flushMutations();
+
+		document.querySelector( 'iframe' ).remove();
+		await flushMutations();
+
+		expect( document.querySelector( '.exelearning-fullscreen-btn' ).disabled ).toBe( true );
+	} );
+
+	it( 'syncs a whole block inserted after binding', async () => {
+		const holder = document.createElement( 'div' );
+		holder.innerHTML = blockMarkup( { withIframe: true } );
+		document.body.appendChild( holder );
+		await flushMutations();
+
+		expect( document.querySelector( '.exelearning-fullscreen-btn' ).disabled ).toBe( false );
+	} );
+
+	it( 'leaves buttons outside an eXeLearning block alone', async () => {
+		document.body.innerHTML =
+			'<div data-type="core/paragraph">' +
+			'<button class="exelearning-fullscreen-btn">Fullscreen</button></div>';
+		await flushMutations();
+
+		const button = document.querySelector( '.exelearning-fullscreen-btn' );
+		expect( button.disabled ).toBe( false );
+		expect( button.hasAttribute( 'aria-disabled' ) ).toBe( false );
+	} );
+} );
+
+describe( 'elp-upload-fullscreen: clicking the button', () => {
+	it( 'opens the preview fullscreen with the standard API', async () => {
+		document.body.innerHTML = blockMarkup( { withIframe: true } );
+		await flushMutations();
+		const calls = stubFullscreenApi( 'requestFullscreen' );
+
+		const blocked = clickAndReportBlocked(
+			document.querySelector( '.exelearning-fullscreen-btn' )
+		);
+
+		expect( calls ).toEqual( [ 'requestFullscreen' ] );
+		expect( blocked ).toBe( true );
+	} );
+
+	it( 'falls back to the WebKit API', async () => {
+		document.body.innerHTML = blockMarkup( { withIframe: true } );
+		await flushMutations();
+		const calls = stubFullscreenApi( 'webkitRequestFullscreen' );
+
+		clickAndReportBlocked( document.querySelector( '.exelearning-fullscreen-btn' ) );
+
+		expect( calls ).toEqual( [ 'webkitRequestFullscreen' ] );
+	} );
+
+	it( 'falls back to the Microsoft API', async () => {
+		document.body.innerHTML = blockMarkup( { withIframe: true } );
+		await flushMutations();
+		const calls = stubFullscreenApi( 'msRequestFullscreen' );
+
+		clickAndReportBlocked( document.querySelector( '.exelearning-fullscreen-btn' ) );
+
+		expect( calls ).toEqual( [ 'msRequestFullscreen' ] );
+	} );
+
+	it( 'still swallows the click when no fullscreen API exists', async () => {
+		document.body.innerHTML = blockMarkup( { withIframe: true } );
+		await flushMutations();
+		stubFullscreenApi( null );
+
+		expect(
+			clickAndReportBlocked( document.querySelector( '.exelearning-fullscreen-btn' ) )
+		).toBe( true );
+	} );
+
+	it( 'disables the button when the preview vanished before the click', async () => {
+		// The observer may not have caught up with Gutenberg yet, so the click handler
+		// re-checks instead of trusting the button state it finds.
+		document.body.innerHTML = blockMarkup( { withIframe: true } );
+		await flushMutations();
+		document.querySelector( 'iframe' ).remove();
+
+		const button = document.querySelector( '.exelearning-fullscreen-btn' );
+		expect( clickAndReportBlocked( button ) ).toBe( true );
+		expect( button.disabled ).toBe( true );
+	} );
+
+	it( 'reacts to a click on a child of the button', async () => {
+		document.body.innerHTML = blockMarkup( {
+			withIframe: true,
+			label: '<span class="label">Fullscreen</span>',
+		} );
+		await flushMutations();
+		const calls = stubFullscreenApi( 'requestFullscreen' );
+
+		clickAndReportBlocked( document.querySelector( '.label' ) );
+
+		expect( calls ).toEqual( [ 'requestFullscreen' ] );
+	} );
+
+	it( 'ignores clicks elsewhere in the editor', async () => {
+		document.body.innerHTML =
+			blockMarkup( { withIframe: true } ) + '<button id="publish">Publish</button>';
+		await flushMutations();
+		const calls = stubFullscreenApi( 'requestFullscreen' );
+
+		expect( clickAndReportBlocked( document.getElementById( 'publish' ) ) ).toBe( false );
+		expect( calls ).toEqual( [] );
+	} );
+} );

--- a/tests/js/exelearning_editor.test.js
+++ b/tests/js/exelearning_editor.test.js
@@ -58,6 +58,20 @@ async function loadEditorOn( markup ) {
 		nonce: 'rest-nonce',
 		i18n: {},
 	};
+	// close() and onSaveComplete() both reach refreshMediaLibrary(), which reads a bare
+	// `wp`. Without the global that is a ReferenceError rather than a readable failure.
+	global.wp = {};
+	// Nothing here belongs on the network. Opening the modal points the iframe at the
+	// editor page, and happy-dom fetches that for real; tests that care about a specific
+	// response replace this stub.
+	window.fetch = () =>
+		Promise.resolve( {
+			ok: false,
+			status: 404,
+			json: () => Promise.resolve( {} ),
+			text: () => Promise.resolve( '' ),
+			headers: { get: () => null },
+		} );
 
 	await import( /* @vite-ignore */ `${ EDITOR_SCRIPT }?load=${ ++loadCount }` );
 
@@ -91,8 +105,52 @@ function cleanupEditor() {
 		window.removeEventListener( 'message', listener, options );
 	}
 	document.body.innerHTML = '';
+	// open() marks the body while the modal is up; the class outlives innerHTML.
+	document.body.className = '';
 	delete window.ExeLearningEditor;
 	delete global.exelearningEditorVars;
+	delete global.wp;
+	delete window.fetch;
+}
+
+/**
+ * Give the modal iframe a controllable content window.
+ *
+ * The controller identifies the editor by object identity — `event.source !== iframeWindow`
+ * — and talks to it with postMessage, so a stub window is what makes both observable. The
+ * real iframe element stays in the document; only its window is ours.
+ *
+ * @param {Object} editor The controller under test.
+ * @return {Object[]} Array collecting {message, origin} for everything posted to the editor.
+ */
+function stubEditorWindow( editor ) {
+	const posted = [];
+	const editorWindow = {
+		postMessage: ( message, origin ) => posted.push( { message, origin } ),
+	};
+	Object.defineProperty( editor.iframe[ 0 ], 'contentWindow', {
+		get: () => editorWindow,
+		configurable: true,
+	} );
+	editor.editorWindow = editorWindow;
+	return posted;
+}
+
+/**
+ * Deliver a message as if the editor iframe had posted it.
+ *
+ * @param {Object} editor    The controller under test.
+ * @param {Object} data      Message payload.
+ * @param {string} [origin]  Origin the message claims to come from.
+ * @return {Promise} Resolves once the controller has finished handling it.
+ */
+function messageFromEditor( editor, data, origin = window.location.origin ) {
+	return editor.handleMessage( { data, source: editor.editorWindow, origin } );
+}
+
+/** Read the messages of a given type out of a postMessage log. */
+function messagesOfType( posted, type ) {
+	return posted.filter( ( entry ) => entry.message.type === type ).map( ( entry ) => entry.message );
 }
 
 afterEach( cleanupEditor );
@@ -132,5 +190,624 @@ describe( 'exelearning-editor: the meta box "Edit in eXeLearning" button', () =>
 		window.dispatchEvent( new window.MessageEvent( 'message', { data: { type: 'DOCUMENT_CHANGED' } } ) );
 
 		expect( handled ).toEqual( [] );
+	} );
+} );
+
+describe( 'exelearning-editor: the pieces the rest is built on', () => {
+	it( 'issues request ids that never repeat within a session', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+
+		const first = editor.nextRequestId( 'export' );
+		const second = editor.nextRequestId( 'export' );
+
+		expect( first ).toMatch( /^export-\d+-1$/ );
+		expect( second ).toMatch( /^export-\d+-2$/ );
+		expect( second ).not.toBe( first );
+	} );
+
+	it( 'saves as elpx, whatever else the editor can export', async () => {
+		// The modal writes back to the attachment, and the attachment is the .elpx. The
+		// other formats are downloads, and they go through wp-exe-download.js instead.
+		const editor = await loadEditorOn( MODAL_MARKUP );
+
+		expect( editor.getFormat() ).toBe( 'elpx' );
+	} );
+
+	it( 'names a file after the format when the editor sends none', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+
+		expect( editor.defaultFilenameForFormat( 'elpx' ) ).toBe( 'project.elpx' );
+		expect( editor.defaultFilenameForFormat( 'epub3' ) ).toBe( 'project.epub' );
+		expect( editor.defaultFilenameForFormat( 'epub' ) ).toBe( 'project.epub' );
+		expect( editor.defaultFilenameForFormat( 'scorm12' ) ).toBe( 'project.zip' );
+	} );
+
+	it( 'reads the media type off the filename', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+
+		expect( editor.mimeForFilename( 'book.epub' ) ).toBe( 'application/epub+zip' );
+		expect( editor.mimeForFilename( 'course.zip' ) ).toBe( 'application/zip' );
+		expect( editor.mimeForFilename( 'project.elpx' ) ).toBe( 'application/zip' );
+	} );
+
+	it( 'pins postMessage to the origin the iframe actually loaded', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+
+		editor.iframe.attr( 'src', 'https://editor.test/wp-admin/admin.php?page=exelearning-editor' );
+		expect( editor.getEditorOrigin() ).toBe( 'https://editor.test' );
+
+		editor.iframe.attr( 'src', '/wp-admin/admin.php?page=exelearning-editor' );
+		expect( editor.getEditorOrigin() ).toBe( window.location.origin );
+	} );
+} );
+
+describe( 'exelearning-editor: the format selector', () => {
+	it( 'offers the three export formats with elpx preselected', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+
+		editor.insertFormatSelector();
+
+		const select = document.getElementById( 'exelearning-editor-format' );
+		expect( select ).not.toBeNull();
+		expect( Array.from( select.options ).map( ( option ) => option.value ) ).toEqual( [
+			'elpx',
+			'scorm12',
+			'epub3',
+		] );
+		expect( select.value ).toBe( 'elpx' );
+		expect( select.nextElementSibling.id ).toBe( 'exelearning-editor-close' );
+	} );
+
+	it( 'does not add a second selector when called again', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+
+		editor.insertFormatSelector();
+		editor.insertFormatSelector();
+
+		expect( document.querySelectorAll( '#exelearning-editor-format' ) ).toHaveLength( 1 );
+	} );
+} );
+
+describe( 'exelearning-editor: the saving overlay', () => {
+	it( 'appears on save and goes away when saving ends', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+
+		editor.setSavingState( true );
+
+		const modal = document.getElementById( 'exelearning-loading-modal' );
+		expect( modal.classList.contains( 'is-visible' ) ).toBe( true );
+		expect( document.getElementById( 'exelearning-editor-save' ).disabled ).toBe( true );
+
+		editor.setSavingState( false );
+
+		expect( modal.classList.contains( 'is-visible' ) ).toBe( false );
+		expect( document.getElementById( 'exelearning-editor-save' ).disabled ).toBe( false );
+	} );
+
+	it( 'shows the reason when a save fails, and can be dismissed', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+
+		editor.showLoadingError( 'Save failed (503)' );
+
+		const modal = document.getElementById( 'exelearning-loading-modal' );
+		expect( modal.classList.contains( 'is-error' ) ).toBe( true );
+		expect( modal.querySelector( '.exelearning-loading-modal__error-text' ).textContent ).toBe(
+			'Save failed (503)'
+		);
+
+		modal.querySelector( '.exelearning-loading-modal__close' ).click();
+
+		expect( modal.classList.contains( 'is-error' ) ).toBe( false );
+		expect( modal.classList.contains( 'is-visible' ) ).toBe( false );
+	} );
+
+	it( 'clears a previous error when the next save starts', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+
+		editor.showLoadingError( 'Save failed (503)' );
+		editor.showLoadingModal();
+
+		const modal = document.getElementById( 'exelearning-loading-modal' );
+		expect( modal.classList.contains( 'is-error' ) ).toBe( false );
+		expect( modal.classList.contains( 'is-visible' ) ).toBe( true );
+	} );
+
+	it( 'reuses the same overlay across saves', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+
+		editor.showLoadingModal();
+		editor.hideLoadingModal();
+		editor.showLoadingModal();
+
+		expect( document.querySelectorAll( '.exelearning-loading-modal' ) ).toHaveLength( 1 );
+	} );
+} );
+
+describe( 'exelearning-editor: opening a file', () => {
+	it( 'refuses to open without an attachment', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+
+		editor.open( 0 );
+
+		expect( editor.isOpen ).toBe( false );
+		expect( document.body.classList.contains( 'exelearning-editor-open' ) ).toBe( false );
+	} );
+
+	it( 'points the iframe at the file the editor should import', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		const requests = [];
+		window.fetch = ( url, options ) => {
+			requests.push( { url, options } );
+			return Promise.resolve( {
+				ok: true,
+				json: () => Promise.resolve( { url: 'https://files.test/my project.elpx' } ),
+			} );
+		};
+
+		editor.open( 42 );
+
+		expect( editor.isOpen ).toBe( true );
+		expect( document.body.classList.contains( 'exelearning-editor-open' ) ).toBe( true );
+		expect( document.getElementById( 'exelearning-editor-save' ).disabled ).toBe( true );
+
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+		expect( requests[ 0 ].url ).toBe( '/wp-json/exelearning/v1/elp-data/42' );
+		expect( requests[ 0 ].options.headers[ 'X-WP-Nonce' ] ).toBe( 'rest-nonce' );
+
+		const src = editor.iframe.attr( 'src' );
+		expect( src ).toContain( 'attachment_id=42' );
+		expect( src ).toContain( '_wpnonce=editor-nonce' );
+		expect( src ).toContain( 'import=' + encodeURIComponent( 'https://files.test/my project.elpx' ) );
+	} );
+
+	it( 'still opens the editor when the file URL cannot be resolved', async () => {
+		// A failed lookup must not cost the user the editor: it opens empty rather than
+		// not at all.
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		window.fetch = () => Promise.reject( new Error( 'network down' ) );
+
+		editor.open( 42 );
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+		expect( editor.iframe.attr( 'src' ) ).toContain( 'attachment_id=42' );
+		expect( editor.iframe.attr( 'src' ) ).not.toContain( 'import=' );
+	} );
+
+	it( 'omits the import when the lookup answers without a URL', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		window.fetch = () => Promise.resolve( { ok: false, json: () => Promise.resolve( {} ) } );
+
+		editor.open( 42 );
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+		expect( editor.iframe.attr( 'src' ) ).not.toContain( 'import=' );
+	} );
+
+	it( 'falls back to a separate window on a screen with no modal', async () => {
+		const editor = await loadEditorOn( '<div></div>' );
+		const opened = [];
+		window.open = ( url, target, features ) => opened.push( { url, target, features } );
+
+		editor.open( 42 );
+
+		expect( opened ).toHaveLength( 1 );
+		expect( opened[ 0 ].url ).toContain( 'attachment_id=42' );
+		expect( opened[ 0 ].target ).toBe( '_blank' );
+		expect( editor.isOpen ).toBe( false );
+	} );
+} );
+
+describe( 'exelearning-editor: closing without losing work', () => {
+	it( 'does nothing when the editor is not open', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+
+		editor.close();
+
+		expect( document.body.classList.contains( 'exelearning-editor-open' ) ).toBe( false );
+	} );
+
+	it( 'asks before discarding unsaved changes, and stays open on refusal', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		editor.isOpen = true;
+		editor.hasUnsavedChanges = true;
+		window.confirm = () => false;
+
+		editor.close();
+
+		expect( editor.isOpen ).toBe( true );
+	} );
+
+	it( 'closes when the reader confirms, and lets the iframe go', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		editor.isOpen = true;
+		editor.hasUnsavedChanges = true;
+		window.confirm = () => true;
+
+		editor.close();
+
+		expect( editor.isOpen ).toBe( false );
+		expect( editor.hasUnsavedChanges ).toBe( false );
+		expect( editor.currentAttachmentId ).toBeNull();
+		expect( document.body.classList.contains( 'exelearning-editor-open' ) ).toBe( false );
+		expect( editor.iframe.attr( 'src' ) ).toBe( 'about:blank' );
+		expect( document.getElementById( 'exelearning-editor-save' ).disabled ).toBe( false );
+	} );
+
+	it( 'skips the question when the caller already knows', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		editor.isOpen = true;
+		editor.hasUnsavedChanges = true;
+		let asked = false;
+		window.confirm = () => {
+			asked = true;
+			return false;
+		};
+
+		editor.close( true );
+
+		expect( asked ).toBe( false );
+		expect( editor.isOpen ).toBe( false );
+	} );
+
+	it( 'treats a dirty document inside the editor as unsaved work', async () => {
+		// The flag only tracks what the editor announced. A document the editor knows is
+		// dirty but has not reported yet still counts.
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		stubEditorWindow( editor );
+		editor.editorWindow.eXeLearning = {
+			app: { project: { _yjsBridge: { documentManager: { isDirty: true } } } },
+		};
+
+		expect( editor.checkUnsavedChanges() ).toBe( true );
+	} );
+
+	it( 'reports no unsaved work when neither side has any', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		stubEditorWindow( editor );
+
+		expect( editor.checkUnsavedChanges() ).toBe( false );
+	} );
+
+	it( 'closes on Escape while open', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		editor.isOpen = true;
+
+		$( document ).trigger( $.Event( 'keydown', { key: 'Escape' } ) );
+
+		expect( editor.isOpen ).toBe( false );
+	} );
+} );
+
+describe( 'exelearning-editor: the conversation with the editor', () => {
+	it( 'hides the editor chrome WordPress provides itself', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		const posted = stubEditorWindow( editor );
+
+		await messageFromEditor( editor, { type: 'EXELEARNING_READY' } );
+
+		const configure = messagesOfType( posted, 'CONFIGURE' );
+		expect( configure ).toHaveLength( 1 );
+		expect( configure[ 0 ].data.hideUI ).toEqual( {
+			fileMenu: true,
+			saveButton: true,
+			userMenu: true,
+		} );
+	} );
+
+	it( 'enables saving once a document is loaded', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		stubEditorWindow( editor );
+		editor.saveBtn.prop( 'disabled', true );
+		editor.hasUnsavedChanges = true;
+
+		await messageFromEditor( editor, { type: 'DOCUMENT_LOADED' } );
+
+		expect( document.getElementById( 'exelearning-editor-save' ).disabled ).toBe( false );
+		expect( editor.hasUnsavedChanges ).toBe( false );
+	} );
+
+	it( 'keeps the save button disabled while a save is in flight', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		stubEditorWindow( editor );
+		editor.isSaving = true;
+		editor.saveBtn.prop( 'disabled', true );
+
+		await messageFromEditor( editor, { type: 'DOCUMENT_LOADED' } );
+
+		expect( document.getElementById( 'exelearning-editor-save' ).disabled ).toBe( true );
+	} );
+
+	it( 'remembers that the document changed', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		stubEditorWindow( editor );
+
+		await messageFromEditor( editor, { type: 'DOCUMENT_CHANGED' } );
+
+		expect( editor.hasUnsavedChanges ).toBe( true );
+	} );
+
+	it( 'gives the save button back when the editor reports a failure', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		stubEditorWindow( editor );
+		editor.setSavingState( true );
+		editor.exportRequestId = 'export-1';
+
+		await messageFromEditor( editor, {
+			type: 'WP_REQUEST_SAVE_ERROR',
+			requestId: 'export-1',
+			error: 'exporter blew up',
+		} );
+
+		expect( editor.isSaving ).toBe( false );
+		expect( document.getElementById( 'exelearning-editor-save' ).disabled ).toBe( false );
+	} );
+
+	it( 'ignores a failure that belongs to an earlier save', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		stubEditorWindow( editor );
+		editor.setSavingState( true );
+		editor.exportRequestId = 'export-2';
+
+		await messageFromEditor( editor, { type: 'WP_REQUEST_SAVE_ERROR', requestId: 'export-1' } );
+
+		expect( editor.isSaving ).toBe( true );
+	} );
+
+	it( 'ignores messages from anywhere but the editor iframe', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		stubEditorWindow( editor );
+
+		await editor.handleMessage( {
+			data: { type: 'DOCUMENT_CHANGED' },
+			source: { postMessage: () => {} },
+			origin: window.location.origin,
+		} );
+
+		expect( editor.hasUnsavedChanges ).toBe( false );
+	} );
+
+	it( 'ignores messages from an origin other than the one it loaded', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		stubEditorWindow( editor );
+		editor.editorOrigin = 'https://editor.test';
+
+		await messageFromEditor( editor, { type: 'DOCUMENT_CHANGED' }, 'https://evil.test' );
+
+		expect( editor.hasUnsavedChanges ).toBe( false );
+	} );
+
+	it( 'accepts a save request relayed by the page itself', async () => {
+		// The standalone editor page has no iframe of ours to post from, so its bridge
+		// relays through the parent window with a marker instead.
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		const posted = stubEditorWindow( editor );
+
+		await editor.handleMessage( {
+			data: { source: 'wp-exe-editor', type: 'request-save' },
+			source: window,
+			origin: window.location.origin,
+		} );
+
+		expect( messagesOfType( posted, 'WP_REQUEST_SAVE' ) ).toHaveLength( 1 );
+	} );
+
+	it( 'asks the editor for the file when the save button is pressed', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		const posted = stubEditorWindow( editor );
+
+		document.getElementById( 'exelearning-editor-save' ).click();
+
+		const requests = messagesOfType( posted, 'WP_REQUEST_SAVE' );
+		expect( requests ).toHaveLength( 1 );
+		expect( requests[ 0 ].requestId ).toBe( editor.exportRequestId );
+		expect( editor.isSaving ).toBe( true );
+	} );
+
+	it( 'does not ask twice while a save is already running', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		const posted = stubEditorWindow( editor );
+
+		editor.requestSave();
+		editor.requestSave();
+
+		expect( messagesOfType( posted, 'WP_REQUEST_SAVE' ) ).toHaveLength( 1 );
+	} );
+} );
+
+describe( 'exelearning-editor: writing the file back to WordPress', () => {
+	/**
+	 * Answer the save request with a canned REST response.
+	 *
+	 * @param {Object} response What fetch should resolve to.
+	 * @return {Object[]} Array collecting the fetch calls.
+	 */
+	function stubRestApi( response ) {
+		const calls = [];
+		window.fetch = ( url, options ) => {
+			calls.push( { url, options } );
+			return Promise.resolve( response );
+		};
+		return calls;
+	}
+
+	it( 'updates the attachment the modal was opened on', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		const posted = stubEditorWindow( editor );
+		editor.isOpen = true;
+		editor.currentAttachmentId = 42;
+		const calls = stubRestApi( {
+			ok: true,
+			json: () => Promise.resolve( { success: true, attachment_id: 42 } ),
+		} );
+
+		await editor.handleExportFile( {
+			bytes: new Uint8Array( [ 1, 2, 3 ] ),
+			filename: 'my-course.elpx',
+			mimeType: 'application/zip',
+		} );
+
+		expect( calls ).toHaveLength( 1 );
+		expect( calls[ 0 ].url ).toBe( '/wp-json/exelearning/v1/save/42' );
+		expect( calls[ 0 ].options.method ).toBe( 'POST' );
+		expect( calls[ 0 ].options.headers[ 'X-WP-Nonce' ] ).toBe( 'rest-nonce' );
+
+		// The filename is asserted server-side: happy-dom's FormData drops the third
+		// argument of append(), so the name is not observable from here.
+		const body = calls[ 0 ].options.body;
+		expect( body.get( 'format' ) ).toBe( 'elpx' );
+		expect( body.get( 'file' ).size ).toBe( 3 );
+		expect( body.get( 'file' ).type ).toBe( 'application/zip' );
+
+		expect( messagesOfType( posted, 'WP_SAVE_CONFIRMED' ) ).toHaveLength( 1 );
+		expect( editor.isOpen ).toBe( false );
+		expect( editor.hasUnsavedChanges ).toBe( false );
+	} );
+
+	it( 'creates a new attachment when the modal was opened on nothing', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		stubEditorWindow( editor );
+		editor.currentAttachmentId = null;
+		const calls = stubRestApi( {
+			ok: true,
+			json: () => Promise.resolve( { success: true, attachmentId: 7 } ),
+		} );
+
+		await editor.handleExportFile( { bytes: new Uint8Array( [ 1 ] ) } );
+
+		expect( calls[ 0 ].url ).toBe( '/wp-json/exelearning/v1/create' );
+		expect( calls[ 0 ].options.body.get( 'file' ).size ).toBe( 1 );
+	} );
+
+	it( 'keeps the editor open and says why when WordPress rejects the save', async () => {
+		// Closing here would throw away the only copy of the work: the file lives in the
+		// editor and nowhere else until this request succeeds.
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		stubEditorWindow( editor );
+		editor.isOpen = true;
+		editor.currentAttachmentId = 42;
+		editor.setSavingState( true );
+		stubRestApi( {
+			ok: false,
+			status: 413,
+			json: () => Promise.resolve( { message: 'File too large' } ),
+		} );
+
+		await editor.handleExportFile( { bytes: new Uint8Array( [ 1 ] ) } );
+
+		expect( editor.isOpen ).toBe( true );
+		expect( editor.isSaving ).toBe( false );
+		expect(
+			document.querySelector( '.exelearning-loading-modal__error-text' ).textContent
+		).toBe( 'File too large' );
+		expect( document.getElementById( 'exelearning-editor-save' ).disabled ).toBe( false );
+	} );
+
+	it( 'treats a 200 that did not save as a failure', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		stubEditorWindow( editor );
+		editor.isOpen = true;
+		editor.currentAttachmentId = 42;
+		stubRestApi( { ok: true, json: () => Promise.resolve( { success: false } ) } );
+
+		await editor.handleExportFile( { bytes: new Uint8Array( [ 1 ] ) } );
+
+		expect( editor.isOpen ).toBe( true );
+		expect(
+			document.querySelector( '.exelearning-loading-modal' ).classList.contains( 'is-error' )
+		).toBe( true );
+	} );
+} );
+
+describe( 'exelearning-editor: what the rest of the screen sees after a save', () => {
+	/**
+	 * Stand in for the block editor data store with a fixed set of blocks.
+	 *
+	 * @param {Object[]} blocks Blocks the store should report.
+	 * @return {Object} Record of the updates and post saves the controller asked for.
+	 */
+	function stubBlockEditor( blocks ) {
+		const record = { updates: [], postSaved: 0 };
+		global.wp.data = {
+			select: ( store ) =>
+				store === 'core/block-editor' ? { getBlocks: () => blocks } : {},
+			dispatch: ( store ) =>
+				store === 'core/block-editor'
+					? {
+						updateBlockAttributes: ( clientId, attributes ) =>
+							record.updates.push( { clientId, attributes } ),
+					}
+					: { savePost: () => ( record.postSaved += 1 ) },
+		};
+		return record;
+	}
+
+	it( 'repoints the block that holds the file just saved', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		const record = stubBlockEditor( [
+			{ name: 'exelearning/elp-upload', clientId: 'a', attributes: { attachmentId: 42 } },
+			{ name: 'exelearning/elp-upload', clientId: 'b', attributes: { attachmentId: 99 } },
+			{ name: 'core/paragraph', clientId: 'c', attributes: {} },
+		] );
+
+		editor.updateBlockPreview( 42, 'https://files.test/preview.html' );
+
+		expect( record.updates ).toEqual( [
+			{ clientId: 'a', attributes: { previewUrl: 'https://files.test/preview.html' } },
+		] );
+		expect( record.postSaved ).toBe( 1 );
+	} );
+
+	it( 'leaves the post alone when no block was pointing at the file', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		const record = stubBlockEditor( [
+			{ name: 'exelearning/elp-upload', clientId: 'b', attributes: { attachmentId: 99 } },
+		] );
+
+		editor.updateBlockPreview( 42, 'https://files.test/preview.html' );
+
+		expect( record.updates ).toEqual( [] );
+		expect( record.postSaved ).toBe( 0 );
+	} );
+
+	it( 'does nothing outside the block editor', async () => {
+		// The modal also opens from the media library, where there is no block store.
+		const editor = await loadEditorOn( MODAL_MARKUP );
+
+		expect( () => editor.updateBlockPreview( 42, 'https://files.test/preview.html' ) ).not.toThrow();
+	} );
+
+	it( 'refreshes the attachment the media library is showing', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+		document.body.insertAdjacentHTML(
+			'beforeend',
+			'<div class="attachment-details"><div class="thumbnail exelearning-details-preview-added"></div></div>' +
+			'<span class="exelearning-metadata">old</span>'
+		);
+		const attachment = {
+			data: {},
+			triggered: [],
+			get: ( key ) => attachment.data[ key ],
+			set: ( key, value ) => ( attachment.data[ key ] = value ),
+			fetch: () => ( { done: ( callback ) => ( callback(), { fail: () => {} } ) } ),
+			trigger: ( event ) => attachment.triggered.push( event ),
+		};
+		global.wp.media = { attachment: () => attachment };
+
+		editor.refreshAttachment( 42, 'https://files.test/preview.html' );
+
+		expect( attachment.data.exelearning.preview_url ).toBe( 'https://files.test/preview.html' );
+		expect( attachment.triggered ).toEqual( [ 'change' ] );
+		expect(
+			document.querySelector( '.thumbnail' ).classList.contains( 'exelearning-details-preview-added' )
+		).toBe( false );
+		expect( document.querySelector( '.exelearning-metadata' ) ).toBeNull();
+	} );
+
+	it( 'survives a media library that is not there', async () => {
+		const editor = await loadEditorOn( MODAL_MARKUP );
+
+		expect( () => editor.refreshAttachment( 42, 'https://files.test/preview.html' ) ).not.toThrow();
+		expect( () => editor.refreshMediaLibrary() ).not.toThrow();
 	} );
 } );

--- a/tests/js/exelearning_settings.test.js
+++ b/tests/js/exelearning_settings.test.js
@@ -1,0 +1,111 @@
+// Unit tests for assets/js/exelearning-settings.js.
+//
+// The script guards the per-style Delete links on the settings screen. Those links are
+// nonced admin-post URLs, so letting a click through deletes a style with no way back:
+// the guard is the only thing between a stray click and a lost upload. What matters is
+// which clicks it blocks and, just as much, which it leaves alone.
+//
+// The script is an IIFE with no exports that binds one delegated listener on the
+// document. It is imported once for the whole file, exactly as the browser loads it:
+// importing per test would stack a second listener on the same document and every
+// click would be handled twice.
+
+const path = require( 'path' );
+const { pathToFileURL } = require( 'url' );
+
+const SETTINGS = pathToFileURL(
+	path.resolve( __dirname, '../../assets/js/exelearning-settings.js' )
+).href;
+
+beforeAll( async () => {
+	await import( /* @vite-ignore */ SETTINGS );
+} );
+
+/**
+ * Click an element and report whether the default action was prevented.
+ *
+ * @param {Element} element Element to click.
+ * @return {boolean} Whether the click was blocked.
+ */
+function clickAndReportBlocked( element ) {
+	const event = new window.MouseEvent( 'click', { bubbles: true, cancelable: true } );
+	element.dispatchEvent( event );
+	return event.defaultPrevented;
+}
+
+afterEach( () => {
+	document.body.innerHTML = '';
+	delete window.confirm;
+} );
+
+describe( 'exelearning-settings: the delete confirmation guard', () => {
+	it( 'blocks the deletion when the confirmation is declined', () => {
+		document.body.innerHTML =
+			'<a class="exelearning-delete-style" href="/admin-post.php" data-confirm="Delete this style?">Delete</a>';
+		window.confirm = () => false;
+
+		expect( clickAndReportBlocked( document.querySelector( 'a' ) ) ).toBe( true );
+	} );
+
+	it( 'lets the deletion through when the confirmation is accepted', () => {
+		document.body.innerHTML =
+			'<a class="exelearning-delete-style" href="/admin-post.php" data-confirm="Delete this style?">Delete</a>';
+		window.confirm = () => true;
+
+		expect( clickAndReportBlocked( document.querySelector( 'a' ) ) ).toBe( false );
+	} );
+
+	it( 'passes the link message to the confirmation', () => {
+		document.body.innerHTML =
+			'<a class="exelearning-delete-style" href="/admin-post.php" data-confirm="Delete “Blue”?">Delete</a>';
+		const asked = [];
+		window.confirm = ( message ) => {
+			asked.push( message );
+			return true;
+		};
+
+		clickAndReportBlocked( document.querySelector( 'a' ) );
+
+		expect( asked ).toEqual( [ 'Delete “Blue”?' ] );
+	} );
+
+	it( 'asks nothing for a delete link that carries no message', () => {
+		// The markup builds the message server-side; a link without one is a link the
+		// screen did not mean to guard, and stopping it would break the delete instead.
+		document.body.innerHTML =
+			'<a class="exelearning-delete-style" href="/admin-post.php">Delete</a>';
+		let asked = false;
+		window.confirm = () => {
+			asked = true;
+			return false;
+		};
+
+		expect( clickAndReportBlocked( document.querySelector( 'a' ) ) ).toBe( false );
+		expect( asked ).toBe( false );
+	} );
+
+	it( 'guards a click that lands on a child of the link', () => {
+		// WordPress puts icons and screen-reader text inside admin links, so the click
+		// target is usually not the anchor itself.
+		document.body.innerHTML =
+			'<a class="exelearning-delete-style" href="/admin-post.php" data-confirm="Delete this style?">' +
+			'<span class="label">Delete</span></a>';
+		window.confirm = () => false;
+
+		expect( clickAndReportBlocked( document.querySelector( '.label' ) ) ).toBe( true );
+	} );
+
+	it( 'ignores clicks on anything else on the screen', () => {
+		document.body.innerHTML =
+			'<a class="exelearning-delete-style" href="/x" data-confirm="Delete?">Delete</a>' +
+			'<button id="save">Save changes</button>';
+		let asked = false;
+		window.confirm = () => {
+			asked = true;
+			return false;
+		};
+
+		expect( clickAndReportBlocked( document.getElementById( 'save' ) ) ).toBe( false );
+		expect( asked ).toBe( false );
+	} );
+} );

--- a/tests/js/wp_exe_download.test.js
+++ b/tests/js/wp_exe_download.test.js
@@ -1,0 +1,285 @@
+// Unit tests for assets/js/wp-exe-download.js.
+//
+// The script drives the split download button rendered by
+// ExeLearning_Download_Button_Renderer. Two paths matter and they are not alike:
+//
+//   - `.elpx` is the uploaded attachment itself, fetched as a blob so that the download
+//     goes through whatever serves the uploads (a Playground service worker, for one)
+//     instead of a top-level navigation that bypasses it. If fetch is missing or fails,
+//     a direct link is the fallback -- failing silently here means no file at all.
+//   - Every other format is exported client-side inside a hidden editor iframe. Only
+//     the refusals are unit-tested: the handshake itself needs an iframe that really
+//     loads the editor and answers by postMessage, which is what the Playwright suite
+//     gives it. Faking it here would test the fake.
+//
+// The script is an IIFE that reads window.wpExeDownloadConfig at load time and binds
+// listeners on the document, so it is configured first and imported once for the file.
+
+const path = require( 'path' );
+const { pathToFileURL } = require( 'url' );
+
+const SCRIPT = pathToFileURL(
+	path.resolve( __dirname, '../../assets/js/wp-exe-download.js' )
+).href;
+
+const EDITOR_URL = 'http://example.test/wp-content/plugins/exelearning/dist/static';
+
+/** Downloads triggered through an anchor, in order. */
+let downloads = [];
+/** Object URLs handed out by the stubbed URL factory. */
+let objectUrls = [];
+/** Anything the script reported to the console. */
+let consoleErrors = [];
+
+let originalCreateObjectURL;
+let originalRevokeObjectURL;
+let originalConsoleError;
+let originalAnchorClick;
+
+beforeAll( async () => {
+	window.wpExeDownloadConfig = {
+		editorUrl: EDITOR_URL,
+		exportBase: 'http://example.test/',
+		i18n: { failed: 'No se pudo descargar. Inténtalo de nuevo.' },
+	};
+
+	// An anchor click would be a navigation, which is neither available nor the point:
+	// what the test needs to know is the href and the filename it was given.
+	originalAnchorClick = window.HTMLAnchorElement.prototype.click;
+	window.HTMLAnchorElement.prototype.click = function () {
+		downloads.push( { href: this.href, download: this.download } );
+	};
+
+	originalCreateObjectURL = window.URL.createObjectURL;
+	originalRevokeObjectURL = window.URL.revokeObjectURL;
+	window.URL.createObjectURL = ( blob ) => {
+		const url = `blob:mock/${ objectUrls.length }`;
+		objectUrls.push( { url, blob, revoked: false } );
+		return url;
+	};
+	window.URL.revokeObjectURL = ( url ) => {
+		const entry = objectUrls.find( ( candidate ) => candidate.url === url );
+		if ( entry ) {
+			entry.revoked = true;
+		}
+	};
+
+	originalConsoleError = console.error;
+	console.error = ( ...args ) => consoleErrors.push( args.join( ' ' ) );
+
+	await import( /* @vite-ignore */ SCRIPT );
+} );
+
+afterAll( () => {
+	window.HTMLAnchorElement.prototype.click = originalAnchorClick;
+	window.URL.createObjectURL = originalCreateObjectURL;
+	window.URL.revokeObjectURL = originalRevokeObjectURL;
+	console.error = originalConsoleError;
+} );
+
+beforeEach( () => {
+	downloads = [];
+	objectUrls = [];
+	consoleErrors = [];
+} );
+
+afterEach( () => {
+	document.body.innerHTML = '';
+	delete window.fetch;
+} );
+
+/**
+ * Render the markup of the split download button, dropdown and all.
+ *
+ * @return {HTMLElement} The download container.
+ */
+function renderButton() {
+	document.body.innerHTML =
+		'<div class="exelearning-download" data-attachment-id="42"' +
+			' data-elp-url="http://example.test/uploads/project.elpx" data-slug="project">' +
+			'<button type="button" class="exelearning-download__primary"' +
+				' data-format="elpx" data-suffix=".elpx">Download</button>' +
+			'<button type="button" class="exelearning-download__toggle"' +
+				' aria-expanded="false">More</button>' +
+			'<div class="exelearning-download__menu" hidden>' +
+				'<button type="button" data-format="scorm12" data-suffix="_scorm.zip">SCORM</button>' +
+			'</div>' +
+		'</div>';
+
+	return document.querySelector( '.exelearning-download' );
+}
+
+/** Click an element the way the page would. */
+function click( element ) {
+	element.dispatchEvent( new window.MouseEvent( 'click', { bubbles: true, cancelable: true } ) );
+}
+
+/** Let the promise chain inside the script settle. */
+async function settle() {
+	for ( let i = 0; i < 6; i++ ) {
+		await Promise.resolve();
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+	}
+}
+
+describe( 'wp-exe-download: the format menu', () => {
+	it( 'opens on the toggle and reports the state to assistive tech', () => {
+		const container = renderButton();
+
+		click( container.querySelector( '.exelearning-download__toggle' ) );
+
+		const menu = container.querySelector( '.exelearning-download__menu' );
+		expect( menu.hidden ).toBe( false );
+		expect( menu.getAttribute( 'data-open' ) ).toBe( '1' );
+		expect(
+			container.querySelector( '.exelearning-download__toggle' ).getAttribute( 'aria-expanded' )
+		).toBe( 'true' );
+	} );
+
+	it( 'closes again on a second click of the toggle', () => {
+		const container = renderButton();
+		const toggle = container.querySelector( '.exelearning-download__toggle' );
+
+		click( toggle );
+		click( toggle );
+
+		const menu = container.querySelector( '.exelearning-download__menu' );
+		expect( menu.hidden ).toBe( true );
+		expect( menu.hasAttribute( 'data-open' ) ).toBe( false );
+		expect( toggle.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
+	} );
+
+	it( 'closes on a click anywhere else on the page', () => {
+		const container = renderButton();
+		document.body.insertAdjacentHTML( 'beforeend', '<p id="elsewhere">Text</p>' );
+
+		click( container.querySelector( '.exelearning-download__toggle' ) );
+		click( document.getElementById( 'elsewhere' ) );
+
+		expect( container.querySelector( '.exelearning-download__menu' ).hidden ).toBe( true );
+	} );
+
+	it( 'closes on Escape', () => {
+		const container = renderButton();
+
+		click( container.querySelector( '.exelearning-download__toggle' ) );
+		document.dispatchEvent(
+			new window.KeyboardEvent( 'keydown', { key: 'Escape', bubbles: true } )
+		);
+
+		expect( container.querySelector( '.exelearning-download__menu' ).hidden ).toBe( true );
+	} );
+
+	it( 'leaves other keys alone', () => {
+		const container = renderButton();
+
+		click( container.querySelector( '.exelearning-download__toggle' ) );
+		document.dispatchEvent(
+			new window.KeyboardEvent( 'keydown', { key: 'a', bubbles: true } )
+		);
+
+		expect( container.querySelector( '.exelearning-download__menu' ).hidden ).toBe( false );
+	} );
+
+	it( 'does nothing for a toggle with no menu behind it', () => {
+		document.body.innerHTML =
+			'<div class="exelearning-download" data-attachment-id="42">' +
+			'<button class="exelearning-download__toggle" aria-expanded="false">More</button></div>';
+
+		click( document.querySelector( '.exelearning-download__toggle' ) );
+
+		expect(
+			document.querySelector( '.exelearning-download__toggle' ).getAttribute( 'aria-expanded' )
+		).toBe( 'false' );
+	} );
+} );
+
+describe( 'wp-exe-download: downloading the .elpx itself', () => {
+	it( 'fetches the attachment and downloads it as a blob', async () => {
+		const container = renderButton();
+		const blob = { size: 10 };
+		window.fetch = () => Promise.resolve( { ok: true, blob: () => Promise.resolve( blob ) } );
+
+		click( container.querySelector( '[data-format="elpx"]' ) );
+		await settle();
+
+		expect( downloads ).toEqual( [
+			{ href: 'blob:mock/0', download: 'project.elpx' },
+		] );
+		expect( objectUrls[ 0 ].blob ).toBe( blob );
+		expect( container.hasAttribute( 'data-busy' ) ).toBe( false );
+	} );
+
+	it( 'marks the button busy while the fetch is in flight', async () => {
+		const container = renderButton();
+		let release;
+		window.fetch = () => new Promise( ( resolve ) => {
+			release = () => resolve( { ok: true, blob: () => Promise.resolve( {} ) } );
+		} );
+
+		click( container.querySelector( '[data-format="elpx"]' ) );
+		await Promise.resolve();
+
+		expect( container.getAttribute( 'data-busy' ) ).toBe( '1' );
+
+		release();
+		await settle();
+
+		expect( container.hasAttribute( 'data-busy' ) ).toBe( false );
+	} );
+
+	it( 'falls back to the direct URL when the fetch fails', async () => {
+		const container = renderButton();
+		window.fetch = () => Promise.reject( new Error( 'offline' ) );
+
+		click( container.querySelector( '[data-format="elpx"]' ) );
+		await settle();
+
+		expect( downloads ).toEqual( [
+			{ href: 'http://example.test/uploads/project.elpx', download: 'project.elpx' },
+		] );
+	} );
+
+	it( 'falls back to the direct URL on an HTTP error', async () => {
+		const container = renderButton();
+		window.fetch = () => Promise.resolve( { ok: false, status: 404 } );
+
+		click( container.querySelector( '[data-format="elpx"]' ) );
+		await settle();
+
+		expect( downloads ).toEqual( [
+			{ href: 'http://example.test/uploads/project.elpx', download: 'project.elpx' },
+		] );
+	} );
+
+	it( 'falls back to the direct URL where fetch does not exist', async () => {
+		renderButton();
+
+		await window.wpExeDownload.downloadFormat( {
+			format: 'elpx',
+			suffix: '.elpx',
+			attachmentId: 42,
+			elpUrl: 'http://example.test/uploads/project.elpx',
+			slug: 'project',
+		} );
+
+		expect( downloads ).toEqual( [
+			{ href: 'http://example.test/uploads/project.elpx', download: 'project.elpx' },
+		] );
+	} );
+
+	it( 'rejects when there is no attachment URL to download', async () => {
+		await expect(
+			window.wpExeDownload.downloadFormat( { format: 'elpx', attachmentId: 42 } )
+		).rejects.toThrow( 'Missing .elpx URL' );
+	} );
+} );
+
+describe( 'wp-exe-download: exporting through the editor iframe', () => {
+	it( 'refuses to export without an attachment id', async () => {
+		await expect(
+			window.wpExeDownload.downloadFormat( { format: 'scorm12' } )
+		).rejects.toThrow( 'Missing attachment id or editor URL' );
+		expect( consoleErrors.join( ' ' ) ).toContain( 'Missing attachment id or editor URL' );
+	} );
+} );

--- a/tests/unit/ViewerEnhancementsTest.php
+++ b/tests/unit/ViewerEnhancementsTest.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Tests for ExeLearning_Viewer_Enhancements.
+ *
+ * @package Exelearning
+ */
+
+/**
+ * Class ViewerEnhancementsTest.
+ *
+ * A percentage height means "this fraction of the rendered width", which only the
+ * browser can resolve. The filter answers it by appending a style rule and a small
+ * script to the shortcode output, so what matters is both what it emits for a valid
+ * request and how quietly it steps aside for everything else: the filter runs on
+ * every embed on the site, including those it has no business touching.
+ *
+ * @covers ExeLearning_Viewer_Enhancements
+ */
+class ViewerEnhancementsTest extends WP_UnitTestCase {
+
+	/**
+	 * Instance under test.
+	 *
+	 * @var ExeLearning_Viewer_Enhancements
+	 */
+	private $enhancements;
+
+	/**
+	 * Shortcode output as the renderer produces it.
+	 *
+	 * @var string
+	 */
+	private $html;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->enhancements = new ExeLearning_Viewer_Enhancements();
+		$this->html         =
+			'<div id="exelearning-abc123" class="exelearning-preview">' .
+			'<iframe class="exelearning-iframe" src="about:blank"></iframe>' .
+			'</div>';
+	}
+
+	/**
+	 * Run the filter with the default fixture markup.
+	 *
+	 * @param array $atts    Shortcode attributes.
+	 * @param int   $file_id Attachment ID.
+	 * @return string Filtered HTML.
+	 */
+	private function filter( $atts, $file_id = 42 ) {
+		return $this->enhancements->add_responsive_height_behavior( $this->html, $file_id, $atts );
+	}
+
+	/**
+	 * register_hooks() wires the shortcode filter and the block editor assets action.
+	 */
+	public function test_register_hooks_registers_callbacks() {
+		$this->enhancements->register_hooks();
+
+		$this->assertNotFalse(
+			has_filter(
+				'exelearning_shortcode_output',
+				array( $this->enhancements, 'add_responsive_height_behavior' )
+			)
+		);
+		$this->assertNotFalse(
+			has_action(
+				'enqueue_block_editor_assets',
+				array( $this->enhancements, 'enqueue_block_editor_fullscreen_script' )
+			)
+		);
+	}
+
+	/**
+	 * A percentage height appends the responsive sizing behavior.
+	 */
+	public function test_percentage_height_appends_behavior() {
+		$output = $this->filter( array( 'height' => '75%' ) );
+
+		$this->assertStringStartsWith( $this->html, $output, 'The original markup must survive untouched.' );
+		$this->assertStringContainsString( '#exelearning-abc123[data-exelearning-responsive-height="1"]', $output );
+		$this->assertStringContainsString( '--exelearning-responsive-height', $output );
+		$this->assertStringContainsString( 'document.getElementById("exelearning-abc123")', $output );
+		$this->assertStringContainsString( 'width * 75 / 100', $output );
+	}
+
+	/**
+	 * The behavior observes the container when ResizeObserver is available and falls
+	 * back to a window resize listener otherwise.
+	 */
+	public function test_behavior_covers_both_resize_paths() {
+		$output = $this->filter( array( 'height' => '50%' ) );
+
+		$this->assertStringContainsString( 'window.ResizeObserver', $output );
+		$this->assertStringContainsString( 'observer.observe(container)', $output );
+		$this->assertStringContainsString( 'window.addEventListener("resize", updateHeight)', $output );
+	}
+
+	/**
+	 * Percentages are read as integers, whatever the surrounding whitespace or case.
+	 */
+	public function test_percentage_is_normalized() {
+		$output = $this->filter( array( 'height' => '  100%  ' ) );
+
+		$this->assertStringContainsString( 'width * 100 / 100', $output );
+	}
+
+	/**
+	 * Absolute heights are the browser's business, not ours.
+	 */
+	public function test_absolute_height_is_left_alone() {
+		$this->assertSame( $this->html, $this->filter( array( 'height' => '600px' ) ) );
+	}
+
+	/**
+	 * A shortcode without a height attribute is left alone.
+	 */
+	public function test_missing_height_is_left_alone() {
+		$this->assertSame( $this->html, $this->filter( array() ) );
+	}
+
+	/**
+	 * Percentages that cannot describe a height are rejected rather than emitted as
+	 * a rule the browser would have to guess at.
+	 *
+	 * @dataProvider provide_unusable_heights
+	 *
+	 * @param string $height Height attribute value.
+	 */
+	public function test_unusable_percentages_are_left_alone( $height ) {
+		$this->assertSame( $this->html, $this->filter( array( 'height' => $height ) ) );
+	}
+
+	/**
+	 * Height values that must not produce a rule.
+	 *
+	 * @return array[] Data sets.
+	 */
+	public function provide_unusable_heights() {
+		return array(
+			'zero'             => array( '0%' ),
+			'leading zero'     => array( '075%' ),
+			'fractional'       => array( '33.3%' ),
+			'negative'         => array( '-50%' ),
+			'empty'            => array( '' ),
+			'percent alone'    => array( '%' ),
+			'trailing content' => array( '75% !important' ),
+		);
+	}
+
+	/**
+	 * Output from another renderer, without the preview wrapper, is not ours to touch.
+	 */
+	public function test_foreign_markup_is_left_alone() {
+		$html   = '<div id="exelearning-abc123">no preview class here</div>';
+		$output = $this->enhancements->add_responsive_height_behavior( $html, 42, array( 'height' => '75%' ) );
+
+		$this->assertSame( $html, $output );
+	}
+
+	/**
+	 * Without a container id there is nothing for the script to attach to.
+	 */
+	public function test_markup_without_container_id_is_left_alone() {
+		$html   = '<div class="exelearning-preview"><iframe class="exelearning-iframe"></iframe></div>';
+		$output = $this->enhancements->add_responsive_height_behavior( $html, 42, array( 'height' => '75%' ) );
+
+		$this->assertSame( $html, $output );
+	}
+
+	/**
+	 * A missing attachment id means the shortcode never resolved a file.
+	 */
+	public function test_missing_file_id_is_left_alone() {
+		$this->assertSame( $this->html, $this->filter( array( 'height' => '75%' ), 0 ) );
+	}
+
+	/**
+	 * A filter caller that passes something other than an attribute array is ignored
+	 * rather than allowed to reach the percentage parsing.
+	 */
+	public function test_non_array_attributes_are_left_alone() {
+		$output = $this->enhancements->add_responsive_height_behavior( $this->html, 42, 'height=75%' );
+
+		$this->assertSame( $this->html, $output );
+	}
+
+	/**
+	 * The container id lands in the script as a JSON string, so an id that closed the
+	 * string early could inject script into the page.
+	 */
+	public function test_container_id_is_encoded_for_the_script() {
+		// The id pattern only admits word characters and dashes, so the realistic
+		// worry is the rest of the attribute, which must not leak into the argument.
+		$html   = '<div id="exelearning-a-b_c" class="exelearning-preview" data-x="\"><script>">' .
+			'<iframe class="exelearning-iframe"></iframe></div>';
+		$output = $this->enhancements->add_responsive_height_behavior( $html, 42, array( 'height' => '75%' ) );
+
+		$this->assertStringContainsString( 'document.getElementById("exelearning-a-b_c")', $output );
+		$this->assertStringContainsString( '#exelearning-a-b_c[data-exelearning-responsive-height="1"]', $output );
+	}
+
+	/**
+	 * The block editor gets the fullscreen behavior, dependent on the block script.
+	 */
+	public function test_enqueue_block_editor_fullscreen_script() {
+		$this->enhancements->enqueue_block_editor_fullscreen_script();
+
+		$this->assertTrue( wp_script_is( 'exelearning-elp-block-fullscreen', 'enqueued' ) );
+
+		$script = wp_scripts()->registered['exelearning-elp-block-fullscreen'];
+		$this->assertStringEndsWith( 'assets/js/elp-upload-fullscreen.js', $script->src );
+		$this->assertContains( 'exelearning-elp-block', $script->deps );
+		$this->assertSame( EXELEARNING_VERSION, $script->ver );
+	}
+}


### PR DESCRIPTION
Five files, four of which carried no tests at all. They were picked by what a failure costs the reader, not by line count: each one breaks in a way that shows up on screen rather than in a stack trace.

## What is covered now

**`exelearning-editor.js` — 7.87% → 88.18%**
The whole save path: it opens the modal, talks to the editor iframe, and writes the file back through the REST API. It had exactly one test, on the meta-box button that opens it.
- Opening resolves the file URL first and hands it to the editor as `?import=`; a lookup that fails still opens the editor rather than nothing.
- Closing asks before discarding unsaved work, counts a dirty document *inside* the iframe as unsaved even when the editor has not announced it, and replaces the iframe rather than navigating it — which is what keeps the browser from raising "Leave site?".
- A save WordPress rejects leaves the modal open and says why. The file lives in the editor and nowhere else until that request succeeds, so closing on failure would throw away the only copy.
- Messages are ignored unless they come from the editor iframe *and* its origin; a save error only counts against the request actually in flight.

**`ExeLearning_Viewer_Enhancements` — 18.51% → 100%** (`includes/class-viewer-enhancements.php`)
Turns `height="75%"` into a rule the browser can resolve. The filter runs on *every* embed on the site, so the tests weigh what it emits for a valid request against how quietly it steps aside for everything else: absolute heights, percentages that cannot describe a height (`0%`, `075%`, `33.3%`, `-50%`, `75% !important`), markup from another renderer, markup with no container id, and callers that pass no attribute array.

**`elp-upload-fullscreen.js` — 0% → 95.8%**
Keeps the fullscreen button in step with the preview iframe Gutenberg keeps rebuilding underneath it. A button left enabled with no iframe behind it does nothing when clicked, which reads as a broken editor. The tests drive the MutationObserver through the preview appearing and disappearing, and cover all three vendor-prefixed fullscreen APIs plus the case where none exists.

**`exelearning-settings.js` — 0% → 100%**
Guards the per-style Delete links, which are nonced admin-post URLs with no way back. Both answers to the confirmation are covered, plus the clicks it must *not* touch.

**`wp-exe-download.js` — 0% → 50%**
Downloads the `.elpx` through `fetch` so the request goes via whatever serves the uploads (a Playground service worker, for one) instead of a top-level navigation that bypasses it. Both fallbacks are covered — no `fetch`, and a `fetch` that fails — along with the menu behaviour (toggle, click-outside, Escape, `aria-expanded`).

## Measured, not estimated

Same command before and after, in wp-env with Xdebug in coverage mode:

| Suite | Before | After |
|---|---|---|
| PHP lines | 84.25% (2675/3175) | **84.94%** (2697/3175) |
| PHP classes at 100% | 12/29 | **13/29** |
| JavaScript lines | 5.42% (59/1087) | **37.81%** (411/1087) |

820 PHP tests and 87 JavaScript tests pass (JS was 12 before).

## How the iframe protocols are tested

The controller identifies the editor by object identity (`event.source !== iframeWindow`) and answers it with `postMessage`, so the tests install a stub window on the real iframe element — the same trick `exelearning_embed_loader.test.js` already uses for `contentDocument`. That makes both directions observable without an editor.

Two things the tests carry rather than assert, both documented inline: `wp` is defined as a bare global before `close()`, which reaches `refreshMediaLibrary()` and would otherwise raise a `ReferenceError` instead of failing readably; and `window.fetch` is stubbed by default, because happy-dom fetches the iframe's `src` for real.

## What is deliberately left out

The **export**-iframe handshake in `wp-exe-download.js` (`ensureIframe` / `requestExport`). Unlike the editor modal, that script creates its own iframe and points it at the export bootstrap, and happy-dom's attempt to load that URL fires the frame's `error` handler, which rejects the export before any synthetic reply can arrive. I tried it: the tests fail against the load, not against the code. `disableIframePageLoading` swaps that for a `DOMException` on every iframe in the suite, including the pre-existing ones. It is covered by the Playwright suite, where the frame really loads.

That is the ~50% still uncovered in that file. happy-dom also logs a handful of aborted iframe navigations from the modal tests; the run is green and exits 0.

Independent of exelearning/wp-exelearning#83 (Codecov reporting); no overlapping files.