### PR TITLE
Make .distignore the single source of truth for the release ZIP

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,92 +1,92 @@
-# Directories
-.agents
-.git
-.github
-.idea
-.wordpress-org
-artifacts
-bin
-build
-build-cs
-build-phpunit
-docs
+# Files and directories kept out of the release ZIP.
+#
+# This is the single source of truth for what ships. `make package` builds the
+# archive with `wp dist-archive`, which reads this file straight from the working
+# tree, so the generated files that .gitignore keeps out of the repository
+# (dist/static/, the runtime translations) are packaged like any other file.
+#
+# `.gitattributes` does NOT feed this archive. It only shapes the source ZIP that
+# GitHub serves at archive/refs/heads/*.zip, the one blueprint.json installs in
+# WordPress Playground.
+#
+# Two matching rules to keep in mind, both inherited from
+# inmarelibero/gitignore-checker:
+#
+#   * Matching is case-insensitive, unlike git on Linux.
+#   * An unanchored rule matches at any depth, so it also reaches inside the
+#     bundled editor under dist/static/. A bare `build` rule used to strip
+#     dist/static/libs/yjs/build/ out of the package for exactly that reason.
+#
+# Root-only rules therefore carry a leading slash. The few rules that must match
+# at any depth are grouped at the end.
+
+# CI
+/.github
+
+# Agent instructions and vendored skills
+/.agents
+/.claude
+/AGENTS.md
+/CLAUDE.md
+
+# Development tooling and configuration
+/.editorconfig
+/.env
+/.env.dist
+/.phpcs.xml.dist
+/.phpunit.result.cache
+/.stylelintrc
+/.wp-env.json
+/bin
+/codecov.yml
+/composer.json
+/composer.lock
+/Makefile
+/package.json
+/package-lock.json
+/phpmd.xml
+/phpunit.xml.dist
+/playwright.config.*
+/renovate.json
+/scripts
+/vitest.config.*
+
+# Tests and everything they write
+/artifacts
+/test-results
+/tests
+
+# Dependencies and build inputs. Only the built editor in dist/static/ ships;
+# the sources it is built from live in the exelearning/ submodule.
 /exelearning
-node_modules
-patches
-# Distributed via vendor/plugin-check/phpcs-sniffs instead
-/phpcs-sniffs/
-tests
 /vendor
-wp-content
 
-# Language stuff. Only the runtime files ship: .l10n.php (WordPress 6.5+),
-# .mo (fallback for 6.1-6.4) and the JS .json files. The .po/.pot sources stay
-# in the repository.
-languages/*.pot
+# Repository documentation. readme.txt is the user-facing one and does ship.
+/blueprint.json
+/CODE_OF_CONDUCT.md
+/CONVENTIONS.md
+/docs
+/EXELEARNING_CHANGES.md
+/README.md
+/SECURITY.md
+
+# Translation sources. Only the runtime files ship: .l10n.php (WordPress 6.5+),
+# .mo (fallback for 6.1-6.4) and the JS .json files. Both rules contain a slash,
+# which already anchors them to the root.
 languages/*.po
+languages/*.pot
 
-# Files
-.claude
-.env
-.env.dist
-.aider.chat.history.md
-.aider.input.history
-*.DS_Store
+# The packaging metadata itself
+/.distignore
+/.gitattributes
+/.gitignore
+
+# Rules that must match at any depth: none of these is ever legitimate inside a
+# release, wherever it turns up.
+.git
+node_modules
 .DS_Store
-.distignore
-.editorconfig
-.eslintrc.js
-.gherkin-lintignore
-.gherkin-lintrc
-.gitattributes
-.gitignore
-.nvmrc
-.php-cs-fixer.php
-.phpunit.result.cache
-.stylelintrc
-.typos.toml
-.wp-env.json
-.wp-env.override.json
-behat.yml
-codecov.yml
-CODE_OF_CONDUCT.md
-composer.json
-composer.lock
-composer.phar
-CONVENTIONS.md
-CONTRIBUTING.md
-docker-compose.yml
-Makefile
-package.json
-package-lock.json
-phpcs.xml
-phpcs.xml.dist
-.phpcs.xml.dist
-phpmd.xml
-phpstan.neon
-phpstan.neon.dist
-phpunit.xml
-phpunit.xml.dist
-plugin-check.iml
-README.md
-CLAUDE.md
-blueprint.json
-renovate.json
-SECURITY.md
+*.DS_Store
+.idea
 sftp-config.json
-AGENTS.md
-EXELEARNING_CHANGES.md
-playwright.config.*
-vitest.config.*
-scripts
-cloudflare-worker
-mkdocs.yml
-sonar-project.properties
-test.php
-CHANGELOG.md
-# Anchored on purpose: an unanchored "LICENSE.txt" also matches the licence
-# files bundled with the static editor (matching is case-insensitive, so it
-# even catches dist/static/libs/tinymce_5/js/tinymce/license.txt).
-/LICENSE.txt
-phpmd.baseline.xml
 *.elpx

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,56 +1,18 @@
-# Exclude hidden files and directories
-.*                         								   export-ignore
+# Line endings are normalised on every checkout.
+* text=auto eol=lf
 
-# Exclude .po and .pot language files
-languages/*.po             								   export-ignore
-languages/*.pot           								   export-ignore
-
-# Exclude environment files
-.env                                                          export-ignore
-.env.dist                                                     export-ignore
-
-# Exclude Claude/AI config
-.claude/                                                      export-ignore
-.agents/                                                      export-ignore
-
-# Exclude development files
-EXELEARNING_CHANGES.md                                        export-ignore
-playwright.config.*                                           export-ignore
-scripts/                                                      export-ignore
-*.css.map 				   								   export-ignore
-/vendor/                   								   export-ignore
-AGENTS.md                                                  export-ignore
-artifacts/                                                 export-ignore
-blueprint.json                                             export-ignore
-CHANGELOG.md                                               export-ignore
-CLAUDE.md                                                  export-ignore
-cloudflare-worker/		                                   export-ignore
-codecov.yml                                                export-ignore
-CODE_OF_CONDUCT.md                                         export-ignore
-composer.json                                              export-ignore
-composer.lock                                              export-ignore
-CONVENTIONS.md                                             export-ignore
-docker-compose.yml                                         export-ignore
-docs/                                                      export-ignore
-LICENSE.txt                                                export-ignore
-Makefile                                                   export-ignore
-mkdocs.yml                                                 export-ignore
-node_modules/                                              export-ignore
-package-lock.json                                          export-ignore
-package.json                                               export-ignore
-phpmd.baseline.xml                                         export-ignore
-phpmd.xml                                                  export-ignore
-phpunit.xml.dist                                           export-ignore
-phpunit.xml.dist                                           export-ignore
-README.md                                                  export-ignore
-README.md                                                  export-ignore
-renovate.json                                              export-ignore
-SECURITY.md                                                export-ignore
-sftp-config.json                                           export-ignore
-sonar-project.properties                                   export-ignore
-test.php                                                   export-ignore
-tests/                                                     export-ignore
-vitest.config.*                                            export-ignore
-
-# eXeLearning submodule (built editor is in dist/static/)
-exelearning/                                               export-ignore
+# Nothing below feeds the release ZIP. That archive is built by `wp dist-archive`
+# and its exclusion list is .distignore, the single source of truth for what
+# ships.
+#
+# These rules only shape the source ZIP that GitHub serves at
+# archive/refs/heads/*.zip, the one blueprint.json installs in WordPress
+# Playground. Keep the list short and do not mirror .distignore into it: paths
+# git does not track (node_modules/, vendor/, dist/, artifacts/) never reach a
+# git archive in the first place, and submodule contents are never exported.
+/.agents        export-ignore
+/.claude        export-ignore
+/.github        export-ignore
+/.gitattributes export-ignore
+/docs           export-ignore
+/tests          export-ignore

--- a/.github/workflows/check-editor-releases.yml
+++ b/.github/workflows/check-editor-releases.yml
@@ -51,6 +51,21 @@ jobs:
         if: steps.check.outputs.found == 'true'
         uses: oven-sh/setup-bun@v2
 
+      # `make package` needs the WP-CLI i18n command to build the runtime
+      # translations and the dist-archive command to build the ZIP, both from
+      # require-dev. Without this the Create package step below fails outright.
+      - name: Setup PHP
+        if: steps.check.outputs.found == 'true'
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer:v2
+          coverage: none
+
+      - name: Install Composer dependencies
+        if: steps.check.outputs.found == 'true'
+        run: composer install --prefer-dist --no-progress
+
       - name: Build static editor
         if: steps.check.outputs.found == 'true'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,8 @@ jobs:
       # An absolute-type pattern matches that checkout location itself and
       # silently excludes every file (exit 0, zero files checked), so assert
       # the nested copy is actually scanned. checkout-index, not git archive:
-      # .gitattributes export-ignores dotfiles, including .phpcs.xml.dist.
+      # it writes the index verbatim, with no export-ignore filtering, so the
+      # guard stays independent of whatever .gitattributes happens to exclude.
       - name: PHPCS exclude-pattern regression guard
         run: |
           nested="${RUNNER_TEMP}/wp-content/uploads/exelearning/plugin"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,8 +150,19 @@ them: diverging from upstream makes future updates harder. Fix the problem
 upstream and re-vendor instead. The same set is used in `wp-decker`,
 `wp-documentate` and `wp-autofirma`.
 
-Skills are kept out of the release ZIP by `.distignore` — the file
-`wp dist-archive` actually reads — and out of `git archive` by `.gitattributes`.
+Skills are kept out of the release ZIP by `.distignore` and out of the source ZIP
+by `.gitattributes`. Those two files have separate jobs and must not be kept in
+sync with each other:
+
+- **`.distignore`** decides what ships. It is the only list `wp dist-archive`
+  reads, so it is the single source of truth for the release ZIP. Its rules match
+  case-insensitively and at any depth unless anchored with a leading slash, which
+  is why root-only rules carry one — an unanchored rule reaches inside the
+  bundled editor under `dist/static/`. See
+  [ADR-0003](docs/architecture/adr/ADR-0003-distignore-single-source-of-truth.md).
+- **`.gitattributes`** only shapes the source ZIP GitHub serves at
+  `archive/refs/heads/*.zip`, which `blueprint.json` installs in Playground. Keep
+  it short; untracked paths never reach a git archive and need no rule.
 
 ## Aider-specific usage
 

--- a/Makefile
+++ b/Makefile
@@ -554,6 +554,10 @@ package: package-translations
 	@# and the runtime translations) are packaged like any other file.
 	@# --plugin-dirname is what makes the archive extract as exelearning/ even
 	@# though the development checkout is named wp-exelearning.
+	@# `--force` does not empty an existing archive: dist-archive 3.1 shells out
+	@# to the `zip` binary, which ADDS to one. Without this removal a file that a
+	@# new .distignore rule excludes would survive from an earlier build.
+	rm -f "$(CURDIR)/exelearning-$(VERSION).zip"
 	./vendor/bin/wp dist-archive . "$(CURDIR)/exelearning-$(VERSION).zip" \
 		--plugin-dirname=exelearning --force
 

--- a/docs/architecture/adr/ADR-0003-distignore-single-source-of-truth.md
+++ b/docs/architecture/adr/ADR-0003-distignore-single-source-of-truth.md
@@ -1,0 +1,158 @@
+---
+id: ADR-0003
+title: "Make .distignore the single source of truth for the release ZIP"
+status: Proposed
+date: 2026-08-03
+related:
+  issues: []
+  prs: []
+  sdds:
+    - SDD-0002
+  adrs:
+    - ADR-0002
+supersedes: []
+superseded_by: []
+ai_assistance:
+  tool: "Claude Code"
+  model: "claude-opus-5"
+---
+
+# ADR-0003: Make .distignore the single source of truth for the release ZIP
+
+## Status
+
+Proposed
+
+## Context
+
+The repository carries two exclusion lists that look interchangeable and are not:
+
+- `.distignore` is the only list `wp dist-archive` reads
+  (`vendor/wp-cli/dist-archive-command/src/Dist_Archive_Command.php:77-84`), and
+  `make package` builds the release ZIP with that command
+  (`Makefile:557` @ `2d9fcb7`).
+- `.gitattributes` `export-ignore` rules are read by `git archive`, which is what
+  GitHub serves at `archive/refs/heads/*.zip` — the URL `blueprint.json` installs
+  in WordPress Playground (`blueprint.json` @ `2d9fcb7`).
+
+Before this decision both files listed roughly the same paths, 45 rules in
+`.gitattributes` against 81 in `.distignore`, with only 41 in common and two rules
+duplicated verbatim in `.gitattributes` (`README.md`, `phpunit.xml.dist`). The
+overlap invited maintaining them as mirrors of each other, which is wrong in both
+directions: a rule added to `.gitattributes` does not affect the release, and a
+rule added to `.distignore` does not affect the Playground preview.
+
+Roughly 35 rules in `.distignore` matched nothing in this repository. They were
+inherited by copying the file from `WordPress/plugin-check`, which is visible in
+the leftovers (`plugin-check.iml`, `behat.yml`, `.gherkin-lintrc`,
+`/phpcs-sniffs/`, `phpstan.neon`).
+
+The same two files, with the same drift, exist in `wp-decker`, `wp-documentate`
+and `wp-autofirma`. SDD-0002 covers unifying all four.
+
+## Problem
+
+Which file decides what ships, and what is the other one for?
+
+## Decision drivers
+
+- **Correctness of the release ZIP.** It is the artifact users install; the source
+  ZIP is a convenience.
+- **Generated files must ship.** `dist/static/` (the bundled editor, ADR-0002) and
+  the runtime translations are kept out of the repository by `.gitignore`, so any
+  packaging method that reads git rather than the working tree cannot produce a
+  valid release.
+- **One list to maintain.** Two overlapping lists drift, and the drift is silent.
+- **WordPress.org compatibility.** If the plugin is ever published there, the
+  standard deploy action prefers `.distignore` and falls back to `.gitattributes`.
+- **Faithfulness of the bundled editor.** What is packaged under `dist/static/`
+  should equal what `make build-editor` produced.
+
+## Alternatives considered
+
+### A. `.gitattributes` + `git archive` as the single mechanism
+
+Rejected. `git archive` only sees committed files, so the 92 MB editor build and
+the generated runtime translations would be absent. Producing a valid ZIP would
+require a staging script that copies the generated files back in — the
+complexity this repository already removed when it adopted `wp dist-archive`.
+
+### B. Keep both lists, generated from one source and checked in CI
+
+Rejected as disproportionate. It adds a generator and a CI gate to keep a file in
+sync that only shapes a preview ZIP.
+
+### C. `.distignore` decides what ships; `.gitattributes` is scoped down
+
+Chosen.
+
+## Decision
+
+`.distignore` is the single source of truth for the release ZIP. `.gitattributes`
+keeps only line-ending normalisation and a short, stable set of `export-ignore`
+rules whose sole purpose is shaping the source ZIP GitHub generates. The two files
+are not mirrors and must not be synchronised with each other; both say so in a
+header comment.
+
+Two consequences are recorded as rules:
+
+1. **Root-only `.distignore` rules carry a leading slash.** Matching in
+   `wp dist-archive` is delegated to `inmarelibero/gitignore-checker`, which
+   compiles every rule with the regex `i` flag and matches at any depth. An
+   unanchored rule therefore reaches inside the bundled editor. This was not
+   theoretical: `build`, `README.md`, `CHANGELOG.md` and `package.json` were
+   silently stripping 16 files out of `dist/static/`, among them
+   `dist/static/libs/yjs/build/` (7 files), `dist/static/CHANGELOG.md` and four
+   third-party `README.md` files. An earlier instance of the same bug is recorded
+   in the `LICENSE.txt` comment that this ADR's change replaces.
+2. **`.gitattributes` lists only tracked paths.** `node_modules/`, `vendor/`,
+   `dist/` and `artifacts/` are untracked, so `git archive` never sees them and
+   rules for them are noise.
+
+## Consequences
+
+### Positive
+
+- One list to maintain, and its scope is stated in the file itself.
+- The packaged editor is now a faithful copy of `dist/static/`.
+- `LICENSE.txt` ships (it did not before), and `test-results/` no longer does.
+- `.gitattributes` drops from 45 rules to 6.
+
+### Negative
+
+- The source ZIP and the release ZIP no longer contain the same files. Anyone
+  wanting a runnable plugin must take the release ZIP, which is already true
+  today because the source ZIP has never contained the bundled editor.
+- Pruning the unmatched rules removes guards against files that do not exist yet.
+  A short block of rules that must match at any depth (`.git`, `node_modules`,
+  `.DS_Store`, `.idea`, `sftp-config.json`) is kept deliberately for that reason.
+
+### Neutral
+
+- `make package` is unchanged; this ADR records the division of labour and fixes
+  the rules, not the command.
+
+## Verification
+
+Build the ZIP before and after and diff the file lists, which is what caught both
+regressions:
+
+```bash
+./vendor/bin/wp dist-archive . /tmp/before.zip --plugin-dirname=exelearning --force
+# apply the change
+./vendor/bin/wp dist-archive . /tmp/after.zip --plugin-dirname=exelearning --force
+diff <(unzip -l /tmp/before.zip | awk '{print $4}' | sort) \
+     <(unzip -l /tmp/after.zip  | awk '{print $4}' | sort)
+```
+
+## References
+
+- `Makefile:557` @ `2d9fcb7` — the packaging command.
+- `vendor/wp-cli/dist-archive-command/src/Dist_Archive_Command.php:77-84` —
+  `.distignore` is the only list read.
+- [ADR-0002](ADR-0002-bundle-editor-exclusively-in-release-packages.md) — the
+  bundled editor is a release artifact.
+- [SDD-0002](../sdd/SDD-0002-unify-release-packaging.md) — the cross-repository
+  design this decision belongs to.
+- [10up/action-wordpress-plugin-deploy](https://github.com/10up/action-wordpress-plugin-deploy)
+  — `.distignore` takes precedence, `.gitattributes` is the fallback.

--- a/docs/architecture/adr/records.md
+++ b/docs/architecture/adr/records.md
@@ -11,10 +11,12 @@ status, update the table and the per-status lists below.
 |----|-------|--------|------|-------------|
 | [ADR-0001](ADR-0001-obsolete-hash-alias-storage.md) | Resolve obsolete extraction hashes through attachment post meta aliases | Accepted | 2026-07-10 | [SDD-0001](../sdd/SDD-0001-stale-content-url-redirects.md) |
 | [ADR-0002](ADR-0002-bundle-editor-exclusively-in-release-packages.md) | Bundle the embedded editor exclusively in release packages | Accepted | 2026-07-24 | — |
+| [ADR-0003](ADR-0003-distignore-single-source-of-truth.md) | Make `.distignore` the single source of truth for the release ZIP | Proposed | 2026-08-03 | [SDD-0002](../sdd/SDD-0002-unify-release-packaging.md) |
 
 ## Proposed ADRs
 
-_No proposed ADRs yet._
+- [ADR-0003](ADR-0003-distignore-single-source-of-truth.md) — Make
+  `.distignore` the single source of truth for the release ZIP.
 
 ## Accepted ADRs
 

--- a/docs/architecture/sdd/SDD-0002-unify-release-packaging.md
+++ b/docs/architecture/sdd/SDD-0002-unify-release-packaging.md
@@ -1,0 +1,273 @@
+---
+id: SDD-0002
+title: "Unify release packaging on .distignore and wp dist-archive"
+status: Draft
+date: 2026-08-03
+related:
+  issues: []
+  prs: []
+  adrs:
+    - ADR-0003
+  sdds: []
+supersedes: []
+superseded_by: []
+ai_assistance:
+  tool: "Claude Code"
+  model: "claude-opus-5"
+---
+
+# SDD-0002: Unify release packaging on .distignore and wp dist-archive
+
+## Status
+
+Draft
+
+## Summary
+
+Four sibling plugins — `wp-exelearning`, `wp-decker`, `wp-documentate` and
+`wp-autofirma` — each build their release ZIP with a different tool, and each
+carries both a `.distignore` and a `.gitattributes` that overlap without agreeing.
+In three of the four the `.distignore` is not read by anything at all. This design
+puts all four on `wp dist-archive` + `.distignore`, and scopes `.gitattributes`
+down to the one job only it can do.
+
+This repository is the least affected: it already packages with `wp dist-archive`.
+Its share of the work is fixing the rules and recording the decision (ADR-0003) so
+the other three can cite it.
+
+## Context
+
+`make package` here builds the ZIP with
+`wp dist-archive . <zip> --plugin-dirname=exelearning --force` (`Makefile:557` @
+`2d9fcb7`). The other three repositories use `composer archive` (`wp-decker`,
+`wp-documentate`) or `git archive` plus a staging script (`wp-autofirma`).
+
+The four repositories share their agent skills, conventions and Makefile shape, so
+a maintainer moving between them reasonably expects packaging to work the same
+way. It does not.
+
+## Problem statement
+
+Maintainers of the four plugins cannot tell which file controls the release, and
+two of the four ship a ZIP that WordPress installs into the wrong directory.
+
+Concretely, measured by building each package:
+
+- **`wp-decker` and `wp-documentate` produce a ZIP with no top-level directory.**
+  `composer archive` never adds a path prefix. WordPress then names the plugin
+  folder after the ZIP file (`wp-admin/includes/class-wp-upgrader.php:640-643`,
+  reached because `WP_PLUGIN_DIR` is a protected directory, with the working
+  directory named at `:378` from the package filename). `decker-1.2.3.zip`
+  installs into `wp-content/plugins/decker-1.2.3/`, so every release lands in a
+  new folder, WordPress treats it as a different plugin and deactivates the
+  previous one.
+- **Dev files ship.** `wp-documentate` ships `fixtures/`, `docs/` and `scripts/`,
+  1.1 MB of a 4.0 MB ZIP, including `propuestagasto.odt.bak` and
+  `propuestagasto_OLD.odt`; `wp-decker` ships `jest.config.js` and `SECURITY.md`;
+  `wp-autofirma` ships `codecov.yml` and `phpunit-integration.xml.dist`; this
+  repository shipped `test-results/`.
+- **The dead lists are the good ones.** The `.distignore` files in `wp-decker`,
+  `wp-documentate` and `wp-autofirma` list exactly the paths that leak, and
+  nothing reads them.
+- **Unanchored rules reach into the bundled editor here.** See ADR-0003.
+
+## Goals
+
+- One packaging command across the four repositories, differing only in the slug.
+- One exclusion list per repository, with its scope stated in the file.
+- Every release ZIP extracts to a directory equal to the plugin slug.
+- No development file in any release ZIP, verified by diffing the ZIP file list.
+
+## Non-goals
+
+- Publishing any of the four to the WordPress.org directory.
+- Changing the version-bumping flow (`make package VERSION=…` and the
+  `sed`-in-place dance) in any repository.
+- Changing what `blueprint.json` installs. The Playground previews keep using
+  GitHub's source ZIP.
+
+## Current behavior
+
+| Repository | Tool | List actually read | Top-level dir |
+|---|---|---|---|
+| `wp-exelearning` | `wp dist-archive` | `.distignore` | `exelearning/` |
+| `wp-decker` | `composer archive` | `.gitattributes` | none |
+| `wp-documentate` | `composer archive` | `.gitattributes` | none |
+| `wp-autofirma` | `git archive` + staging | `.gitattributes` | `wp-autofirma/` |
+
+`composer archive` honours `.gitattributes` `export-ignore` and ignores
+`.gitignore` entirely, verified on Composer 2.10.2 with a controlled repository:
+a `.gitignore`d untracked file was archived, an `export-ignore`d directory was
+not, and the archive had no path prefix.
+
+## Proposed design
+
+**Packaging.** Every repository runs, from its `package` target:
+
+```make
+./vendor/bin/wp dist-archive . "$(CURDIR)/<slug>-$(VERSION).zip" \
+    --plugin-dirname=<slug> --force
+```
+
+`wp-cli/dist-archive-command: ^3.1` goes into `require-dev` where it is missing.
+The pin matters: 3.2+ requires `wp-cli ^2.13`, which has no stable release, and
+3.1.0 shells out to the `zip` binary so no `ext-zip` is needed.
+
+`--plugin-dirname` is what makes `wp-exelearning` extract as `exelearning/`, and
+it is what fixes the folder name for `wp-decker` and `wp-documentate`.
+
+**`.distignore`.** Becomes the real list in each repository: pruned of the rules
+inherited from `WordPress/plugin-check` that match nothing, extended with the
+paths that currently leak, and with root-only rules anchored by a leading slash.
+
+**`.gitattributes`.** Reduced to line-ending normalisation plus a short
+`export-ignore` block for tracked development paths (`.agents/`, `.claude/`,
+`.github/`, `docs/`, `tests/`), with a header stating that it does not feed the
+release. Untracked paths need no rule because `git archive` never sees them.
+
+**`wp-autofirma`** needs `vendor/` inside its ZIP, which is why its script
+installs runtime dependencies into a staging tree. It adopts the pattern the two
+sibling plugins already use: `composer.json` `post-install-cmd` copies the runtime
+library into a committed tree, and a small PSR-4 autoloader loads it when Composer
+is absent — `wp-documentate` already vendors the very same
+`erseco/autofirma-intermediate-server` this way
+(`wp-documentate/includes/autofirma/class-documentate-autofirma-bundled-autoloader.php`).
+Its packaging script then reduces to a version check plus the shared command.
+
+## Affected areas
+
+- [x] Build / packaging (`Makefile`, distribution)
+
+Everything else in the template is untouched: no PHP classes, admin UI, public
+rendering, block, shortcode, REST endpoint, Media Library integration, upload or
+extraction path, content proxy or style registry changes.
+
+## Data model or storage impact
+
+Not applicable — no stored data changes.
+
+## WordPress hooks/filters impact
+
+Not applicable — no hooks added or changed.
+
+## REST API impact
+
+Not applicable — no REST surface changes.
+
+## Shortcode/block impact
+
+Not applicable — no shortcode or block contract changes.
+
+## Security considerations
+
+The change removes files from the distributed package rather than adding any, and
+crosses no trust boundary in plugin code. Two points are relevant:
+
+- Pruning unmatched rules removes guards against files that do not exist yet. Each
+  repository keeps a deliberate block of rules that must match at any depth —
+  `.git`, `node_modules`, `.DS_Store`, `.idea`, `sftp-config.json` — so a
+  credential file dropped in a working tree still cannot reach a release.
+- `wp-autofirma` moves from packaging `HEAD` to packaging the working tree, so a
+  local build from a dirty tree now includes uncommitted changes. In CI the
+  checkout is clean and the release workflow already asserts `git diff
+  --exit-code -- build`.
+
+## Privacy considerations
+
+Not applicable — no personal data is handled.
+
+## Accessibility considerations
+
+Not applicable — no user-facing surface changes.
+
+## Internationalization considerations
+
+No new strings. The `.distignore` rules that keep `.po`/`.pot` sources out while
+shipping `.l10n.php`, `.mo` and the JS `.json` files are preserved verbatim,
+including the leading path segment that already anchors them.
+
+## Backward compatibility
+
+For this repository the packaged file list changes by +16 files inside
+`dist/static/` (previously stripped by unanchored rules), plus `LICENSE.txt`,
+minus `test-results/`. No installed site is affected by a re-packaging change; the
+plugin folder name is unchanged.
+
+For `wp-decker` and `wp-documentate` the installed folder name changes from
+`<slug>-<version>` to `<slug>`. Sites that installed a previous release from
+GitHub keep the old directory and must remove it by hand once; plugin options are
+keyed by option name, not by path, so no data is lost.
+
+## Migration/rollout
+
+One pull request per repository, in this order, each verified by diffing the ZIP
+file list against the previous build:
+
+1. `wp-exelearning` — rules and documentation only, no command change.
+2. `wp-decker` — smallest of the three tool switches.
+3. `wp-documentate` — same switch, plus the largest cleanup.
+4. `wp-autofirma` — the tool switch plus vendoring the runtime dependency.
+
+Rollback is reverting the pull request; nothing persists outside the repository.
+
+## Testing strategy
+
+Packaging has no unit-test surface. Verification is the ZIP file-list diff shown
+in ADR-0003, run for every repository and pasted into its pull request. The
+existing `make lint`, `make test` and `make check-plugin` gates continue to apply
+and must stay green.
+
+## Acceptance criteria
+
+- [ ] The four repositories build their ZIP with `wp dist-archive` and
+      `--plugin-dirname` set to the plugin slug.
+- [ ] Every ZIP extracts to a single directory named after the slug.
+- [ ] No `tests/`, `docs/`, `fixtures/`, `scripts/`, `node_modules/`,
+      `test-results/`, CI config or agent instruction file appears in any ZIP.
+- [ ] `LICENSE.txt` appears in all four ZIPs.
+- [ ] Each `.gitattributes` states that it does not feed the release ZIP.
+- [ ] `wp-autofirma` loads its runtime dependency from the committed tree with no
+      `vendor/` directory present.
+
+## Open questions
+
+None outstanding; the three design choices this document rested on were settled
+before drafting (tool, `wp-autofirma` dependency handling, shipping `LICENSE.txt`).
+
+## ADRs required or referenced
+
+| Decision | ADR | Status |
+|----------|-----|--------|
+| `.distignore` is the single source of truth; `.gitattributes` only shapes the source ZIP | [ADR-0003](../adr/ADR-0003-distignore-single-source-of-truth.md) | Proposed |
+| The embedded editor is a release artifact | [ADR-0002](../adr/ADR-0002-bundle-editor-exclusively-in-release-packages.md) | Accepted |
+
+## Evidence
+
+- Packages built from each repository at their current `main`, and their file
+  lists compared: `wp-decker` 154 files with no top-level directory,
+  `wp-documentate` 128 files / 4.0 MB with no top-level directory,
+  `wp-autofirma` 28 entries under `wp-autofirma/`, `wp-exelearning` 3910 entries
+  under `exelearning/`.
+- `wp-admin/includes/class-wp-upgrader.php:378` and `:640-643` — how WordPress
+  derives the installed folder name.
+- `vendor/wp-cli/dist-archive-command/src/Dist_Archive_Command.php:77-84` —
+  `.distignore` is the only list read.
+- Composer 2.10.2 probe repository — `composer archive` ignores `.gitignore`,
+  honours `.gitattributes`, adds no prefix.
+- `wp-documentate/composer.json` (`copy-runtime-dependencies`) and
+  `wp-decker/composer.json` (`post-install-cmd`) — the existing vendoring pattern.
+
+## Follow-up tasks
+
+- [ ] Open the four pull requests in the order listed under Migration/rollout.
+- [ ] Once `.gitattributes` no longer carries the blanket `.*` rule, revisit the
+      `git checkout-index` workaround in `.github/workflows/ci.yml:127-128`, which
+      exists only because that rule hid `.phpcs.xml.dist` from `git archive`.
+
+## References
+
+- [ADR-0003](../adr/ADR-0003-distignore-single-source-of-truth.md)
+- [ADR-0002](../adr/ADR-0002-bundle-editor-exclusively-in-release-packages.md)
+- [wp-cli/dist-archive-command](https://github.com/wp-cli/dist-archive-command)
+- [10up/action-wordpress-plugin-deploy](https://github.com/10up/action-wordpress-plugin-deploy)
+  — `.distignore` takes precedence over `.gitattributes`.

--- a/docs/architecture/sdd/records.md
+++ b/docs/architecture/sdd/records.md
@@ -10,10 +10,12 @@ the table and the per-status lists below.
 | ID | Title | Status | Date | Related ADRs |
 |----|-------|--------|------|--------------|
 | [SDD-0001](SDD-0001-stale-content-url-redirects.md) | Stale content URL redirects to the latest ELPX extraction | Accepted | 2026-07-10 | [ADR-0001](../adr/ADR-0001-obsolete-hash-alias-storage.md) |
+| [SDD-0002](SDD-0002-unify-release-packaging.md) | Unify release packaging on `.distignore` and `wp dist-archive` | Draft | 2026-08-03 | [ADR-0003](../adr/ADR-0003-distignore-single-source-of-truth.md) |
 
 ## Draft SDDs
 
-_No draft SDDs yet._
+- [SDD-0002](SDD-0002-unify-release-packaging.md) — Unify release packaging on
+  `.distignore` and `wp dist-archive`.
 
 ## In Review SDDs
 


### PR DESCRIPTION
## Why

`.distignore` and `.gitattributes` listed roughly the same paths — 41 rules in common, and two duplicated verbatim inside `.gitattributes` (`README.md`, `phpunit.xml.dist`) — even though they have different jobs:

- **`.distignore`** is the only list `wp dist-archive` reads (`vendor/wp-cli/dist-archive-command/src/Dist_Archive_Command.php:77-84`), so it alone decides what ships.
- **`.gitattributes`** `export-ignore` only shapes the source ZIP GitHub serves at `archive/refs/heads/*.zip` — the URL `blueprint.json` installs in Playground.

Maintaining them as mirrors is wrong in both directions and hid two bugs.

## Bugs fixed

**1. Unanchored rules were eating the bundled editor.** `wp dist-archive` delegates matching to `inmarelibero/gitignore-checker`, which compiles every rule with the regex `i` flag and matches at *any depth*. So the bare `build`, `README.md`, `CHANGELOG.md` and `package.json` rules reached inside `dist/static/` and silently stripped 16 files from the packaged editor. The `LICENSE.txt` rule already carried a comment about this exact trap; now every root-only rule is anchored.

**2. `test-results/` was shipping** — Playwright output, gitignored, but `dist-archive` reads the working tree.

## Verification

Built the ZIP before and after and diffed the file lists (3910 → 3926 entries):

```
> exelearning/LICENSE.txt
> exelearning/dist/static/libs/yjs/build/            (7 files)
> exelearning/dist/static/CHANGELOG.md
> exelearning/dist/static/libs/README.md
> exelearning/dist/static/libs/tinymce_5/CHANGELOG.md
> exelearning/dist/static/libs/tinymce_5/js/tinymce/langs/README.md
> exelearning/dist/static/app/common/mindmaps/README.md
> exelearning/dist/static/app/common/edicuatex/README.md
> exelearning/dist/static/app/common/fix_webm_duration/README.md
> exelearning/dist/static/app/common/fix_webm_duration/package.json
> exelearning/dist/static/files/perm/idevices/base/lomloe/README.md
< exelearning/test-results/
< exelearning/test-results/.last-run.json
```

Nothing else changed. `make package` itself is untouched.

## Also in this PR

- `.distignore` loses ~35 rules inherited from `WordPress/plugin-check` that match nothing here (`plugin-check.iml`, `behat.yml`, `.gherkin-lintrc`, `phpstan.neon`, `/phpcs-sniffs/`…), and keeps a deliberate block of rules that *must* match at any depth (`.git`, `node_modules`, `.DS_Store`, `.idea`, `sftp-config.json`).
- `LICENSE.txt` now ships; it did not before.
- `.gitattributes` goes from 45 rules to 6. Rules for untracked paths (`node_modules/`, `vendor/`, `dist/`, `artifacts/`) were noise — `git archive` never sees them.
- Both files now state their scope in a header comment, so nobody re-syncs them by hand.

## Context

`wp-decker`, `wp-documentate` and `wp-autofirma` carry the same two drifting files, and two of them ship a ZIP with no top-level directory (WordPress then installs them as `decker-1.2.3/`). **ADR-0003** records the decision and **SDD-0002** the cross-repository design; this is the first of four PRs and the only one that does not change the packaging command.

## Follow-up (not here)

`ci.yml:127-128` uses `git checkout-index` instead of `git archive` only because the blanket `.*` rule hid `.phpcs.xml.dist`. That rule is gone, so the workaround can be revisited — left out to keep this PR to packaging.


---

## Añadido tras revisar la CI

**`check-editor-releases.yml` no instalaba PHP ni Composer** y sin embargo llama a `make package`, que necesita el comando i18n de WP-CLI para las traducciones de runtime y `dist-archive` para el ZIP, ambos en `require-dev`. El paso *Create package* fallaba en cuanto salía una versión nueva del editor. Es un fallo preexistente, no lo introduce esta PR; los pasos son los mismos que ya usa `release.yml`.

**Comentario obsoleto en el guard de PHPCS.** Decía que se usaba `checkout-index` porque `.gitattributes` excluía los dotfiles, incluido `.phpcs.xml.dist` — dejó de ser cierto al desaparecer la regla `.*`. `checkout-index` sigue siendo lo correcto, pero por una razón mejor: escribe el índice tal cual, sin filtrar por `export-ignore`, así que el guard no depende de lo que `.gitattributes` excluya en cada momento.

**`rm -f` antes de archivar**, porque `--force` no vacía el ZIP anterior (ver el commit correspondiente).
