### PR TITLE
Raise PHP test coverage to 94% and replace the assert-nothing tests

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -26,6 +26,13 @@
     <arg name="colors"/>
     <arg value="sp"/>
 
+    <!-- Check the code really runs on the minimum PHP the plugin declares.
+         phpcompatibility-wp was already in require-dev but no ruleset referenced
+         it, so it never ran. Keep this in step with "Requires PHP" in
+         exelearning.php and readme.txt. -->
+    <config name="testVersion" value="8.0-"/>
+    <rule ref="PHPCompatibilityWP"/>
+
     <rule ref="WordPress">
         <exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
         <exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>

--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,7 @@ test-verbose: start-if-not-running
 # - defensive I/O failure branches (mkdir/copy/read/write) that cannot be
 #   provoked as root, and Admin_Styles::handle_upload() past its
 #   is_uploaded_file() gate
-MIN_COVERAGE ?= 93
+MIN_COVERAGE ?= 94
 
 # Run tests with code coverage report.
 # IMPORTANT: Requires wp-env started with Xdebug enabled:

--- a/Makefile
+++ b/Makefile
@@ -231,10 +231,18 @@ check-plugin: check-docker start-if-not-running
 	# decides nothing: the output is what has to be read. Verified by injecting
 	# a forbidden call, which the checker reported as an ERROR while still
 	# exiting 0.
+	#
+	# The exclusion list used to name `exelearning`, the editor submodule. The
+	# plugin is installed under that same name, so the rule matched the plugin's
+	# own root and the checker scanned nothing at all — it reported only "the
+	# plugin readme.txt does not exist". Same trap `.phpcs.xml.dist` documents
+	# for PHPCS. Neither the submodule nor dist/ holds a single PHP file, so
+	# excluding them was never needed; tests/ and bin/ are the only ones that do,
+	# and bin/ is developer tooling that is not shipped.
 	@echo "Running WordPress Plugin Check..."
 	@TMPFILE=$$(mktemp); \
 	npx wp-env run cli wp plugin check exelearning \
-		--exclude-directories=tests,exelearning,dist \
+		--exclude-directories=tests,bin \
 		--exclude-checks=file_type,image_functions \
 		--ignore-warnings \
 		--color 2>&1 | tee $$TMPFILE; \

--- a/Makefile
+++ b/Makefile
@@ -374,13 +374,14 @@ install-phpcs: check-docker start-if-not-running
 	fi
 
 
-# Check code style with PHP Code Sniffer (uses same setup as CI)
+# Check code style with PHP Code Sniffer. The ruleset decides what gets
+# scanned, so composer, the Makefile and CI all check exactly the same thing.
 lint:
-	./vendor/bin/phpcs --standard=.phpcs.xml.dist .
+	composer phpcs
 
-# Automatically fix code style with PHP Code Beautifier (uses same setup as CI)
+# Automatically fix code style with PHP Code Beautifier
 fix:
-	./vendor/bin/phpcbf --standard=.phpcs.xml.dist . || true
+	composer phpcbf || true
 
 # Run PHP Mess Detector with the repository ruleset (same as CI).
 phpmd:

--- a/Makefile
+++ b/Makefile
@@ -266,11 +266,15 @@ test-verbose: start-if-not-running
 	npx wp-env run tests-cli --env-cwd=wp-content/plugins/exelearning $$CMD --colors=always
 
 # Minimum coverage threshold (percentage)
-# Note: 74% is the achievable maximum given that some code cannot be unit tested:
-# - Content_Proxy: exit(), header(), readfile() calls
-# - Editor: exit(), include(), ob_start() calls
-# - REST_API: file upload handling requires $_FILES superglobal
-MIN_COVERAGE ?= 74
+# The remaining gap is code PHPUnit cannot reach:
+# - admin/views/editor-bootstrap.php: standalone template that tears down every
+#   output buffer and ends in exit()
+# - exit() paths in Content_Proxy::serve_content(), Editor::render_editor_page()
+#   and Export_Bootstrap::maybe_render()
+# - defensive I/O failure branches (mkdir/copy/read/write) that cannot be
+#   provoked as root, and Admin_Styles::handle_upload() past its
+#   is_uploaded_file() gate
+MIN_COVERAGE ?= 93
 
 # Run tests with code coverage report.
 # IMPORTANT: Requires wp-env started with Xdebug enabled:

--- a/Makefile
+++ b/Makefile
@@ -227,21 +227,25 @@ check-plugin: check-docker start-if-not-running
 	# Install plugin-check if needed (don't fail if already active)
 	@npx wp-env run cli wp plugin install plugin-check --activate --color || true
 
-	# Run plugin check with colored output, capture exit code, and fail if needed
+	# `wp plugin check` exits 0 even when it reports errors, so the exit code
+	# decides nothing: the output is what has to be read. Verified by injecting
+	# a forbidden call, which the checker reported as an ERROR while still
+	# exiting 0.
 	@echo "Running WordPress Plugin Check..."
-	@npx wp-env run cli wp plugin check exelearning \
+	@TMPFILE=$$(mktemp); \
+	npx wp-env run cli wp plugin check exelearning \
 		--exclude-directories=tests,exelearning,dist \
 		--exclude-checks=file_type,image_functions \
 		--ignore-warnings \
-		--color; \
-	EXIT_CODE=$$?; \
+		--color 2>&1 | tee $$TMPFILE; \
+	ERRORS=$$(sed 's/\x1B\[[0-9;]*[mK]//g' $$TMPFILE | grep -cE '\bERROR\b' || true); \
+	rm -f $$TMPFILE; \
 	echo ""; \
-	if [ $$EXIT_CODE -eq 0 ]; then \
-		echo "Plugin Check: ✓ No errors found."; \
-	else \
-		echo "Plugin Check: ✗ Errors found (exit code: $$EXIT_CODE)."; \
-		exit $$EXIT_CODE; \
-	fi
+	if [ "$$ERRORS" -gt 0 ]; then \
+		echo "Plugin Check: ✗ $$ERRORS error(s) found."; \
+		exit 1; \
+	fi; \
+	echo "Plugin Check: ✓ No errors found."
 
 
 # Combined check for lint, tests, untranslated, and more

--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,10 @@
     "require-dev": {
         "phpcompatibility/phpcompatibility-wp": "*",
         "phpunit/phpunit": "*",
-        "squizlabs/php_codesniffer": "*",
+        "squizlabs/php_codesniffer": "^3.13.5",
         "wp-cli/dist-archive-command": "^3.1",
         "wp-cli/i18n-command": "*",
-        "wp-coding-standards/wpcs": "*",
+        "wp-coding-standards/wpcs": "^3.4",
         "yoast/phpunit-polyfills": "*",
         "yoast/wp-test-utils": "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     "scripts": {
         "phpunit": "vendor/bin/phpunit",
         "test": "phpunit",
-        "phpcs": "phpcs --standard=WordPress . --ignore=vendor/,assets/,node_modules/,tests/js/,wp/,wp-content/,tests/ --colors --warning-severity=0 --extensions=php",
-        "phpcbf": "phpcbf --standard=WordPress . --ignore=vendor/,assets/,node_modules/,tests/js/,wp/,wp-content/ --colors --warning-severity=0 --extensions=php",
+        "phpcs": "phpcs --standard=.phpcs.xml.dist",
+        "phpcbf": "phpcbf --standard=.phpcs.xml.dist",
         "make-pot": "wp i18n make-pot . languages/exelearning.pot --slug=exelearning --domain=exelearning --exclude=vendor,node_modules,tests,wp,wp-content,dist,exelearning,bin",
         "pot-remove-ctime": "sed -i.bak '/POT-Creation-Date:/d' languages/exelearning.pot && rm languages/exelearning.pot.bak",
         "po": "@php bin/po-update.php",

--- a/composer.json
+++ b/composer.json
@@ -61,5 +61,8 @@
             "Exelearning\\Tests\\": "tests/"
         }
     },
-    "type": "project"
+    "type": "project",
+    "require": {
+        "php": ">=8.0"
+    }
 }

--- a/exelearning.php
+++ b/exelearning.php
@@ -11,6 +11,7 @@
  * Description:       Plugin to support eXeLearning .elpx files in WordPress. Upload, manage and embed eXeLearning content.
  * Version:           0.0.0
  * Requires at least: 6.1
+ * Requires PHP:      8.0
  * Author:            INTEF
  * Author URI:        https://exelearning.net/
  * License:           AGPL-3.0+

--- a/languages/exelearning-ca.po
+++ b/languages/exelearning-ca.po
@@ -33,12 +33,12 @@ msgid "Plugin to support eXeLearning .elpx files in WordPress. Upload, manage an
 msgstr "Connector per gestionar fitxers .elpx d'eXeLearning a WordPress. Puja, gestiona i incrusta contingut d'eXeLearning."
 
 #. Author of the plugin
-#: exelearning.php:14
+#: exelearning.php:15
 msgid "INTEF"
 msgstr "INTEF"
 
 #. Author URI of the plugin
-#: exelearning.php:15
+#: exelearning.php:16
 msgid "https://exelearning.net/"
 msgstr "https://exelearning.net/"
 

--- a/languages/exelearning-ca_valencia.po
+++ b/languages/exelearning-ca_valencia.po
@@ -33,12 +33,12 @@ msgid "Plugin to support eXeLearning .elpx files in WordPress. Upload, manage an
 msgstr "Connector per a gestionar fitxers .elpx d'eXeLearning en WordPress. Puja, gestiona i incrusta contingut d'eXeLearning."
 
 #. Author of the plugin
-#: exelearning.php:14
+#: exelearning.php:15
 msgid "INTEF"
 msgstr "INTEF"
 
 #. Author URI of the plugin
-#: exelearning.php:15
+#: exelearning.php:16
 msgid "https://exelearning.net/"
 msgstr "https://exelearning.net/"
 

--- a/languages/exelearning-de_DE.po
+++ b/languages/exelearning-de_DE.po
@@ -33,12 +33,12 @@ msgid "Plugin to support eXeLearning .elpx files in WordPress. Upload, manage an
 msgstr "Plugin zur Unterstützung von eXeLearning .elpx-Dateien in WordPress. Hochladen, Verwalten und Einbetten von eXeLearning-Inhalten."
 
 #. Author of the plugin
-#: exelearning.php:14
+#: exelearning.php:15
 msgid "INTEF"
 msgstr "INTEF"
 
 #. Author URI of the plugin
-#: exelearning.php:15
+#: exelearning.php:16
 msgid "https://exelearning.net/"
 msgstr "https://exelearning.net/"
 

--- a/languages/exelearning-eo.po
+++ b/languages/exelearning-eo.po
@@ -33,12 +33,12 @@ msgid "Plugin to support eXeLearning .elpx files in WordPress. Upload, manage an
 msgstr "Kromprogramo por subteni eXeLearning .elpx-dosierojn en WordPress. Alŝutu, administru kaj enkorpigu eXeLearning-enhavon."
 
 #. Author of the plugin
-#: exelearning.php:14
+#: exelearning.php:15
 msgid "INTEF"
 msgstr "INTEF"
 
 #. Author URI of the plugin
-#: exelearning.php:15
+#: exelearning.php:16
 msgid "https://exelearning.net/"
 msgstr "https://exelearning.net/"
 

--- a/languages/exelearning-es_ES.po
+++ b/languages/exelearning-es_ES.po
@@ -33,12 +33,12 @@ msgid "Plugin to support eXeLearning .elpx files in WordPress. Upload, manage an
 msgstr "Plugin para gestionar archivos .elpx de eXeLearning en WordPress. Sube, gestiona e incrusta contenido de eXeLearning."
 
 #. Author of the plugin
-#: exelearning.php:14
+#: exelearning.php:15
 msgid "INTEF"
 msgstr "INTEF"
 
 #. Author URI of the plugin
-#: exelearning.php:15
+#: exelearning.php:16
 msgid "https://exelearning.net/"
 msgstr "https://exelearning.net/"
 

--- a/languages/exelearning-eu.po
+++ b/languages/exelearning-eu.po
@@ -33,12 +33,12 @@ msgid "Plugin to support eXeLearning .elpx files in WordPress. Upload, manage an
 msgstr "eXeLearning .elpx fitxategiak WordPressen kudeatzeko plugina. Igo, kudeatu eta txertatu eXeLearning edukiak."
 
 #. Author of the plugin
-#: exelearning.php:14
+#: exelearning.php:15
 msgid "INTEF"
 msgstr "INTEF"
 
 #. Author URI of the plugin
-#: exelearning.php:15
+#: exelearning.php:16
 msgid "https://exelearning.net/"
 msgstr "https://exelearning.net/"
 

--- a/languages/exelearning-gl_ES.po
+++ b/languages/exelearning-gl_ES.po
@@ -33,12 +33,12 @@ msgid "Plugin to support eXeLearning .elpx files in WordPress. Upload, manage an
 msgstr "Complemento para xestionar ficheiros .elpx de eXeLearning en WordPress. Sube, xestiona e incrusta contido de eXeLearning."
 
 #. Author of the plugin
-#: exelearning.php:14
+#: exelearning.php:15
 msgid "INTEF"
 msgstr "INTEF"
 
 #. Author URI of the plugin
-#: exelearning.php:15
+#: exelearning.php:16
 msgid "https://exelearning.net/"
 msgstr "https://exelearning.net/"
 

--- a/languages/exelearning-it_IT.po
+++ b/languages/exelearning-it_IT.po
@@ -33,12 +33,12 @@ msgid "Plugin to support eXeLearning .elpx files in WordPress. Upload, manage an
 msgstr "Plugin per gestire i file .elpx di eXeLearning in WordPress. Carica, gestisci e incorpora contenuti eXeLearning."
 
 #. Author of the plugin
-#: exelearning.php:14
+#: exelearning.php:15
 msgid "INTEF"
 msgstr "INTEF"
 
 #. Author URI of the plugin
-#: exelearning.php:15
+#: exelearning.php:16
 msgid "https://exelearning.net/"
 msgstr "https://exelearning.net/"
 

--- a/languages/exelearning-pt_PT.po
+++ b/languages/exelearning-pt_PT.po
@@ -33,12 +33,12 @@ msgid "Plugin to support eXeLearning .elpx files in WordPress. Upload, manage an
 msgstr "Plugin para gerir ficheiros .elpx do eXeLearning no WordPress. Carregue, gira e incorpore conteúdo eXeLearning."
 
 #. Author of the plugin
-#: exelearning.php:14
+#: exelearning.php:15
 msgid "INTEF"
 msgstr "INTEF"
 
 #. Author URI of the plugin
-#: exelearning.php:15
+#: exelearning.php:16
 msgid "https://exelearning.net/"
 msgstr "https://exelearning.net/"
 

--- a/languages/exelearning-ro_RO.po
+++ b/languages/exelearning-ro_RO.po
@@ -33,12 +33,12 @@ msgid "Plugin to support eXeLearning .elpx files in WordPress. Upload, manage an
 msgstr "Plugin pentru gestionarea fișierelor .elpx eXeLearning în WordPress. Încărcați, gestionați și încorporați conținut eXeLearning."
 
 #. Author of the plugin
-#: exelearning.php:14
+#: exelearning.php:15
 msgid "INTEF"
 msgstr "INTEF"
 
 #. Author URI of the plugin
-#: exelearning.php:15
+#: exelearning.php:16
 msgid "https://exelearning.net/"
 msgstr "https://exelearning.net/"
 

--- a/languages/exelearning.pot
+++ b/languages/exelearning.pot
@@ -32,12 +32,12 @@ msgid "Plugin to support eXeLearning .elpx files in WordPress. Upload, manage an
 msgstr ""
 
 #. Author of the plugin
-#: exelearning.php:14
+#: exelearning.php:15
 msgid "INTEF"
 msgstr ""
 
 #. Author URI of the plugin
-#: exelearning.php:15
+#: exelearning.php:16
 msgid "https://exelearning.net/"
 msgstr ""
 

--- a/tests/unit/ActivatorDeactivatorTest.php
+++ b/tests/unit/ActivatorDeactivatorTest.php
@@ -29,14 +29,6 @@ class ActivatorDeactivatorTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test Activator activate can be called.
-	 */
-	public function test_activator_activate_callable() {
-		ExeLearning_Activator::activate();
-		$this->assertTrue( true );
-	}
-
-	/**
 	 * Test Deactivator deactivate method exists.
 	 */
 	public function test_deactivator_deactivate_exists() {
@@ -49,13 +41,5 @@ class ActivatorDeactivatorTest extends WP_UnitTestCase {
 	public function test_deactivator_deactivate_is_static() {
 		$method = new ReflectionMethod( ExeLearning_Deactivator::class, 'deactivate' );
 		$this->assertTrue( $method->isStatic() );
-	}
-
-	/**
-	 * Test Deactivator deactivate can be called.
-	 */
-	public function test_deactivator_deactivate_callable() {
-		ExeLearning_Deactivator::deactivate();
-		$this->assertTrue( true );
 	}
 }

--- a/tests/unit/AdminSettingsScreenTest.php
+++ b/tests/unit/AdminSettingsScreenTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Tests for the screen-scoped behaviour of ExeLearning_Admin_Settings.
+ *
+ * AdminSettingsTest covers the option registration and the rendered markup.
+ * This file covers the parts that only run once WordPress has loaded the
+ * settings screen: the contextual help, the screen-scoped assets, and the
+ * notice that explains a missing editor bundle.
+ *
+ * @package Exelearning
+ */
+
+/**
+ * Class AdminSettingsScreenTest.
+ *
+ * @covers ExeLearning_Admin_Settings
+ */
+class AdminSettingsScreenTest extends WP_UnitTestCase {
+
+	/**
+	 * Test instance.
+	 *
+	 * @var ExeLearning_Admin_Settings
+	 */
+	private $settings;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		require_once ABSPATH . 'wp-admin/includes/admin.php';
+
+		$this->settings                = new ExeLearning_Admin_Settings();
+		$GLOBALS['wp_settings_errors'] = array();
+		$_GET                          = array();
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tear_down() {
+		$GLOBALS['wp_settings_errors'] = array();
+		$_GET                          = array();
+		wp_dequeue_style( 'exelearning-settings' );
+		wp_dequeue_script( 'exelearning-settings' );
+		parent::tear_down();
+	}
+
+	/**
+	 * The screen gets a contextual Help tab pointing at the shortcode, plus a
+	 * sidebar linking the reference docs.
+	 */
+	public function test_the_settings_screen_gets_contextual_help() {
+		set_current_screen( 'settings_page_' . ExeLearning_Admin_Settings::PAGE_SLUG );
+
+		$this->settings->on_settings_page_load();
+		$screen = get_current_screen();
+
+		$tab = $screen->get_help_tab( 'exelearning-overview' );
+		$this->assertIsArray( $tab, 'The overview help tab must be registered.' );
+		$this->assertStringContainsString( '[exelearning id="123"]', $tab['content'] );
+
+		$this->assertStringContainsString( 'docs/SHORTCODES.md', $screen->get_help_sidebar() );
+		$this->assertStringContainsString( 'docs/HOOKS.md', $screen->get_help_sidebar() );
+	}
+
+	/**
+	 * Nothing is announced on a plain visit to the settings screen.
+	 */
+	public function test_no_notice_is_raised_without_the_redirect_marker() {
+		set_current_screen( 'settings_page_' . ExeLearning_Admin_Settings::PAGE_SLUG );
+
+		$this->settings->on_settings_page_load();
+
+		$this->assertSame( array(), get_settings_errors( 'exelearning_editor' ) );
+	}
+
+	/**
+	 * The editor bootstrap redirects here with `editor-missing=1` when the
+	 * bundle is absent. The notice is raised only when that is really the case,
+	 * so the marker cannot be used to fake a warning on a healthy install.
+	 */
+	public function test_the_editor_missing_notice_tracks_the_actual_bundle() {
+		set_current_screen( 'settings_page_' . ExeLearning_Admin_Settings::PAGE_SLUG );
+		$_GET['editor-missing'] = '1';
+
+		$this->settings->on_settings_page_load();
+		$notices = get_settings_errors( 'exelearning_editor' );
+
+		if ( ExeLearning_Editor_Bundle::is_available() ) {
+			$this->assertSame( array(), $notices, 'A bundled editor must not be reported as missing.' );
+			return;
+		}
+
+		$this->assertCount( 1, $notices );
+		$this->assertSame( 'exelearning_editor_missing', $notices[0]['code'] );
+		$this->assertSame( 'warning', $notices[0]['type'] );
+		$this->assertStringContainsString( 'make build-editor', $notices[0]['message'] );
+	}
+
+	/**
+	 * A value other than "1" in the marker is ignored.
+	 */
+	public function test_an_unexpected_marker_value_is_ignored() {
+		set_current_screen( 'settings_page_' . ExeLearning_Admin_Settings::PAGE_SLUG );
+		$_GET['editor-missing'] = 'yes';
+
+		$this->settings->on_settings_page_load();
+
+		$this->assertSame( array(), get_settings_errors( 'exelearning_editor' ) );
+	}
+
+	/**
+	 * The settings assets load on the plugin's own screen only.
+	 */
+	public function test_assets_are_enqueued_on_the_settings_screen_only() {
+		$hook = $this->register_menu();
+
+		$this->settings->enqueue_assets( 'index.php' );
+		$this->assertFalse( wp_style_is( 'exelearning-settings', 'enqueued' ) );
+		$this->assertFalse( wp_script_is( 'exelearning-settings', 'enqueued' ) );
+
+		$this->settings->enqueue_assets( $hook );
+		$this->assertTrue( wp_style_is( 'exelearning-settings', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'exelearning-settings', 'enqueued' ) );
+	}
+
+	/**
+	 * Registering the menu also wires the screen-load callback, which is what
+	 * scopes the help tab and the notice to this screen.
+	 */
+	public function test_registering_the_menu_hooks_the_screen_load_callback() {
+		$hook = $this->register_menu();
+
+		$this->assertStringEndsWith( '_page_' . ExeLearning_Admin_Settings::PAGE_SLUG, $hook );
+		$this->assertSame(
+			10,
+			has_action( 'load-' . $hook, array( $this->settings, 'on_settings_page_load' ) )
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// Helpers.
+	// ------------------------------------------------------------------
+
+	/**
+	 * Register the options page and return its hook suffix.
+	 *
+	 * @return string Hook suffix.
+	 */
+	private function register_menu() {
+		$this->settings->add_admin_menu();
+
+		$property = new ReflectionProperty( ExeLearning_Admin_Settings::class, 'hook_suffix' );
+		$property->setAccessible( true );
+
+		return $property->getValue( $this->settings );
+	}
+}

--- a/tests/unit/AdminStylesTest.php
+++ b/tests/unit/AdminStylesTest.php
@@ -268,4 +268,33 @@ class AdminStylesTest extends WP_UnitTestCase {
 	public function wp_die_handler( $message, $title = '', $args = array() ) {
 		throw new WPDieException( is_scalar( $message ) ? (string) $message : '' );
 	}
+
+	/**
+	 * A temp path that did not arrive through a real upload is refused: the
+	 * handler must never read an arbitrary server path chosen by the request.
+	 */
+	public function test_upload_refuses_a_file_that_was_not_uploaded() {
+		$this->setup_admin_for( ExeLearning_Admin_Styles::ACTION_UPLOAD );
+
+		$planted = wp_tempnam( 'planted.zip' );
+		file_put_contents( $planted, 'PK' ); // phpcs:ignore
+
+		$_FILES['style_zip'] = array(
+			'error'    => UPLOAD_ERR_OK,
+			'name'     => 'planted.zip',
+			'size'     => 2,
+			'tmp_name' => $planted,
+		);
+
+		$this->run_handler_expecting_redirect(
+			function () {
+				$this->handler->handle_upload();
+			}
+		);
+
+		wp_delete_file( $planted );
+		$this->assertSame( 'error', $this->get_persisted_notice()['type'] );
+		$this->assertSame( array(), ExeLearning_Styles_Service::get_registry()['uploaded'] );
+	}
+
 }

--- a/tests/unit/ContentProxyServeTest.php
+++ b/tests/unit/ContentProxyServeTest.php
@@ -1,0 +1,383 @@
+<?php
+/**
+ * Tests for the delivery half of ExeLearning_Content_Proxy.
+ *
+ * ContentProxyTest covers validation and URL rewriting in isolation. This file
+ * exercises the code that actually answers a request: reading the file from the
+ * extraction directory, rewriting its references and writing the body.
+ *
+ * serve_content() ends in exit(), so the tests drive the private serve_file()
+ * seam it delegates to. The response headers themselves cannot be asserted: the
+ * CLI runner has already flushed WordPress' bootstrap banner, so every header()
+ * call is a no-op that neither headers_list() nor xdebug_get_headers() records.
+ *
+ * @package Exelearning
+ */
+
+/**
+ * Class ContentProxyServeTest.
+ *
+ * @covers ExeLearning_Content_Proxy
+ */
+class ContentProxyServeTest extends WP_UnitTestCase {
+
+	/**
+	 * Test instance.
+	 *
+	 * @var ExeLearning_Content_Proxy
+	 */
+	private $proxy;
+
+	/**
+	 * Extraction hash used by the fixture package.
+	 *
+	 * @var string
+	 */
+	private $hash;
+
+	/**
+	 * Absolute path of the fixture extraction directory.
+	 *
+	 * @var string
+	 */
+	private $dir;
+
+	/**
+	 * Warnings raised while a proxy method was running, other than the
+	 * unavoidable "headers already sent" notice from the CLI runner.
+	 *
+	 * @var string[]
+	 */
+	private $unexpected_errors = array();
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->proxy = new ExeLearning_Content_Proxy();
+		$this->hash  = sha1( 'content-proxy-serve-' . wp_rand() );
+
+		$upload_dir = wp_upload_dir();
+		$this->dir  = trailingslashit( $upload_dir['basedir'] ) . 'exelearning/' . $this->hash;
+
+		wp_mkdir_p( $this->dir . '/css' );
+		wp_mkdir_p( $this->dir . '/images' );
+
+		delete_option( ExeLearning_Content_Proxy::OPTION_PROXY_ASSETS );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tear_down() {
+		$this->recursive_delete( $this->dir );
+		parent::tear_down();
+	}
+
+	/**
+	 * An HTML document is served with its references rewritten: sibling pages
+	 * go through the proxy, plain assets are linked straight from uploads.
+	 */
+	public function test_serve_file_rewrites_html_references() {
+		$this->write(
+			'index.html',
+			'<html><head><link href="css/style.css" rel="stylesheet"></head>'
+			. '<body><a href="page2.html">Next</a><img src="images/logo.png"></body></html>'
+		);
+
+		$output = $this->serve( 'index.html' );
+
+		$this->assertStringContainsString(
+			ExeLearning_Content_Proxy::get_proxy_url( $this->hash, 'page2.html' ),
+			$output,
+			'Sibling HTML pages must stay behind the proxy.'
+		);
+		$this->assertStringContainsString(
+			ExeLearning_Content_Proxy::get_uploads_url( $this->hash, 'images/logo.png' ),
+			$output,
+			'Images must be linked directly from the uploads directory.'
+		);
+		$this->assertStringContainsString(
+			ExeLearning_Content_Proxy::get_uploads_url( $this->hash, 'css/style.css' ),
+			$output
+		);
+	}
+
+	/**
+	 * A stylesheet's url() references are resolved against the directory the
+	 * stylesheet lives in, not against the package root.
+	 */
+	public function test_serve_file_resolves_css_urls_against_the_stylesheet_directory() {
+		$this->write( 'css/style.css', 'body{background:url(../images/bg.png)}.i{background:url("icon.svg")}' );
+
+		$output = $this->serve( 'css/style.css' );
+
+		$this->assertStringContainsString(
+			ExeLearning_Content_Proxy::get_uploads_url( $this->hash, 'images/bg.png' ),
+			$output,
+			'../ in a url() must resolve relative to the stylesheet.'
+		);
+		$this->assertStringContainsString(
+			ExeLearning_Content_Proxy::get_proxy_url( $this->hash, 'css/icon.svg' ),
+			$output,
+			'SVG is script-capable and must be routed through the proxy.'
+		);
+	}
+
+	/**
+	 * Absolute and external url() references in CSS are left untouched.
+	 */
+	public function test_serve_file_leaves_absolute_css_urls_alone() {
+		$css = '.a{background:url(/root.png)}.b{background:url(https://cdn.example.com/x.png)}';
+		$this->write( 'css/absolute.css', $css );
+
+		$this->assertSame( $css, $this->serve( 'css/absolute.css' ) );
+	}
+
+	/**
+	 * Files that are neither HTML nor CSS are streamed byte for byte.
+	 */
+	public function test_serve_file_streams_other_assets_verbatim() {
+		$bytes = "\x89PNG\r\n\x1a\n" . random_bytes( 64 );
+		$this->write( 'images/logo.png', $bytes );
+
+		$this->assertSame( $bytes, $this->serve( 'images/logo.png' ) );
+	}
+
+	/**
+	 * A symlink that resolves outside the extraction directory is refused even
+	 * though the path itself contains no traversal.
+	 */
+	public function test_symlink_escaping_the_extraction_directory_is_denied() {
+		$outside = wp_upload_dir()['basedir'] . '/outside-' . wp_rand() . '.html';
+		file_put_contents( $outside, 'secret' ); // phpcs:ignore
+		symlink( $outside, $this->dir . '/escape.html' );
+
+		$method = new ReflectionMethod( ExeLearning_Content_Proxy::class, 'validate_file_path' );
+		$method->setAccessible( true );
+		$result = $method->invoke( $this->proxy, 'escape.html', $this->hash );
+
+		wp_delete_file( $outside );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'access_denied', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * A file that really lives inside the extraction directory resolves to its
+	 * sanitized path and absolute location.
+	 */
+	public function test_validate_file_path_resolves_a_file_inside_the_extraction_dir() {
+		$this->write( 'css/style.css', 'body{}' );
+
+		$method = new ReflectionMethod( ExeLearning_Content_Proxy::class, 'validate_file_path' );
+		$method->setAccessible( true );
+		$result = $method->invoke( $this->proxy, './css//style.css', $this->hash );
+
+		$this->assertSame(
+			array(
+				'file'      => 'css/style.css',
+				'full_path' => $this->dir . '/css/style.css',
+			),
+			$result
+		);
+	}
+
+	/**
+	 * The site origin used for frame-ancestors is derived from home_url(),
+	 * including the port when the site runs on a non-default one.
+	 */
+	public function test_site_origin_includes_the_port() {
+		$method = new ReflectionMethod( ExeLearning_Content_Proxy::class, 'site_origin' );
+		$method->setAccessible( true );
+
+		$home = static function () {
+			return 'https://example.org:8443/blog';
+		};
+		add_filter( 'home_url', $home );
+		$origin = $method->invoke( null );
+		remove_filter( 'home_url', $home );
+
+		$this->assertSame( 'https://example.org:8443', $origin );
+	}
+
+	// ------------------------------------------------------------------
+	// Helpers.
+	// ------------------------------------------------------------------
+
+	/**
+	 * Write a file into the fixture extraction directory.
+	 *
+	 * @param string $relative Path relative to the extraction directory.
+	 * @param string $contents File contents.
+	 */
+	private function write( $relative, $contents ) {
+		file_put_contents( $this->dir . '/' . $relative, $contents ); // phpcs:ignore
+	}
+
+	/**
+	 * Run the proxy's private serve_file() and capture what it writes.
+	 *
+	 * The proxy calls header(), which the CLI test runner cannot honour once
+	 * WordPress' bootstrap has printed its banner. That single warning is
+	 * swallowed; anything else is recorded and fails the test.
+	 *
+	 * @param string $file Path relative to the extraction directory.
+	 * @return string Response body.
+	 */
+	private function serve( $file ) {
+		$method = new ReflectionMethod( ExeLearning_Content_Proxy::class, 'serve_file' );
+		$method->setAccessible( true );
+
+		$this->unexpected_errors = array();
+		set_error_handler( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_set_error_handler
+			function ( $errno, $errstr ) {
+				if ( false === strpos( $errstr, 'Cannot modify header information' ) ) {
+					$this->unexpected_errors[] = $errstr;
+				}
+				return true;
+			}
+		);
+
+		ob_start();
+		try {
+			$method->invoke( $this->proxy, $this->dir . '/' . $file, $file, $this->hash );
+			$output = ob_get_clean();
+		} catch ( Throwable $e ) {
+			ob_end_clean();
+			restore_error_handler();
+			throw $e;
+		}
+		restore_error_handler();
+
+		$this->assertSame( array(), $this->unexpected_errors, 'The proxy raised an unexpected PHP warning.' );
+
+		return $output;
+	}
+
+	/**
+	 * Scheme://host[:port] of the test site.
+	 *
+	 * @return string
+	 */
+	private function site_origin() {
+		$parts  = wp_parse_url( home_url() );
+		$origin = $parts['scheme'] . '://' . $parts['host'];
+		return empty( $parts['port'] ) ? $origin : $origin . ':' . $parts['port'];
+	}
+
+	/**
+	 * Recursively remove a directory tree.
+	 *
+	 * @param string $dir Directory path.
+	 */
+	private function recursive_delete( $dir ) {
+		if ( ! is_dir( $dir ) ) {
+			return;
+		}
+		foreach ( array_diff( scandir( $dir ), array( '.', '..' ) ) as $entry ) {
+			$path = $dir . '/' . $entry;
+			if ( is_dir( $path ) && ! is_link( $path ) ) {
+				$this->recursive_delete( $path );
+			} else {
+				wp_delete_file( $path );
+			}
+		}
+		rmdir( $dir ); // phpcs:ignore
+	}
+
+	/**
+	 * SVG is streamed as-is: it is served as an image, never rewritten as a
+	 * document, so nothing inside it is turned into a same-origin URL.
+	 */
+	public function test_serve_file_streams_svg_verbatim() {
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg"><image href="images/logo.png"/></svg>';
+		$this->write( 'images/icon.svg', $svg );
+
+		$this->assertSame( $svg, $this->serve( 'images/icon.svg' ) );
+	}
+
+	/**
+	 * A stylesheet at the package root resolves its references against the
+	 * root, not against a phantom "." directory.
+	 */
+	public function test_serve_file_resolves_root_level_css_urls() {
+		$this->write( 'main.css', 'body{background:url(images/bg.png)}' );
+
+		$output = $this->serve( 'main.css' );
+
+		$this->assertStringContainsString(
+			ExeLearning_Content_Proxy::get_uploads_url( $this->hash, 'images/bg.png' ),
+			$output
+		);
+	}
+
+	/**
+	 * Absolute url() references inside an inline style attribute are left
+	 * alone, like every other absolute reference.
+	 */
+	public function test_serve_file_leaves_absolute_inline_style_urls_alone() {
+		$html = '<div style="background:url(/theme/bg.png)"></div>';
+		$this->write( 'index.html', $html );
+
+		$this->assertSame( $html, $this->serve( 'index.html' ) );
+	}
+
+	/**
+	 * A home_url() without a usable scheme and host yields no site origin, so
+	 * no malformed value can end up in a framing policy.
+	 */
+	public function test_site_origin_is_empty_for_an_unusable_home_url() {
+		$method = new ReflectionMethod( ExeLearning_Content_Proxy::class, 'site_origin' );
+		$method->setAccessible( true );
+
+		$home = static function () {
+			return 'not a url';
+		};
+		add_filter( 'home_url', $home );
+		$origin = $method->invoke( null );
+		remove_filter( 'home_url', $home );
+
+		$this->assertSame( '', $origin );
+	}
+
+	/**
+	 * A stale-hash redirect carries the original query string forward, so a
+	 * deep link keeps its parameters, but never the plain-permalink routing
+	 * argument nor a parameter with no value to re-encode.
+	 */
+	public function test_a_redirect_preserves_only_meaningful_query_arguments() {
+		$method = new ReflectionMethod( ExeLearning_Content_Proxy::class, 'add_preserved_query_args' );
+		$method->setAccessible( true );
+
+		$request = new WP_REST_Request( 'GET', '/exelearning/v1/content/x/index.html' );
+		$request->set_query_params(
+			array(
+				'exe-teacher' => '1',
+				'rest_route'  => '/exelearning/v1/content/x/index.html',
+			)
+		);
+		$this->assertSame(
+			'https://example.org/page.html?exe-teacher=1',
+			$method->invoke( $this->proxy, 'https://example.org/page.html', $request )
+		);
+
+		$empty = new WP_REST_Request( 'GET', '/exelearning/v1/content/x/index.html' );
+		$empty->set_query_params( array( 'rest_route' => '/x' ) );
+		$this->assertSame(
+			'https://example.org/page.html',
+			$method->invoke( $this->proxy, 'https://example.org/page.html', $empty )
+		);
+
+		$blank = new WP_REST_Request( 'GET', '/exelearning/v1/content/x/index.html' );
+		$blank->set_query_params( array( 'nothing' => null ) );
+		$this->assertSame(
+			'https://example.org/page.html',
+			$method->invoke( $this->proxy, 'https://example.org/page.html', $blank )
+		);
+	}
+
+}

--- a/tests/unit/DownloadButtonRendererTest.php
+++ b/tests/unit/DownloadButtonRendererTest.php
@@ -117,4 +117,51 @@ class DownloadButtonRendererTest extends WP_UnitTestCase {
 		// export bootstrap endpoint against home_url() rather than the origin root.
 		$this->assertStringContainsString( 'exportBase', $data );
 	}
+
+	/**
+	 * A title with nothing sluggable still produces a usable download name.
+	 */
+	public function test_render_falls_back_to_an_id_based_slug() {
+		$attachment_id = $this->factory->attachment->create(
+			array(
+				'post_title'     => '###',
+				'post_mime_type' => 'application/zip',
+			)
+		);
+
+		$html = ExeLearning_Download_Button_Renderer::render( $attachment_id, array( 'elpx' ) );
+
+		$this->assertStringContainsString( 'data-slug="exelearning-' . $attachment_id . '"', $html );
+	}
+
+	/**
+	 * The extension is dropped from the download name, so the client-side
+	 * exporter can append its own.
+	 */
+	public function test_render_strips_the_extension_from_the_slug() {
+		$attachment_id = $this->factory->attachment->create(
+			array(
+				'post_title'     => 'My Course.elpx',
+				'post_mime_type' => 'application/zip',
+			)
+		);
+
+		$html = ExeLearning_Download_Button_Renderer::render( $attachment_id, array( 'elpx' ) );
+
+		$this->assertStringContainsString( 'data-slug="my-course"', $html );
+	}
+
+	/**
+	 * An id with no matching format definition is skipped rather than
+	 * rendered as an empty entry.
+	 */
+	public function test_unknown_format_ids_are_skipped() {
+		$method = new ReflectionMethod( ExeLearning_Download_Button_Renderer::class, 'build_items' );
+		$method->setAccessible( true );
+
+		$items = $method->invoke( null, array( 'elpx', 'no-such-format' ), true );
+
+		$this->assertSame( array( 'elpx' ), wp_list_pluck( $items, 'id' ) );
+	}
+
 }

--- a/tests/unit/EditorPageTest.php
+++ b/tests/unit/EditorPageTest.php
@@ -131,11 +131,11 @@ class EditorPageTest extends WP_UnitTestCase {
 	public function test_no_early_renderer_is_scheduled_outside_the_editor_page() {
 		$_GET = array( 'page' => 'some-other-page' );
 
-		$level = ob_get_level();
-		new ExeLearning_Editor();
+		$level  = ob_get_level();
+		$editor = new ExeLearning_Editor();
 
 		$this->assertSame( $level, ob_get_level() );
-		$this->assertFalse( has_action( 'admin_init', array( $this->editor, 'render_editor_page_and_exit' ) ) );
+		$this->assertFalse( has_action( 'admin_init', array( $editor, 'render_editor_page_and_exit' ) ) );
 	}
 
 	/**
@@ -144,17 +144,18 @@ class EditorPageTest extends WP_UnitTestCase {
 	 * of admin_init, so stray notices cannot corrupt the standalone HTML.
 	 */
 	public function test_the_editor_page_is_rendered_ahead_of_admin_init() {
-		$_GET                 = array( 'page' => 'exelearning-editor' );
-		$reporting            = error_reporting(); // phpcs:ignore
-		$level                = ob_get_level();
-		$editor               = new ExeLearning_Editor();
-		$level_after_boot     = ob_get_level();
-		$scheduled_at         = has_action( 'admin_init', array( $editor, 'render_editor_page_and_exit' ) );
-		$displays_errors_flag = ini_get( 'display_errors' );
+		$_GET           = array( 'page' => 'exelearning-editor' );
+		$reporting      = error_reporting(); // phpcs:ignore
+		$display_errors = ini_get( 'display_errors' );
+		$level          = ob_get_level();
+
+		$editor           = new ExeLearning_Editor();
+		$level_after_boot = ob_get_level();
+		$scheduled_at     = has_action( 'admin_init', array( $editor, 'render_editor_page_and_exit' ) );
 
 		ob_end_clean();
 		error_reporting( $reporting ); // phpcs:ignore
-		ini_set( 'display_errors', $displays_errors_flag ? $displays_errors_flag : '0' ); // phpcs:ignore
+		ini_set( 'display_errors', $display_errors ); // phpcs:ignore
 
 		$this->assertSame( $level + 1, $level_after_boot, 'Output must be captured from the very start.' );
 		$this->assertSame( -999, $scheduled_at );

--- a/tests/unit/EditorPageTest.php
+++ b/tests/unit/EditorPageTest.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * Tests for the standalone editor screen served by ExeLearning_Editor.
+ *
+ * render_editor_page() is a front controller: it authenticates the request and
+ * then include()s the bootstrap template and exits. The template itself cannot
+ * run under PHPUnit (it tears down every output buffer and exits), so these
+ * tests cover the guards that decide whether the request ever gets that far.
+ * wp_die() is routed to WPDieException by the WordPress test suite.
+ *
+ * @package Exelearning
+ */
+
+/**
+ * Class EditorPageTest.
+ *
+ * @covers ExeLearning_Editor
+ */
+class EditorPageTest extends WP_UnitTestCase {
+
+	/**
+	 * Test instance.
+	 *
+	 * @var ExeLearning_Editor
+	 */
+	private $editor;
+
+	/**
+	 * Attachment file paths to remove on tear down.
+	 *
+	 * @var string[]
+	 */
+	private $cleanup_paths = array();
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->editor        = new ExeLearning_Editor();
+		$this->cleanup_paths = array();
+		$_GET                = array();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tear_down() {
+		$_GET = array();
+		foreach ( $this->cleanup_paths as $path ) {
+			if ( file_exists( $path ) ) {
+				wp_delete_file( $path );
+			}
+		}
+		parent::tear_down();
+	}
+
+	/**
+	 * A request without a valid nonce is refused before anything else is read.
+	 */
+	public function test_a_missing_nonce_is_refused() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->assertDiesWith( esc_html__( 'Security check failed.', 'exelearning' ) );
+	}
+
+	/**
+	 * A forged nonce is refused just like a missing one.
+	 */
+	public function test_a_forged_nonce_is_refused() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$_GET['_wpnonce'] = 'not-a-nonce';
+
+		$this->assertDiesWith( esc_html__( 'Security check failed.', 'exelearning' ) );
+	}
+
+	/**
+	 * A nonce alone is not enough: the user still needs upload_files.
+	 */
+	public function test_a_user_without_upload_files_is_refused() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'subscriber' ) ) );
+		$_GET['_wpnonce'] = wp_create_nonce( 'exelearning_editor' );
+
+		$this->assertDiesWith( esc_html__( 'You do not have permission to access this page.', 'exelearning' ) );
+	}
+
+	/**
+	 * The editor cannot open without an attachment to edit.
+	 */
+	public function test_a_request_without_an_attachment_is_refused() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$_GET['_wpnonce'] = wp_create_nonce( 'exelearning_editor' );
+
+		$this->assertDiesWith( esc_html__( 'No attachment specified.', 'exelearning' ) );
+	}
+
+	/**
+	 * Only .elpx attachments can be opened in the editor.
+	 */
+	public function test_a_non_elpx_attachment_is_refused() {
+		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		$_GET['_wpnonce']      = wp_create_nonce( 'exelearning_editor' );
+		$_GET['attachment_id'] = $this->make_attachment( $user_id, 'jpg' );
+
+		$this->assertDiesWith( esc_html__( 'This file is not an eXeLearning file (.elpx).', 'exelearning' ) );
+	}
+
+	/**
+	 * A user who may upload files still cannot open somebody else's private
+	 * attachment for editing.
+	 */
+	public function test_a_user_without_edit_rights_on_the_attachment_is_refused() {
+		$owner  = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$intern = $this->factory->user->create( array( 'role' => 'author' ) );
+
+		$attachment_id = $this->make_attachment( $owner, 'elpx' );
+
+		wp_set_current_user( $intern );
+		$_GET['_wpnonce']      = wp_create_nonce( 'exelearning_editor' );
+		$_GET['attachment_id'] = $attachment_id;
+
+		$this->assertDiesWith( esc_html__( 'You do not have permission to edit this file.', 'exelearning' ) );
+	}
+
+	/**
+	 * Loading any other admin screen leaves the request untouched: no buffer is
+	 * opened and no early renderer is scheduled.
+	 */
+	public function test_no_early_renderer_is_scheduled_outside_the_editor_page() {
+		$_GET = array( 'page' => 'some-other-page' );
+
+		$level = ob_get_level();
+		new ExeLearning_Editor();
+
+		$this->assertSame( $level, ob_get_level() );
+		$this->assertFalse( has_action( 'admin_init', array( $this->editor, 'render_editor_page_and_exit' ) ) );
+	}
+
+	/**
+	 * On the editor page the constructor takes over the request: it buffers
+	 * everything WordPress prints and schedules the renderer ahead of the rest
+	 * of admin_init, so stray notices cannot corrupt the standalone HTML.
+	 */
+	public function test_the_editor_page_is_rendered_ahead_of_admin_init() {
+		$_GET                 = array( 'page' => 'exelearning-editor' );
+		$reporting            = error_reporting(); // phpcs:ignore
+		$level                = ob_get_level();
+		$editor               = new ExeLearning_Editor();
+		$level_after_boot     = ob_get_level();
+		$scheduled_at         = has_action( 'admin_init', array( $editor, 'render_editor_page_and_exit' ) );
+		$displays_errors_flag = ini_get( 'display_errors' );
+
+		ob_end_clean();
+		error_reporting( $reporting ); // phpcs:ignore
+		ini_set( 'display_errors', $displays_errors_flag ? $displays_errors_flag : '0' ); // phpcs:ignore
+
+		$this->assertSame( $level + 1, $level_after_boot, 'Output must be captured from the very start.' );
+		$this->assertSame( -999, $scheduled_at );
+		$this->assertSame( $level, ob_get_level() );
+	}
+
+	/**
+	 * render_editor_page_and_exit() throws away every buffered byte before
+	 * handing over to the page renderer, so no stray notice can survive into
+	 * the standalone HTML document.
+	 *
+	 * The method unwinds output buffering completely — including the runner's
+	 * own buffer — so the test restores it afterwards.
+	 */
+	public function test_buffered_output_is_discarded_before_rendering() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		ob_start();
+		echo 'Notice: something noisy';
+
+		$message = null;
+		try {
+			$this->editor->render_editor_page_and_exit();
+		} catch ( WPDieException $e ) {
+			$message = $e->getMessage();
+		}
+
+		$remaining = ob_get_level();
+		ob_start();
+
+		$this->assertSame( 0, $remaining, 'Every output buffer must be discarded.' );
+		// The nonce guard is what stops the request; the point is that it was
+		// reached with a clean slate.
+		$this->assertSame( esc_html__( 'Security check failed.', 'exelearning' ), $message );
+	}
+
+	// ------------------------------------------------------------------
+	// Helpers.
+	// ------------------------------------------------------------------
+
+	/**
+	 * Create an attachment backed by a file with the given extension.
+	 *
+	 * @param int    $author_id Attachment author.
+	 * @param string $extension File extension without the dot.
+	 * @return int Attachment ID.
+	 */
+	private function make_attachment( $author_id, $extension ) {
+		$attachment_id = $this->factory->attachment->create( array( 'post_author' => $author_id ) );
+
+		$upload_dir = wp_upload_dir();
+		$path       = trailingslashit( $upload_dir['basedir'] ) . 'editor-page-' . $attachment_id . '.' . $extension;
+		file_put_contents( $path, 'fixture' ); // phpcs:ignore
+		update_attached_file( $attachment_id, $path );
+		$this->cleanup_paths[] = $path;
+
+		return $attachment_id;
+	}
+
+	/**
+	 * Assert that rendering the editor page stops the request with a message.
+	 *
+	 * render_editor_page() closes one output buffer on entry, so the assertion
+	 * opens one of its own for it to consume.
+	 *
+	 * @param string $expected Expected wp_die() message.
+	 */
+	private function assertDiesWith( $expected ) {
+		$level = ob_get_level();
+		ob_start();
+
+		try {
+			$this->editor->render_editor_page();
+			$this->fail( 'Expected the editor page to refuse the request.' );
+		} catch ( WPDieException $e ) {
+			$this->assertSame( $expected, $e->getMessage() );
+		} finally {
+			while ( ob_get_level() > $level ) {
+				ob_end_clean();
+			}
+		}
+	}
+}

--- a/tests/unit/EditorTest.php
+++ b/tests/unit/EditorTest.php
@@ -467,19 +467,74 @@ class EditorTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test register_editor_page registers hidden page.
+	 * The editor is a hidden page: it must be reachable at
+	 * admin.php?page=exelearning-editor but never appear in a menu.
+	 *
+	 * A hidden page is registered with an empty parent, so it lands in
+	 * $_registered_pages rather than in $submenu — that is what admin.php
+	 * checks before allowing the request through.
 	 */
-	public function test_register_editor_page_registers_page() {
-		global $submenu;
+	public function test_register_editor_page_registers_hidden_page() {
+		global $submenu, $_registered_pages;
 
 		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
 
+		$_registered_pages = array();
+		$submenu           = array();
+
 		$this->editor->register_editor_page();
 
-		// Since it's a hidden page with empty parent, check the menu structure.
-		// The page should be accessible via admin.php?page=exelearning-editor.
-		$this->assertTrue( true ); // Page registered without error.
+		$this->assertArrayHasKey(
+			'admin_page_exelearning-editor',
+			$_registered_pages,
+			'The editor page must be registered so admin.php serves it.'
+		);
+
+		// A hidden page still gets a $submenu entry, but under the empty parent
+		// slug. Nothing is rendered from it because no top-level menu has an
+		// empty slug — that is precisely what keeps the page out of the sidebar.
+		// So the check is that it never attaches to a real parent menu.
+		foreach ( $submenu as $parent_slug => $items ) {
+			if ( '' === $parent_slug ) {
+				continue;
+			}
+
+			foreach ( $items as $item ) {
+				$this->assertNotSame(
+					'exelearning-editor',
+					$item[2] ?? null,
+					"The editor page must stay hidden, but it attached to the '{$parent_slug}' menu."
+				);
+			}
+		}
+
+		$this->assertContains(
+			'exelearning-editor',
+			wp_list_pluck( $submenu[''] ?? array(), 2 ),
+			'The hidden page must be registered under the empty parent slug.'
+		);
+	}
+
+	/**
+	 * The hidden page is gated on `upload_files`, the same capability that
+	 * governs the media library it edits from.
+	 */
+	public function test_register_editor_page_requires_upload_files() {
+		global $_registered_pages;
+
+		$user_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $user_id );
+
+		$_registered_pages = array();
+
+		$this->editor->register_editor_page();
+
+		$this->assertArrayNotHasKey(
+			'admin_page_exelearning-editor',
+			$_registered_pages,
+			'A user without upload_files must not get the editor page.'
+		);
 	}
 
 	/**

--- a/tests/unit/ElpFileServiceTest.php
+++ b/tests/unit/ElpFileServiceTest.php
@@ -537,4 +537,103 @@ class ElpFileServiceTest extends WP_UnitTestCase {
 
 		wp_delete_file( $zip_path );
 	}
+
+	/**
+	 * The uncompressed-size guard rejects an archive that would expand beyond
+	 * the configured budget, before anything is written to disk.
+	 */
+	public function test_extract_refuses_an_archive_over_the_size_budget() {
+		$destination = wp_tempnam( 'elp-too-large' );
+		wp_delete_file( $destination );
+
+		add_filter( 'exelearning_max_extract_bytes', '__return_zero' );
+		$result = $this->service->extract( self::$test_elp_v3, trailingslashit( $destination ) );
+		remove_filter( 'exelearning_max_extract_bytes', '__return_zero' );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'elp_too_large', $result->get_error_code() );
+		$this->assertSame( array(), glob( trailingslashit( $destination ) . '*' ) );
+
+		ExeLearning_Styles_Service::recursive_delete( $destination );
+	}
+
+	/**
+	 * A destination that cannot be created is reported instead of being
+	 * silently skipped.
+	 */
+	public function test_extract_reports_a_destination_it_cannot_create() {
+		// A regular file cannot have children, so mkdir below it always fails.
+		$blocker = wp_tempnam( 'elp-blocker' );
+
+		$result = $this->service->extract( self::$test_elp_v3, $blocker . '/dest/' );
+
+		wp_delete_file( $blocker );
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'elp_mkdir_failed', $result->get_error_code() );
+	}
+
+	/**
+	 * When a single entry cannot be written the whole extraction fails rather
+	 * than leaving a partial package behind.
+	 */
+	public function test_extract_fails_when_an_entry_cannot_be_written() {
+		$archive = wp_tempnam( 'nested.elpx' );
+		wp_delete_file( $archive );
+		$zip = new ZipArchive();
+		$zip->open( $archive, ZipArchive::CREATE );
+		$zip->addFromString( 'content.xml', '<package></package>' );
+		$zip->addFromString( 'assets/style.css', 'body{}' );
+		$zip->close();
+
+		$destination = wp_tempnam( 'elp-dest' );
+		wp_delete_file( $destination );
+		wp_mkdir_p( $destination );
+		// Occupy "assets" with a file so the directory entry cannot be created.
+		file_put_contents( $destination . '/assets', 'in the way' ); // phpcs:ignore
+
+		$result = $this->service->extract( $archive, trailingslashit( $destination ) );
+
+		wp_delete_file( $archive );
+		ExeLearning_Styles_Service::recursive_delete( $destination );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'elp_mkdir_failed', $result->get_error_code() );
+	}
+
+	/**
+	 * Directory entries are recreated as directories, without reading content.
+	 */
+	public function test_extract_entry_creates_directory_entries() {
+		$destination = wp_tempnam( 'elp-dir-entry' );
+		wp_delete_file( $destination );
+		wp_mkdir_p( $destination );
+
+		$method = new ReflectionMethod( ExeLearning_Elp_File_Service::class, 'extract_entry' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $this->service, new ZipArchive(), 0, 'media/', $destination );
+
+		$this->assertTrue( $result );
+		$this->assertDirectoryExists( $destination . '/media' );
+
+		ExeLearning_Styles_Service::recursive_delete( $destination );
+	}
+
+	/**
+	 * A file whose ZIP header is broken is reported as unopenable rather than
+	 * parsed as an empty project.
+	 */
+	public function test_parse_reports_an_unopenable_archive() {
+		$path = wp_tempnam( 'corrupt.elpx' );
+		// A valid ZIP magic number followed by garbage: sniffed as a ZIP, but
+		// ZipArchive cannot read its central directory.
+		file_put_contents( $path, "PK\x03\x04" . str_repeat( "\x00", 512 ) ); // phpcs:ignore
+
+		$result = $this->service->parse( $path );
+
+		wp_delete_file( $path );
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertContains( $result->get_error_code(), array( 'elp_open_failed', 'elp_not_zip' ) );
+	}
+
 }

--- a/tests/unit/ElpUploadBlockTest.php
+++ b/tests/unit/ElpUploadBlockTest.php
@@ -860,4 +860,27 @@ class ElpUploadBlockTest extends WP_UnitTestCase {
 		$GLOBALS['wp_scripts'] = null;
 		$GLOBALS['wp_styles']  = null;
 	}
+
+	/**
+	 * The block's downloadFormats attribute selects which formats the download
+	 * control offers, and unknown ids are dropped.
+	 */
+	public function test_render_block_honours_the_download_formats_attribute() {
+		$attachment_id = $this->factory->attachment->create();
+		update_post_meta( $attachment_id, '_exelearning_extracted', str_repeat( 'b', 40 ) );
+		update_post_meta( $attachment_id, '_exelearning_has_preview', '1' );
+
+		$result = $this->block->render_block(
+			array(
+				'attachmentId'    => $attachment_id,
+				'showDownload'    => true,
+				'downloadFormats' => array( 'html5', 'not-a-format' ),
+			)
+		);
+
+		$this->assertStringContainsString( 'data-format="html5"', $result );
+		$this->assertStringNotContainsString( 'data-format="scorm12"', $result );
+		$this->assertStringNotContainsString( 'not-a-format', $result );
+	}
+
 }

--- a/tests/unit/ElpUploadHandlerTest.php
+++ b/tests/unit/ElpUploadHandlerTest.php
@@ -157,32 +157,62 @@ class ElpUploadHandlerTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test exelearning_delete_extracted_folder does nothing without metadata.
+	 * Create a real extraction folder holding one file, and return its hash.
+	 *
+	 * Used as a bystander: deleting an unrelated attachment must leave it alone.
+	 *
+	 * @return array{0:string,1:string} The hash and the absolute folder path.
 	 */
-	public function test_delete_extracted_folder_no_metadata() {
-		$attachment_id = $this->factory->attachment->create();
+	private function create_extraction_folder() {
+		$hash       = str_repeat( 'a', 40 );
+		$upload_dir = wp_upload_dir();
+		$path       = trailingslashit( $upload_dir['basedir'] ) . 'exelearning/' . $hash . '/';
 
-		// This should not throw any errors.
-		$this->handler->exelearning_delete_extracted_folder( $attachment_id );
+		wp_mkdir_p( $path );
+		file_put_contents( $path . 'index.html', '<!doctype html>' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 
-		// Test passes if no exception is thrown.
-		$this->assertTrue( true );
+		return array( $hash, $path );
 	}
 
 	/**
-	 * Test exelearning_delete_extracted_folder does nothing for non-existent directory.
+	 * An attachment carrying no extraction hash has nothing to clean up, and
+	 * must not reach into the uploads directory and take somebody else's
+	 * extraction with it.
 	 */
-	public function test_delete_extracted_folder_nonexistent_dir() {
-		$attachment_id = $this->factory->attachment->create();
-		$hash          = str_repeat( 'f', 40 );
+	public function test_delete_extracted_folder_no_metadata() {
+		list( , $bystander ) = $this->create_extraction_folder();
+		$attachment_id       = $this->factory->attachment->create();
 
-		update_post_meta( $attachment_id, '_exelearning_extracted', $hash );
-
-		// This should not throw any errors even if directory doesn't exist.
 		$this->handler->exelearning_delete_extracted_folder( $attachment_id );
 
-		// Test passes if no exception is thrown.
-		$this->assertTrue( true );
+		$this->assertDirectoryExists( $bystander, 'An unrelated extraction was deleted.' );
+		$this->assertFileExists( $bystander . 'index.html' );
+	}
+
+	/**
+	 * A hash whose folder was already removed is a no-op: no error, and no
+	 * other extraction touched.
+	 */
+	public function test_delete_extracted_folder_nonexistent_dir() {
+		list( , $bystander ) = $this->create_extraction_folder();
+		$attachment_id       = $this->factory->attachment->create();
+		$missing_hash        = str_repeat( 'f', 40 );
+
+		update_post_meta( $attachment_id, '_exelearning_extracted', $missing_hash );
+
+		$upload_dir = wp_upload_dir();
+		$missing    = trailingslashit( $upload_dir['basedir'] ) . 'exelearning/' . $missing_hash . '/';
+		$this->assertDirectoryDoesNotExist( $missing, 'Precondition: the folder must be absent.' );
+
+		$this->handler->exelearning_delete_extracted_folder( $attachment_id );
+
+		$this->assertDirectoryDoesNotExist( $missing );
+		$this->assertDirectoryExists( $bystander, 'An unrelated extraction was deleted.' );
+		$this->assertSame(
+			$missing_hash,
+			get_post_meta( $attachment_id, '_exelearning_extracted', true ),
+			'The stored hash must survive a no-op delete.'
+		);
 	}
 
 	/**

--- a/tests/unit/ElpUploadHandlerTest.php
+++ b/tests/unit/ElpUploadHandlerTest.php
@@ -489,4 +489,98 @@ class ElpUploadHandlerTest extends WP_UnitTestCase {
 			unlink( $path );
 		}
 	}
+
+	/**
+	 * When extraction fails the upload is rejected, the stored file is removed
+	 * and no orphaned extraction directory is left behind.
+	 */
+	public function test_a_failed_extraction_rejects_the_upload_and_cleans_up() {
+		$upload_dir = wp_upload_dir();
+		$file       = trailingslashit( $upload_dir['basedir'] ) . 'failing-upload.elpx';
+
+		$zip = new ZipArchive();
+		$zip->open( $file, ZipArchive::CREATE );
+		$zip->addFromString( 'content.xml', '<package></package>' );
+		$zip->addFromString( 'index.html', '<html></html>' );
+		$zip->close();
+
+		$created = array();
+		add_action(
+			'exelearning_before_elpx_extract',
+			static function ( $source, $destination ) use ( &$created ) {
+				$created[] = $destination;
+			},
+			10,
+			2
+		);
+		// Force the zip-bomb guard to trip on a perfectly ordinary archive.
+		add_filter( 'exelearning_max_extract_bytes', '__return_zero' );
+
+		$result = $this->handler->process_elp_upload(
+			array(
+				'file' => $file,
+				'url'  => 'http://example.org/failing-upload.elpx',
+				'type' => 'application/zip',
+			)
+		);
+
+		remove_filter( 'exelearning_max_extract_bytes', '__return_zero' );
+
+		$this->assertArrayHasKey( 'error', $result );
+		$this->assertArrayNotHasKey( 'file', $result );
+		$this->assertFileDoesNotExist( $file, 'The rejected upload must not stay in the uploads directory.' );
+		$this->assertNotEmpty( $created );
+		$this->assertDirectoryDoesNotExist( $created[0] );
+	}
+
+	/**
+	 * Deleting a directory that is not there is a no-op.
+	 */
+	public function test_recursive_delete_ignores_a_missing_directory() {
+		$method = new ReflectionMethod( ExeLearning_Elp_Upload_Handler::class, 'exelearning_recursive_delete' );
+		$method->setAccessible( true );
+
+		$missing = wp_upload_dir()['basedir'] . '/never-created-' . wp_rand();
+		$method->invoke( $this->handler, $missing );
+
+		$this->assertDirectoryDoesNotExist( $missing );
+	}
+
+
+	/**
+	 * If the extraction directory cannot be created the upload is rejected and
+	 * the stored file is removed, rather than left behind unusable.
+	 */
+	public function test_an_unusable_uploads_directory_rejects_the_upload() {
+		$upload_dir = wp_upload_dir();
+		$file       = trailingslashit( $upload_dir['basedir'] ) . 'nowhere-to-extract.elpx';
+
+		$zip = new ZipArchive();
+		$zip->open( $file, ZipArchive::CREATE );
+		$zip->addFromString( 'content.xml', '<package></package>' );
+		$zip->close();
+
+		// A regular file cannot have children, so every mkdir below it fails.
+		$blocker = wp_tempnam( 'uploads-blocker' );
+		$broken  = static function ( $dirs ) use ( $blocker ) {
+			$dirs['basedir'] = $blocker . '/uploads';
+			return $dirs;
+		};
+		add_filter( 'upload_dir', $broken );
+
+		$result = $this->handler->process_elp_upload(
+			array(
+				'file' => $file,
+				'url'  => 'http://example.org/nowhere-to-extract.elpx',
+				'type' => 'application/zip',
+			)
+		);
+
+		remove_filter( 'upload_dir', $broken );
+		wp_delete_file( $blocker );
+
+		$this->assertArrayHasKey( 'error', $result );
+		$this->assertFileDoesNotExist( $file );
+	}
+
 }

--- a/tests/unit/ExeLearningTest.php
+++ b/tests/unit/ExeLearningTest.php
@@ -42,14 +42,6 @@ class ExeLearningTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test run method can be called.
-	 */
-	public function test_run_method_callable() {
-		$this->plugin->run();
-		$this->assertTrue( true );
-	}
-
-	/**
 	 * Read an instantiated component from the plugin's component registry.
 	 *
 	 * @param string $key Component key.

--- a/tests/unit/ExeLearningTest.php
+++ b/tests/unit/ExeLearningTest.php
@@ -164,4 +164,24 @@ class ExeLearningTest extends WP_UnitTestCase {
 			'The text domain loader must not be hooked on plugins_loaded.'
 		);
 	}
+
+	/**
+	 * The style-management admin-post endpoints are only wired up in the admin,
+	 * where their forms live; a front-end request does not load them.
+	 */
+	public function test_admin_styles_component_is_admin_only() {
+		$this->assertNull( $this->get_component( 'admin_styles' ) );
+
+		set_current_screen( 'upload.php' );
+		$admin_plugin = new ExeLearning();
+
+		$property = new ReflectionProperty( ExeLearning::class, 'components' );
+		$property->setAccessible( true );
+		$components = $property->getValue( $admin_plugin );
+
+		set_current_screen( 'front' );
+
+		$this->assertInstanceOf( ExeLearning_Admin_Styles::class, $components['admin_styles'] );
+	}
+
 }

--- a/tests/unit/ExportBootstrapPayloadTest.php
+++ b/tests/unit/ExportBootstrapPayloadTest.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Tests for the HTML ExeLearning_Export_Bootstrap hands to the browser.
+ *
+ * ExportBootstrapTest covers the request guards. This file covers what happens
+ * once a request is accepted: loading the bundled editor template and patching
+ * it so the export-only editor boots against this WordPress install.
+ *
+ * maybe_render() ends in exit() after tearing down output buffering, so the
+ * tests drive the private steps it composes.
+ *
+ * @package Exelearning
+ */
+
+/**
+ * Class ExportBootstrapPayloadTest.
+ *
+ * @covers ExeLearning_Export_Bootstrap
+ */
+class ExportBootstrapPayloadTest extends WP_UnitTestCase {
+
+	/**
+	 * Test instance.
+	 *
+	 * @var ExeLearning_Export_Bootstrap
+	 */
+	private $bootstrap;
+
+	/**
+	 * Absolute plugin URL of the bundled editor.
+	 *
+	 * @var string
+	 */
+	private $editor_base_url;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->bootstrap       = new ExeLearning_Export_Bootstrap();
+		$this->editor_base_url = EXELEARNING_PLUGIN_URL . 'dist/static';
+	}
+
+	/**
+	 * The export configuration is injected as valid JSON the editor can read.
+	 */
+	public function test_the_export_configuration_is_injected_as_json() {
+		$html = $this->inject( '<html><head><title>x</title></head><body></body></html>', 4242, 'https://example.org/f.elpx' );
+
+		$this->assertMatchesRegularExpression( '/window\.__WP_EXE_CONFIG__ = (\{.*?\});/s', $html );
+		preg_match( '/window\.__WP_EXE_CONFIG__ = (\{.*?\});/s', $html, $matches );
+		$config = json_decode( $matches[1], true );
+
+		$this->assertSame(
+			array(
+				'mode'          => 'WordPressExport',
+				'attachmentId'  => 4242,
+				'elpUrl'        => 'https://example.org/f.elpx',
+				'editorBaseUrl' => $this->editor_base_url,
+			),
+			$config
+		);
+		$this->assertStringContainsString( 'window.__EXE_EXPORT_MODE__ = true;', $html );
+	}
+
+	/**
+	 * The bridge script is loaded from the plugin, cache-busted by version.
+	 */
+	public function test_the_bridge_script_is_loaded_from_the_plugin() {
+		$html = $this->inject( '<html><head></head></html>' );
+
+		$this->assertStringContainsString(
+			esc_url( EXELEARNING_PLUGIN_URL . 'assets/js/wp-exe-bridge.js?ver=' . EXELEARNING_VERSION ),
+			$html
+		);
+	}
+
+	/**
+	 * Everything is inserted inside <head>, before the closing tag, so the
+	 * editor sees the configuration before its own bundles run.
+	 */
+	public function test_the_payload_is_inserted_inside_the_head() {
+		$html = $this->inject( '<html><head><meta charset="utf-8"></head><body>page</body></html>' );
+
+		$this->assertLessThan(
+			strpos( $html, '</head>' ),
+			strpos( $html, '__WP_EXE_CONFIG__' ),
+			'The configuration must be part of the document head.'
+		);
+	}
+
+	/**
+	 * A single <base> tag is added right after <head> so the editor's relative
+	 * asset paths resolve inside the bundled build, not against the page URL.
+	 */
+	public function test_a_single_base_tag_points_at_the_bundled_editor() {
+		$html = $this->inject( '<html><head lang="es"><title>t</title></head><body></body></html>' );
+
+		$expected = '<base href="' . esc_url( $this->editor_base_url ) . '/">';
+		$this->assertSame( 1, substr_count( $html, $expected ) );
+		$this->assertStringContainsString( '<head lang="es">' . $expected, $html );
+	}
+
+	/**
+	 * Explicit `./` prefixes in attributes are rewritten to absolute plugin
+	 * URLs, which the <base> tag alone does not cover.
+	 */
+	public function test_relative_asset_paths_are_rewritten_to_absolute_urls() {
+		$html = $this->inject( '<html><head></head><body><script src="./app/bundle.js"></script></body></html>' );
+
+		$this->assertStringContainsString(
+			'src="' . esc_url( $this->editor_base_url ) . '/app/bundle.js"',
+			$html
+		);
+		$this->assertStringNotContainsString( 'src="./app/bundle.js"', $html );
+	}
+
+	/**
+	 * An attachment URL that cannot be resolved is still emitted as valid JSON
+	 * (null), not as a broken literal.
+	 */
+	public function test_a_missing_attachment_url_is_encoded_as_null() {
+		$html = $this->inject( '<html><head></head></html>', 7, false );
+
+		$this->assertStringContainsString( '"elpUrl":false', $html );
+		$this->assertStringContainsString( 'initialProjectUrl: false', $html );
+	}
+
+	/**
+	 * The endpoint URL carries the export signal and the attachment id.
+	 */
+	public function test_url_for_carries_the_export_signal() {
+		$url = ExeLearning_Export_Bootstrap::url_for( 99 );
+
+		$this->assertStringContainsString( 'exe_export=1', $url );
+		$this->assertStringContainsString( 'attachment_id=99', $url );
+		$this->assertStringStartsWith( home_url( '/' ), $url );
+	}
+
+	/**
+	 * Without the bundled editor there is nothing to serve, and the request is
+	 * refused with a 503 instead of rendering a broken page.
+	 */
+	public function test_loading_the_template_fails_when_the_editor_is_not_bundled() {
+		if ( file_exists( EXELEARNING_PLUGIN_DIR . 'dist/static/index.html' ) ) {
+			$this->markTestSkipped( 'The bundled editor is present in this checkout.' );
+		}
+
+		$method = new ReflectionMethod( ExeLearning_Export_Bootstrap::class, 'load_editor_template' );
+		$method->setAccessible( true );
+
+		$this->expectException( WPDieException::class );
+		$method->invoke( $this->bootstrap );
+	}
+
+	/**
+	 * With the bundle in place the template is read from disk as an HTML
+	 * document ready to be patched.
+	 */
+	public function test_the_template_is_read_from_the_bundled_editor() {
+		if ( ! file_exists( EXELEARNING_PLUGIN_DIR . 'dist/static/index.html' ) ) {
+			$this->markTestSkipped( 'This checkout has no bundled editor (run make build-editor).' );
+		}
+
+		$method = new ReflectionMethod( ExeLearning_Export_Bootstrap::class, 'load_editor_template' );
+		$method->setAccessible( true );
+
+		$template = $method->invoke( $this->bootstrap );
+
+		$this->assertIsString( $template );
+		$this->assertStringContainsString( '</head>', $template );
+	}
+
+	// ------------------------------------------------------------------
+	// Helpers.
+	// ------------------------------------------------------------------
+
+	/**
+	 * Run the private payload injection against an arbitrary template.
+	 *
+	 * @param string       $template      Raw editor HTML.
+	 * @param int          $attachment_id Attachment ID.
+	 * @param string|false $elp_url       Attachment URL, or false when unresolved.
+	 * @return string Patched HTML.
+	 */
+	private function inject( $template, $attachment_id = 1, $elp_url = 'https://example.org/project.elpx' ) {
+		$method = new ReflectionMethod( ExeLearning_Export_Bootstrap::class, 'inject_bootstrap_payload' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $this->bootstrap, $template, $attachment_id, $elp_url, $this->editor_base_url );
+	}
+}

--- a/tests/unit/I18nTest.php
+++ b/tests/unit/I18nTest.php
@@ -56,15 +56,6 @@ class I18nTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test load_textdomain can be called without error.
-	 */
-	public function test_load_textdomain_callable() {
-		// Should not throw any errors.
-		$this->i18n->load_textdomain();
-		$this->assertTrue( true );
-	}
-
-	/**
 	 * The bundled Spanish PHP translations must resolve after the loader runs,
 	 * even though the checkout/plugin directory name never matches the text
 	 * domain. This is the behavior WordPress just-in-time loading cannot provide

--- a/tests/unit/MediaLibraryReprocessTest.php
+++ b/tests/unit/MediaLibraryReprocessTest.php
@@ -321,4 +321,57 @@ class MediaLibraryReprocessTest extends WP_UnitTestCase {
 
 		$this->assertEmpty( $output );
 	}
+
+	/**
+	 * An eXeLearning file the current user may not edit is counted as a
+	 * failure, not silently reprocessed on their behalf.
+	 */
+	public function test_handle_bulk_refuses_attachments_the_user_cannot_edit() {
+		$id = $this->make_elpx_attachment();
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'author' ) ) );
+
+		$redirect = $this->media_library->handle_bulk_reprocess(
+			'http://example.org/wp-admin/upload.php',
+			'exelearning_reprocess',
+			array( $id )
+		);
+
+		parse_str( (string) wp_parse_url( $redirect, PHP_URL_QUERY ), $args );
+		$this->assertSame( 1, (int) $args['exe_failed'] );
+		$this->assertSame( 0, (int) $args['exe_reprocessed'] );
+		$this->assertEmpty( get_post_meta( $id, '_exelearning_extracted', true ) );
+	}
+
+	/**
+	 * A .elpx that cannot be processed is reported as a failure rather than
+	 * silently skipped: the extension makes it eXeLearning content that is
+	 * simply broken.
+	 */
+	public function test_handle_bulk_reports_a_broken_elpx_as_a_failure() {
+		$user_id       = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$attachment_id = $this->factory->attachment->create(
+			array(
+				'post_mime_type' => 'application/zip',
+				'post_author'    => $user_id,
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$upload_dir = wp_upload_dir();
+		$file_path  = $upload_dir['basedir'] . '/broken-' . $attachment_id . '.elpx';
+		file_put_contents( $file_path, 'not a zip archive' ); // phpcs:ignore
+		$this->cleanup_paths[] = $file_path;
+		update_attached_file( $attachment_id, $file_path );
+
+		$redirect = $this->media_library->handle_bulk_reprocess(
+			'http://example.org/wp-admin/upload.php',
+			'exelearning_reprocess',
+			array( $attachment_id )
+		);
+
+		parse_str( (string) wp_parse_url( $redirect, PHP_URL_QUERY ), $args );
+		$this->assertSame( 1, (int) $args['exe_failed'] );
+		$this->assertSame( 0, (int) $args['exe_skipped'] );
+	}
+
 }

--- a/tests/unit/MediaLibraryTest.php
+++ b/tests/unit/MediaLibraryTest.php
@@ -687,4 +687,20 @@ class MediaLibraryTest extends WP_UnitTestCase {
 
 		$this->assertFalse( ! empty( $response['exelearningReprocessable'] ) );
 	}
+
+	/**
+	 * The attachment meta box is only added for a real post; without one there
+	 * is nothing to describe.
+	 */
+	public function test_no_meta_box_is_added_without_a_post() {
+		global $post, $wp_meta_boxes;
+
+		$post          = null;
+		$wp_meta_boxes = array();
+
+		$this->media_library->add_elp_meta_box();
+
+		$this->assertSame( array(), $wp_meta_boxes );
+	}
+
 }

--- a/tests/unit/MediaLibraryTest.php
+++ b/tests/unit/MediaLibraryTest.php
@@ -354,17 +354,41 @@ class MediaLibraryTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test enqueue_media_modal_scripts skips other hooks.
+	 * On a screen that is not a media screen the modal assets must stay out.
+	 *
+	 * The method also enqueues whenever `wp_enqueue_media` has already fired,
+	 * and that counter is global to the PHP process: any earlier test that
+	 * enqueued media would make this one pass for the wrong reason. So the
+	 * counter is cleared for the duration and restored afterwards, which leaves
+	 * the hook allow-list as the only thing under test.
 	 */
 	public function test_enqueue_media_modal_scripts_skips_other_hooks() {
+		global $wp_actions;
+
+		$fired = $wp_actions['wp_enqueue_media'] ?? null;
+		unset( $wp_actions['wp_enqueue_media'] );
+
 		wp_dequeue_script( 'exelearning-media-modal' );
 		wp_dequeue_style( 'exelearning-media-library' );
 
-		$this->media_library->enqueue_media_modal_scripts( 'options-general.php' );
+		try {
+			$this->media_library->enqueue_media_modal_scripts( 'options-general.php' );
 
-		// Since did_action might be true, we can't reliably test the skip.
-		// Just verify the method runs without error.
-		$this->assertTrue( true );
+			$this->assertFalse(
+				wp_script_is( 'exelearning-media-modal', 'enqueued' ),
+				'The modal script must not load outside the media screens.'
+			);
+			$this->assertFalse(
+				wp_style_is( 'exelearning-media-library', 'enqueued' ),
+				'The media library style must not load outside the media screens.'
+			);
+		} finally {
+			if ( null === $fired ) {
+				unset( $wp_actions['wp_enqueue_media'] );
+			} else {
+				$wp_actions['wp_enqueue_media'] = $fired;
+			}
+		}
 	}
 
 	/**

--- a/tests/unit/PostTypesTest.php
+++ b/tests/unit/PostTypesTest.php
@@ -35,10 +35,21 @@ class PostTypesTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test register_post_types can be called.
+	 * The plugin deliberately registers no custom post type: ELP packages are
+	 * WordPress attachments and their metadata lives in attachment post meta.
+	 * This guards that decision — registering one here would silently change
+	 * where content is stored.
 	 */
-	public function test_register_post_types_callable() {
+	public function test_register_post_types_registers_no_custom_post_type() {
+		$before = get_post_types( array(), 'names' );
+
 		$this->post_types->register_post_types();
-		$this->assertTrue( true );
+
+		$this->assertSame(
+			array(),
+			array_values( array_diff( get_post_types( array(), 'names' ), $before ) ),
+			'register_post_types() must not register any post type.'
+		);
+		$this->assertFalse( post_type_exists( 'exelearning' ) );
 	}
 }

--- a/tests/unit/ReprocessorTest.php
+++ b/tests/unit/ReprocessorTest.php
@@ -676,4 +676,122 @@ class ReprocessorTest extends WP_UnitTestCase {
 		$this->assertDirectoryExists( $old_dir );
 		$this->assertSame( $old_hash, get_post_meta( $fixture['id'], '_exelearning_extracted', true ) );
 	}
+
+	/**
+	 * Only attachments are candidates; an ordinary post never is.
+	 */
+	public function test_a_post_is_not_an_exelearning_candidate() {
+		$post_id = $this->factory->post->create();
+
+		$this->assertFalse( $this->reprocessor->is_exelearning_candidate( $post_id ) );
+		$this->assertFalse( $this->reprocessor->is_exelearning_candidate( 0 ) );
+	}
+
+	/**
+	 * An attachment with no file on record cannot be classified by extension.
+	 */
+	public function test_an_attachment_without_a_file_is_not_a_candidate() {
+		$attachment_id = $this->factory->attachment->create();
+		delete_post_meta( $attachment_id, '_wp_attached_file' );
+
+		$this->assertFalse( $this->reprocessor->is_exelearning_candidate( $attachment_id ) );
+	}
+
+	/**
+	 * A .zip whose file has disappeared cannot be content-checked, so it is not
+	 * eligible even though its extension is accepted.
+	 */
+	public function test_a_zip_whose_file_is_missing_is_not_eligible() {
+		$zip = $this->make_zip_attachment( 'zip' );
+		wp_delete_file( $zip['path'] );
+
+		$this->assertTrue( $this->reprocessor->is_exelearning_candidate( $zip['id'] ) );
+		$this->assertFalse( $this->reprocessor->is_eligible( $zip['id'] ) );
+	}
+
+	/**
+	 * The candidate scan returns every eXeLearning attachment — processed or
+	 * not — while filtering out plain archives that only look like one.
+	 */
+	public function test_the_candidate_scan_returns_exelearning_attachments_only() {
+		$elpx        = $this->make_elpx_attachment();
+		$exe_zip     = $this->make_zip_attachment( 'zip' );
+		$plain_zip   = $this->make_zip_attachment( 'zip', false );
+		$unrelated   = $this->factory->attachment->create();
+		$this->reprocessor->reprocess( $elpx['id'] );
+
+		$ids = $this->reprocessor->get_candidate_attachment_ids();
+
+		$this->assertContains( $elpx['id'], $ids, 'An already-processed file stays a candidate.' );
+		$this->assertContains( $exe_zip['id'], $ids );
+		$this->assertNotContains( $plain_zip['id'], $ids, 'A plain .zip is not eXeLearning content.' );
+		$this->assertNotContains( $unrelated, $ids );
+
+		$this->cleanup_paths[] = $this->extraction_dir( get_post_meta( $elpx['id'], '_exelearning_extracted', true ) );
+	}
+
+	/**
+	 * A failed extraction leaves no half-written directory behind.
+	 */
+	public function test_a_failed_extraction_removes_its_own_directory() {
+		$elpx = $this->make_elpx_attachment();
+
+		$created = array();
+		add_action(
+			'exelearning_before_elpx_extract',
+			static function ( $file, $destination ) use ( &$created ) {
+				$created[] = $destination;
+			},
+			10,
+			2
+		);
+		// Force the zip-bomb guard to trip on a perfectly ordinary archive.
+		add_filter( 'exelearning_max_extract_bytes', '__return_zero' );
+
+		$result = $this->reprocessor->extract_to_new_dir( $elpx['path'] );
+
+		remove_filter( 'exelearning_max_extract_bytes', '__return_zero' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'elp_too_large', $result->get_error_code() );
+		$this->assertNotEmpty( $created );
+		$this->assertDirectoryDoesNotExist( $created[0] );
+	}
+
+	/**
+	 * Cleaning up an unknown or empty hash is a no-op rather than an error.
+	 */
+	public function test_cleanup_by_hash_ignores_unknown_hashes() {
+		$this->reprocessor->cleanup_by_hash( '' );
+		$this->reprocessor->cleanup_by_hash( str_repeat( 'f', 40 ) );
+
+		$this->assertDirectoryDoesNotExist( $this->extraction_dir( str_repeat( 'f', 40 ) ) );
+	}
+
+
+	/**
+	 * An unusable uploads directory is reported instead of being mistaken for
+	 * an empty extraction.
+	 */
+	public function test_extraction_reports_an_unusable_uploads_directory() {
+		$elpx = $this->make_elpx_attachment();
+
+		// A regular file cannot have children, so every mkdir below it fails.
+		$blocker = wp_tempnam( 'uploads-blocker' );
+		$broken  = static function ( $dirs ) use ( $blocker ) {
+			$dirs['basedir'] = $blocker . '/uploads';
+			return $dirs;
+		};
+		add_filter( 'upload_dir', $broken );
+
+		$result = $this->reprocessor->extract_to_new_dir( $elpx['path'] );
+
+		remove_filter( 'upload_dir', $broken );
+		wp_delete_file( $blocker );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'mkdir_failed', $result->get_error_code() );
+		$this->assertSame( 500, $result->get_error_data()['status'] );
+	}
+
 }

--- a/tests/unit/RestApiUploadTest.php
+++ b/tests/unit/RestApiUploadTest.php
@@ -164,14 +164,13 @@ class RestApiUploadTest extends WP_UnitTestCase {
 	 * reports the failure and leaves no attachment behind.
 	 */
 	public function test_create_rolls_back_the_attachment_when_processing_fails() {
-		$before = count( get_posts( array( 'post_type' => 'attachment', 'fields' => 'ids', 'posts_per_page' => -1 ) ) );
+		$before = $this->attachment_ids();
 		$this->stage_upload( 'broken.elpx', 'this is not a zip archive at all' );
 
 		$result = $this->rest_api->create_elp_file( new WP_REST_Request( 'POST', '/exelearning/v1/create' ) );
 
 		$this->assertWPError( $result );
-		$after = count( get_posts( array( 'post_type' => 'attachment', 'fields' => 'ids', 'posts_per_page' => -1 ) ) );
-		$this->assertSame( $before, $after, 'A failed create must not leave an orphan attachment.' );
+		$this->assertSame( $before, $this->attachment_ids(), 'A failed create must not leave an orphan attachment.' );
 	}
 
 	/**
@@ -482,6 +481,22 @@ class RestApiUploadTest extends WP_UnitTestCase {
 			'id'    => $attachment_id,
 			'path'  => $path,
 			'bytes' => $bytes,
+		);
+	}
+
+	/**
+	 * Every attachment currently in the library.
+	 *
+	 * @return int[] Attachment IDs.
+	 */
+	private function attachment_ids() {
+		return get_posts(
+			array(
+				'post_type'      => 'attachment',
+				'post_status'    => 'any',
+				'fields'         => 'ids',
+				'posts_per_page' => -1,
+			)
 		);
 	}
 

--- a/tests/unit/RestApiUploadTest.php
+++ b/tests/unit/RestApiUploadTest.php
@@ -1,0 +1,572 @@
+<?php
+/**
+ * Tests for the upload-backed halves of ExeLearning_REST_API: /create and the
+ * transactional /save flow.
+ *
+ * Both endpoints hand the raw $_FILES entry to wp_handle_upload(), which refuses
+ * anything that did not arrive through a real multipart POST — a condition no
+ * CLI test can satisfy. WordPress' documented escape hatch for that is
+ * $overrides['upload_error_handler']: _wp_handle_upload() delegates to it and
+ * returns whatever it produces. These tests install a handler that puts the file
+ * where WordPress would have put it, so the endpoints receive the same success
+ * array a real upload yields and every plugin-side step after it runs for real.
+ *
+ * @package Exelearning
+ */
+
+/**
+ * Class RestApiUploadTest.
+ *
+ * @covers ExeLearning_REST_API
+ */
+class RestApiUploadTest extends WP_UnitTestCase {
+
+	/**
+	 * Test instance.
+	 *
+	 * @var ExeLearning_REST_API
+	 */
+	private $rest_api;
+
+	/**
+	 * Files and directories to remove on tear down.
+	 *
+	 * @var string[]
+	 */
+	private $cleanup_paths = array();
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->rest_api      = new ExeLearning_REST_API();
+		$this->cleanup_paths = array();
+
+		add_filter( 'wp_handle_upload_overrides', array( $this, 'install_upload_completer' ) );
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tear_down() {
+		remove_filter( 'wp_handle_upload_overrides', array( $this, 'install_upload_completer' ) );
+		unset( $_FILES['file'] );
+
+		foreach ( $this->cleanup_paths as $path ) {
+			$this->recursive_delete( $path );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Point wp_handle_upload() at the test's own completion handler.
+	 *
+	 * @param array $overrides wp_handle_upload() overrides.
+	 * @return array
+	 */
+	public function install_upload_completer( $overrides ) {
+		$overrides['upload_error_handler'] = array( $this, 'place_uploaded_file' );
+		return $overrides;
+	}
+
+	/**
+	 * Finish an upload that is_uploaded_file() rejected under the CLI runner.
+	 *
+	 * Stores the file in the uploads directory under a unique name and returns
+	 * the same shape wp_handle_upload() returns on success.
+	 *
+	 * @param array  $file    Uploaded file entry, passed by reference by WordPress.
+	 * @param string $message Error message WordPress was about to return.
+	 * @return array Upload result.
+	 */
+	public function place_uploaded_file( &$file, $message ) {
+		$uploads = wp_upload_dir();
+		if ( ! empty( $uploads['error'] ) ) {
+			return array( 'error' => $message );
+		}
+
+		$name     = wp_unique_filename( $uploads['path'], $file['name'] );
+		$new_file = trailingslashit( $uploads['path'] ) . $name;
+		if ( ! copy( $file['tmp_name'], $new_file ) ) { // phpcs:ignore
+			return array( 'error' => $message );
+		}
+		$this->cleanup_paths[] = $new_file;
+
+		return array(
+			'file' => $new_file,
+			'url'  => trailingslashit( $uploads['url'] ) . $name,
+			'type' => $file['type'],
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// /create
+	// ------------------------------------------------------------------
+
+	/**
+	 * A valid upload creates an attachment, extracts it and reports the URLs
+	 * the editor needs to continue working on the new project.
+	 */
+	public function test_create_stores_extracts_and_describes_the_new_project() {
+		$this->stage_upload( 'My Project.elpx', $this->build_elpx( 'Created project' ) );
+
+		$response = $this->rest_api->create_elp_file( new WP_REST_Request( 'POST', '/exelearning/v1/create' ) );
+
+		$this->assertNotWPError( $response );
+		$data = $response->get_data();
+
+		$this->assertTrue( $data['success'] );
+		$attachment_id = $data['attachmentId'];
+		$this->assertSame( 'attachment', get_post( $attachment_id )->post_type );
+		$this->assertSame( 'My-Project', get_post( $attachment_id )->post_title, 'The title comes from the sanitized filename.' );
+		$this->assertSame( 'elpx', pathinfo( get_attached_file( $attachment_id ), PATHINFO_EXTENSION ) );
+
+		$hash = get_post_meta( $attachment_id, '_exelearning_extracted', true );
+		$this->assertMatchesRegularExpression( '/^[a-f0-9]{40}$/', $hash );
+		$this->assertDirectoryExists( $this->extraction_dir( $hash ) );
+		$this->assertSame( 'Created project', get_post_meta( $attachment_id, '_exelearning_title', true ) );
+
+		$this->assertStringContainsString( 'page=exelearning-editor', $data['editUrl'] );
+		$this->assertStringContainsString( 'attachment_id=' . $attachment_id, $data['editUrl'] );
+		$this->assertStringContainsString( '.elpx', $data['url'] );
+
+		$this->cleanup_paths[] = get_attached_file( $attachment_id );
+		$this->cleanup_paths[] = $this->extraction_dir( $hash );
+	}
+
+	/**
+	 * An upload whose name carries a foreign extension is normalized to .elpx
+	 * rather than stored under a type the plugin cannot edit.
+	 */
+	public function test_create_normalizes_the_uploaded_extension_to_elpx() {
+		$this->stage_upload( 'project.zip', $this->build_elpx() );
+
+		$response = $this->rest_api->create_elp_file( new WP_REST_Request( 'POST', '/exelearning/v1/create' ) );
+
+		$this->assertNotWPError( $response );
+		$attachment_id = $response->get_data()['attachmentId'];
+		$path          = get_attached_file( $attachment_id );
+
+		$this->assertStringEndsWith( '.elpx', $path );
+		$this->assertSame( 'project', get_post( $attachment_id )->post_title );
+
+		$this->cleanup_paths[] = $path;
+		$this->cleanup_paths[] = $this->extraction_dir( get_post_meta( $attachment_id, '_exelearning_extracted', true ) );
+	}
+
+	/**
+	 * When the uploaded archive is not an eXeLearning project the endpoint
+	 * reports the failure and leaves no attachment behind.
+	 */
+	public function test_create_rolls_back_the_attachment_when_processing_fails() {
+		$before = count( get_posts( array( 'post_type' => 'attachment', 'fields' => 'ids', 'posts_per_page' => -1 ) ) );
+		$this->stage_upload( 'broken.elpx', 'this is not a zip archive at all' );
+
+		$result = $this->rest_api->create_elp_file( new WP_REST_Request( 'POST', '/exelearning/v1/create' ) );
+
+		$this->assertWPError( $result );
+		$after = count( get_posts( array( 'post_type' => 'attachment', 'fields' => 'ids', 'posts_per_page' => -1 ) ) );
+		$this->assertSame( $before, $after, 'A failed create must not leave an orphan attachment.' );
+	}
+
+	/**
+	 * Uploading requires the upload_files capability.
+	 */
+	public function test_create_permission_callback_requires_upload_files() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'subscriber' ) ) );
+		$this->assertFalse( $this->rest_api->check_upload_permission() );
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'author' ) ) );
+		$this->assertTrue( $this->rest_api->check_upload_permission() );
+	}
+
+	// ------------------------------------------------------------------
+	// /save
+	// ------------------------------------------------------------------
+
+	/**
+	 * A successful save replaces the file on disk, points the metadata at a
+	 * fresh extraction, retires the previous one and announces the commit.
+	 */
+	public function test_save_replaces_the_file_and_commits_a_new_extraction() {
+		$existing = $this->make_existing_elpx_attachment( 'Before' );
+		$old_hash = get_post_meta( $existing['id'], '_exelearning_extracted', true );
+
+		$new_bytes = $this->build_elpx( 'After' );
+		$this->stage_upload( 'whatever.elpx', $new_bytes );
+
+		$fired = array();
+		add_action(
+			'exelearning_after_elpx_save',
+			static function ( $id, $new_hash, $previous ) use ( &$fired ) {
+				$fired[] = compact( 'id', 'new_hash', 'previous' );
+			},
+			10,
+			3
+		);
+
+		$response = $this->rest_api->save_elp_file( $this->save_request( $existing['id'] ) );
+
+		$this->assertNotWPError( $response );
+		$data = $response->get_data();
+		$this->assertTrue( $data['success'] );
+		$this->assertSame( $existing['id'], $data['attachment_id'] );
+
+		$new_hash = get_post_meta( $existing['id'], '_exelearning_extracted', true );
+		$this->assertNotSame( $old_hash, $new_hash );
+		$this->assertSame( $new_bytes, file_get_contents( $existing['path'] ), 'The original .elpx must hold the new bytes.' );
+		$this->assertSame( 'After', get_post_meta( $existing['id'], '_exelearning_title', true ) );
+		$this->assertFileExists( $this->extraction_dir( $new_hash ) . '/index.html' );
+		$this->assertSame(
+			ExeLearning_Content_Proxy::get_proxy_url( $new_hash ),
+			$data['preview_url'],
+			'The response must point at the freshly committed extraction.'
+		);
+
+		$this->assertCount( 1, $fired );
+		$this->assertSame(
+			array(
+				'id'       => $existing['id'],
+				'new_hash' => $new_hash,
+				'previous' => $old_hash,
+			),
+			$fired[0]
+		);
+
+		$this->cleanup_paths[] = $this->extraction_dir( $new_hash );
+	}
+
+	/**
+	 * The superseded extraction stays reachable: its hash is recorded as an
+	 * alias of the attachment so already-published URLs can be redirected.
+	 */
+	public function test_save_retires_the_previous_extraction_as_an_alias() {
+		$existing = $this->make_existing_elpx_attachment();
+		$old_hash = get_post_meta( $existing['id'], '_exelearning_extracted', true );
+
+		$this->stage_upload( 'update.elpx', $this->build_elpx( 'Updated' ) );
+		$this->rest_api->save_elp_file( $this->save_request( $existing['id'] ) );
+
+		$aliases = new ExeLearning_Content_Hash_Aliases();
+		$this->assertSame( $existing['id'], $aliases->resolve( $old_hash ) );
+
+		$this->cleanup_paths[] = $this->extraction_dir( get_post_meta( $existing['id'], '_exelearning_extracted', true ) );
+	}
+
+	/**
+	 * `exelearning_before_elpx_save` runs with the attachment and the path of
+	 * the file that is about to be replaced.
+	 */
+	public function test_save_announces_the_replacement_before_writing() {
+		$existing = $this->make_existing_elpx_attachment();
+		$this->stage_upload( 'update.elpx', $this->build_elpx() );
+
+		$seen = array();
+		add_action(
+			'exelearning_before_elpx_save',
+			static function ( $id, $path ) use ( &$seen ) {
+				$seen[] = array( $id, $path, file_get_contents( $path ) );
+			},
+			10,
+			2
+		);
+
+		$this->rest_api->save_elp_file( $this->save_request( $existing['id'] ) );
+
+		$this->assertCount( 1, $seen );
+		$this->assertSame( $existing['id'], $seen[0][0] );
+		$this->assertSame( $existing['path'], $seen[0][1] );
+		$this->assertSame( $existing['bytes'], $seen[0][2], 'The hook must observe the file before it is overwritten.' );
+
+		$this->cleanup_paths[] = $this->extraction_dir( get_post_meta( $existing['id'], '_exelearning_extracted', true ) );
+	}
+
+	/**
+	 * A save whose payload cannot be validated leaves the stored file, the
+	 * metadata and the live extraction exactly as they were.
+	 */
+	public function test_save_leaves_everything_untouched_when_the_new_content_is_invalid() {
+		$existing = $this->make_existing_elpx_attachment( 'Original' );
+		$old_hash = get_post_meta( $existing['id'], '_exelearning_extracted', true );
+
+		$this->stage_upload( 'broken.elpx', 'not a zip' );
+
+		$result = $this->rest_api->save_elp_file( $this->save_request( $existing['id'] ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( $existing['bytes'], file_get_contents( $existing['path'] ) );
+		$this->assertSame( $old_hash, get_post_meta( $existing['id'], '_exelearning_extracted', true ) );
+		$this->assertSame( 'Original', get_post_meta( $existing['id'], '_exelearning_title', true ) );
+		$this->assertDirectoryExists( $this->extraction_dir( $old_hash ) );
+	}
+
+	/**
+	 * A copy that does not reproduce the announced size is treated as a failed
+	 * save, and the extraction staged for it is cleaned up.
+	 */
+	public function test_save_rejects_a_truncated_copy_and_cleans_up_its_extraction() {
+		$existing = $this->make_existing_elpx_attachment();
+		$old_hash = get_post_meta( $existing['id'], '_exelearning_extracted', true );
+
+		$this->stage_upload( 'update.elpx', $this->build_elpx() );
+		// Announce a size the copied file will never have.
+		$_FILES['file']['size'] = 999999;
+
+		$staged = array();
+		add_action(
+			'exelearning_after_elpx_extract',
+			static function ( $file, $destination ) use ( &$staged ) {
+				$staged[] = $destination;
+			},
+			10,
+			2
+		);
+
+		$result = $this->rest_api->save_elp_file( $this->save_request( $existing['id'] ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'copy_truncated', $result->get_error_code() );
+		$this->assertSame( $old_hash, get_post_meta( $existing['id'], '_exelearning_extracted', true ) );
+		$this->assertNotEmpty( $staged );
+		$this->assertDirectoryDoesNotExist( $staged[0] );
+	}
+
+	/**
+	 * A second save for the same attachment is refused while the first still
+	 * holds the lock, so two POSTs cannot race on the same file.
+	 */
+	public function test_concurrent_saves_on_the_same_attachment_are_refused() {
+		$existing = $this->make_existing_elpx_attachment();
+
+		$acquire = new ReflectionMethod( ExeLearning_REST_API::class, 'acquire_save_lock' );
+		$acquire->setAccessible( true );
+		$this->assertTrue( $acquire->invoke( $this->rest_api, $existing['id'] ) );
+
+		$this->stage_upload( 'update.elpx', $this->build_elpx() );
+		$result = $this->rest_api->save_elp_file( $this->save_request( $existing['id'] ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'save_in_progress', $result->get_error_code() );
+		$this->assertSame( 409, $result->get_error_data()['status'] );
+
+		$release = new ReflectionMethod( ExeLearning_REST_API::class, 'release_save_lock' );
+		$release->setAccessible( true );
+		$release->invoke( $this->rest_api, $existing['id'] );
+	}
+
+	/**
+	 * The lock releases once the save finishes, so the next save is accepted.
+	 */
+	public function test_the_save_lock_is_released_after_a_successful_save() {
+		$existing = $this->make_existing_elpx_attachment();
+
+		$this->stage_upload( 'first.elpx', $this->build_elpx( 'First' ) );
+		$this->assertNotWPError( $this->rest_api->save_elp_file( $this->save_request( $existing['id'] ) ) );
+		$this->cleanup_paths[] = $this->extraction_dir( get_post_meta( $existing['id'], '_exelearning_extracted', true ) );
+
+		$this->stage_upload( 'second.elpx', $this->build_elpx( 'Second' ) );
+		$this->assertNotWPError( $this->rest_api->save_elp_file( $this->save_request( $existing['id'] ) ) );
+
+		$this->assertSame( 'Second', get_post_meta( $existing['id'], '_exelearning_title', true ) );
+		$this->cleanup_paths[] = $this->extraction_dir( get_post_meta( $existing['id'], '_exelearning_extracted', true ) );
+	}
+
+	/**
+	 * With a persistent object cache the lock uses the atomic wp_cache_add()
+	 * path instead of a transient, with the same acquire/release semantics.
+	 */
+	public function test_the_save_lock_uses_the_object_cache_when_one_is_persistent() {
+		$acquire = new ReflectionMethod( ExeLearning_REST_API::class, 'acquire_save_lock' );
+		$acquire->setAccessible( true );
+		$release = new ReflectionMethod( ExeLearning_REST_API::class, 'release_save_lock' );
+		$release->setAccessible( true );
+
+		wp_using_ext_object_cache( true );
+		try {
+			$this->assertTrue( $acquire->invoke( $this->rest_api, 4242 ) );
+			$this->assertFalse( $acquire->invoke( $this->rest_api, 4242 ), 'The lock must not be re-entrant.' );
+			$this->assertFalse( get_transient( 'exe_save_lock_4242' ), 'No transient is written on the object-cache path.' );
+
+			$release->invoke( $this->rest_api, 4242 );
+			$this->assertTrue( $acquire->invoke( $this->rest_api, 4242 ) );
+			$release->invoke( $this->rest_api, 4242 );
+		} finally {
+			wp_using_ext_object_cache( false );
+		}
+	}
+
+	// ------------------------------------------------------------------
+	// Helpers.
+	// ------------------------------------------------------------------
+
+	/**
+	 * Build a minimal but valid .elpx archive.
+	 *
+	 * @param string $title Project title stored in content.xml.
+	 * @return string Raw archive bytes.
+	 */
+	private function build_elpx( $title = 'Test project' ) {
+		$path = wp_tempnam( 'fixture.elpx' );
+		wp_delete_file( $path );
+
+		$zip = new ZipArchive();
+		$zip->open( $path, ZipArchive::CREATE );
+		$zip->addFromString(
+			'content.xml',
+			'<?xml version="1.0" encoding="UTF-8"?><package><odeProperties>'
+			. '<odeProperty><key>pp_title</key><value>' . $title . '</value></odeProperty>'
+			. '<odeProperty><key>pp_description</key><value>' . $title . ' description</value></odeProperty>'
+			. '</odeProperties></package>'
+		);
+		$zip->addFromString( 'index.html', '<html><body>' . $title . '</body></html>' );
+		$zip->close();
+
+		$bytes = file_get_contents( $path ); // phpcs:ignore
+		wp_delete_file( $path );
+
+		return $bytes;
+	}
+
+	/**
+	 * Put raw bytes into $_FILES as if they had just been uploaded.
+	 *
+	 * @param string $name  Client-supplied filename.
+	 * @param string $bytes File contents.
+	 */
+	private function stage_upload( $name, $bytes ) {
+		$tmp = wp_tempnam( 'upload' );
+		file_put_contents( $tmp, $bytes ); // phpcs:ignore
+		$this->cleanup_paths[] = $tmp;
+
+		$_FILES['file'] = array(
+			'name'     => $name,
+			'type'     => 'application/zip',
+			'tmp_name' => $tmp,
+			'error'    => UPLOAD_ERR_OK,
+			'size'     => strlen( $bytes ),
+		);
+	}
+
+	/**
+	 * Create an attachment backed by an already-extracted .elpx file.
+	 *
+	 * @param string $title Project title stored in the archive.
+	 * @return array { id: int, path: string, bytes: string }
+	 */
+	private function make_existing_elpx_attachment( $title = 'Existing' ) {
+		$bytes = $this->build_elpx( $title );
+
+		$attachment_id = $this->factory->attachment->create(
+			array(
+				'post_mime_type' => 'application/zip',
+				'post_author'    => get_current_user_id(),
+			)
+		);
+
+		$upload_dir = wp_upload_dir();
+		$path       = trailingslashit( $upload_dir['basedir'] ) . 'existing-' . $attachment_id . '.elpx';
+		file_put_contents( $path, $bytes ); // phpcs:ignore
+		update_attached_file( $attachment_id, $path );
+		$this->cleanup_paths[] = $path;
+
+		$reprocessor = new ExeLearning_Reprocessor();
+		$this->assertNotWPError( $reprocessor->reprocess( $attachment_id ) );
+		$this->cleanup_paths[] = $this->extraction_dir( get_post_meta( $attachment_id, '_exelearning_extracted', true ) );
+
+		return array(
+			'id'    => $attachment_id,
+			'path'  => $path,
+			'bytes' => $bytes,
+		);
+	}
+
+	/**
+	 * Build a save request for an attachment.
+	 *
+	 * @param int $attachment_id Attachment ID.
+	 * @return WP_REST_Request
+	 */
+	private function save_request( $attachment_id ) {
+		$request = new WP_REST_Request( 'POST', '/exelearning/v1/save/' . $attachment_id );
+		$request->set_param( 'id', $attachment_id );
+		return $request;
+	}
+
+	/**
+	 * Absolute path of an extraction directory.
+	 *
+	 * @param string $hash Extraction hash.
+	 * @return string
+	 */
+	private function extraction_dir( $hash ) {
+		$upload_dir = wp_upload_dir();
+		return trailingslashit( $upload_dir['basedir'] ) . 'exelearning/' . $hash;
+	}
+
+	/**
+	 * Recursively remove a file or directory tree.
+	 *
+	 * @param string $path Path to remove.
+	 */
+	private function recursive_delete( $path ) {
+		if ( ! file_exists( $path ) ) {
+			return;
+		}
+		if ( ! is_dir( $path ) ) {
+			wp_delete_file( $path );
+			return;
+		}
+		foreach ( array_diff( scandir( $path ), array( '.', '..' ) ) as $entry ) {
+			$this->recursive_delete( $path . '/' . $entry );
+		}
+		rmdir( $path ); // phpcs:ignore
+	}
+
+	/**
+	 * If the new bytes cannot be written over the original file the save fails
+	 * and the extraction staged for it is removed, so a failed save leaves no
+	 * orphaned directory behind.
+	 */
+	public function test_save_cleans_up_when_the_original_file_cannot_be_written() {
+		$attachment_id = $this->factory->attachment->create(
+			array(
+				'post_mime_type' => 'application/zip',
+				'post_author'    => get_current_user_id(),
+			)
+		);
+
+		// A directory passes the "exists and is .elpx" checks but can never be
+		// overwritten by a file copy.
+		$upload_dir = wp_upload_dir();
+		$target     = trailingslashit( $upload_dir['basedir'] ) . 'unwritable-' . $attachment_id . '.elpx';
+		wp_mkdir_p( $target );
+		update_attached_file( $attachment_id, $target );
+		$this->cleanup_paths[] = $target;
+
+		$this->stage_upload( 'update.elpx', $this->build_elpx() );
+
+		$staged = array();
+		add_action(
+			'exelearning_after_elpx_extract',
+			static function ( $file, $destination ) use ( &$staged ) {
+				$staged[] = $destination;
+			},
+			10,
+			2
+		);
+
+		$result = $this->rest_api->save_elp_file( $this->save_request( $attachment_id ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'move_failed', $result->get_error_code() );
+		$this->assertNotEmpty( $staged );
+		$this->assertDirectoryDoesNotExist( $staged[0] );
+		$this->assertSame( '', get_post_meta( $attachment_id, '_exelearning_extracted', true ) );
+	}
+
+}

--- a/tests/unit/ShortcodesTest.php
+++ b/tests/unit/ShortcodesTest.php
@@ -1055,4 +1055,36 @@ class ShortcodesTest extends WP_UnitTestCase {
 		// Fullscreen toggled off through the filter is honored.
 		$this->assertStringNotContainsString( 'exelearning-fullscreen-btn', $result );
 	}
+
+	/**
+	 * download_formats limits the download menu to the requested formats,
+	 * dropping anything unknown.
+	 */
+	public function test_download_formats_attribute_selects_the_offered_formats() {
+		$attachment_id = $this->create_previewable_attachment( str_repeat( '7', 40 ) );
+
+		$result = $this->shortcodes->display_exelearning(
+			array(
+				'id'               => $attachment_id,
+				'show_download'    => '1',
+				'download_formats' => 'html5,not-a-format',
+			)
+		);
+
+		$this->assertStringContainsString( 'data-format="html5"', $result );
+		$this->assertStringNotContainsString( 'data-format="scorm12"', $result );
+		$this->assertStringNotContainsString( 'not-a-format', $result );
+	}
+
+	/**
+	 * An attachment with no extraction directory has no screenshot to show.
+	 */
+	public function test_has_screenshot_is_false_without_an_extraction() {
+		$method = new ReflectionMethod( ExeLearning_Shortcodes::class, 'has_screenshot' );
+		$method->setAccessible( true );
+
+		$this->assertFalse( $method->invoke( $this->shortcodes, '' ) );
+		$this->assertFalse( $method->invoke( $this->shortcodes, str_repeat( 'e', 40 ) ) );
+	}
+
 }

--- a/tests/unit/StylePackageTest.php
+++ b/tests/unit/StylePackageTest.php
@@ -491,4 +491,147 @@ class StylePackageTest extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( '<', $result['title'] );
 		$this->assertStringNotContainsString( '<', $result['description'] );
 	}
+
+	/* ---------------------------------------------------------------------
+	 * validate(): config and layout errors
+	 * ------------------------------------------------------------------- */
+
+	/**
+	 * A config.xml that is not well-formed XML fails validation instead of
+	 * producing a half-parsed theme.
+	 */
+	public function test_validate_rejects_a_config_that_is_not_valid_xml() {
+		$zip_path = $this->make_zip( array( 'config.xml' => '<theme><name>broken' ) );
+
+		$result = ExeLearning_Style_Package::validate( $zip_path, self::MAX );
+
+		wp_delete_file( $zip_path );
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'style_bad_xml', $result->get_error_code() );
+	}
+
+	/**
+	 * With config.xml at the archive root, nested folders are part of the
+	 * package and must not be mistaken for a second root.
+	 */
+	public function test_validate_allows_subdirectories_when_config_sits_at_the_root() {
+		$zip_path = $this->make_zip(
+			array(
+				'config.xml'    => $this->sample_config_xml( 'rooted' ),
+				'style.css'     => 'body{}',
+				'img/logo.png'  => 'binary',
+				'css/print.css' => 'p{}',
+			)
+		);
+
+		$result = ExeLearning_Style_Package::validate( $zip_path, self::MAX );
+
+		wp_delete_file( $zip_path );
+		$this->assertIsArray( $result );
+		$this->assertSame( '', $result['prefix'] );
+	}
+
+	/* ---------------------------------------------------------------------
+	 * extract_safely()
+	 * ------------------------------------------------------------------- */
+
+	/**
+	 * extract_safely() re-checks every entry: an archive that escapes its own
+	 * directory is refused even when it is passed straight to extraction.
+	 */
+	public function test_extract_safely_refuses_an_entry_that_escapes_the_package() {
+		$zip_path = $this->make_zip(
+			array(
+				'theme/config.xml' => $this->sample_config_xml( 'evil' ),
+				'theme/../hack.css' => 'body{}',
+			)
+		);
+		$dest = $this->temp_dir();
+
+		$result = ExeLearning_Style_Package::extract_safely( $zip_path, $dest, 'theme/' );
+
+		wp_delete_file( $zip_path );
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'zip_unsafe_entry', $result->get_error_code() );
+	}
+
+	/**
+	 * The wrapper folder itself is stripped, not recreated inside the
+	 * destination, and unrelated roots are skipped.
+	 */
+	public function test_extract_safely_strips_the_wrapper_folder() {
+		$zip_path = wp_tempnam( 'wrapped.zip' );
+		wp_delete_file( $zip_path );
+		$zip = new ZipArchive();
+		$zip->open( $zip_path, ZipArchive::CREATE );
+		$zip->addEmptyDir( 'theme' );
+		$zip->addFromString( 'theme/config.xml', $this->sample_config_xml( 'wrapped' ) );
+		$zip->addFromString( 'theme/style.css', 'body{}' );
+		$zip->addFromString( 'other/readme.txt', 'ignored' );
+		$zip->close();
+
+		$dest   = $this->temp_dir();
+		$result = ExeLearning_Style_Package::extract_safely( $zip_path, $dest, 'theme/' );
+
+		wp_delete_file( $zip_path );
+		$this->assertTrue( $result );
+		$this->assertFileExists( $dest . '/style.css' );
+		$this->assertDirectoryDoesNotExist( $dest . '/theme' );
+		$this->assertFileDoesNotExist( $dest . '/readme.txt' );
+	}
+
+	/**
+	 * A destination that cannot be created surfaces as an error rather than a
+	 * silently empty style directory.
+	 */
+	public function test_extract_safely_reports_a_destination_it_cannot_create() {
+		$zip_path = $this->make_zip(
+			array(
+				'config.xml'    => $this->sample_config_xml( 'nodest' ),
+				'css/style.css' => 'body{}',
+			)
+		);
+		// A regular file cannot have children, so mkdir below it always fails.
+		$blocker = wp_tempnam( 'blocker' );
+
+		$result = ExeLearning_Style_Package::extract_safely( $zip_path, $blocker . '/dest', '' );
+
+		wp_delete_file( $zip_path );
+		wp_delete_file( $blocker );
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'zip_mkdir_failed', $result->get_error_code() );
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Entry helpers
+	 * ------------------------------------------------------------------- */
+
+	/**
+	 * Directory entries create the directory and read nothing from the archive.
+	 */
+	public function test_write_entry_creates_directory_entries() {
+		$dest   = $this->temp_dir();
+		$method = new ReflectionMethod( ExeLearning_Style_Package::class, 'write_entry' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( null, new ZipArchive(), 0, 'theme/icons/', 'icons/', $dest );
+
+		$this->assertTrue( $result );
+		$this->assertDirectoryExists( $dest . '/icons' );
+	}
+
+	/**
+	 * strip_prefix() keeps root entries as they are, drops the prefix folder
+	 * itself, and rejects entries belonging to a different root.
+	 */
+	public function test_strip_prefix_handles_every_entry_shape() {
+		$method = new ReflectionMethod( ExeLearning_Style_Package::class, 'strip_prefix' );
+		$method->setAccessible( true );
+
+		$this->assertSame( 'style.css', $method->invoke( null, 'style.css', '' ) );
+		$this->assertSame( 'style.css', $method->invoke( null, 'theme/style.css', 'theme/' ) );
+		$this->assertNull( $method->invoke( null, 'theme/', 'theme/' ) );
+		$this->assertNull( $method->invoke( null, 'other/style.css', 'theme/' ) );
+	}
+
 }

--- a/tests/unit/StylesServiceTest.php
+++ b/tests/unit/StylesServiceTest.php
@@ -432,9 +432,24 @@ class StylesServiceTest extends WP_UnitTestCase {
 		$this->assertSame( array(), $r['disabled_builtins'] );
 	}
 
+	/**
+	 * Deleting a path that is not there returns early and, crucially, does not
+	 * walk up and take a sibling with it.
+	 */
 	public function test_recursive_delete_handles_missing_path_gracefully() {
-		ExeLearning_Styles_Service::recursive_delete( sys_get_temp_dir() . '/does-not-exist-' . uniqid() );
-		$this->assertTrue( true );
+		$bystander = sys_get_temp_dir() . '/deltree-keep-' . uniqid();
+		mkdir( $bystander, 0755, true );
+		file_put_contents( $bystander . '/keep.txt', 'keep' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+
+		$missing = sys_get_temp_dir() . '/does-not-exist-' . uniqid();
+		$this->assertDirectoryDoesNotExist( $missing, 'Precondition: the path must be absent.' );
+
+		ExeLearning_Styles_Service::recursive_delete( $missing );
+
+		$this->assertDirectoryDoesNotExist( $missing );
+		$this->assertFileExists( $bystander . '/keep.txt', 'A sibling directory was deleted.' );
+
+		ExeLearning_Styles_Service::recursive_delete( $bystander );
 	}
 
 	public function test_recursive_delete_removes_nested_files() {

--- a/tests/unit/StylesServiceTest.php
+++ b/tests/unit/StylesServiceTest.php
@@ -582,4 +582,101 @@ class StylesServiceTest extends WP_UnitTestCase {
 			. '<description>Test theme.</description>'
 			. '</theme>';
 	}
+
+	/**
+	 * A registry option corrupted into a non-array yields no disabled styles
+	 * instead of a type error.
+	 */
+	public function test_a_corrupt_disabled_styles_option_disables_nothing() {
+		update_option( ExeLearning_Styles_Service::OPTION_DISABLED_STYLES, 'not-an-array' );
+
+		$this->assertSame( array(), ExeLearning_Styles_Service::get_disabled_styles() );
+		$this->assertFalse( ExeLearning_Styles_Service::is_style_disabled( 'anything' ) );
+	}
+
+	/**
+	 * Installing an archive that is not a style package fails with the
+	 * validation error and writes nothing to the registry.
+	 */
+	public function test_install_from_zip_refuses_an_archive_that_is_not_a_style() {
+		$zip_path = $this->make_zip( array( 'readme.txt' => 'just a backup' ) );
+
+		$result = ExeLearning_Styles_Service::install_from_zip( $zip_path, 'backup.zip' );
+
+		wp_delete_file( $zip_path );
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'zip_missing_config', $result->get_error_code() );
+		$this->assertSame( array(), ExeLearning_Styles_Service::get_registry()['uploaded'] );
+	}
+
+	/**
+	 * A package whose config.xml declares no name is refused: the slug the
+	 * style is stored and served under is derived from that name.
+	 */
+	public function test_install_from_zip_requires_a_declared_name() {
+		$zip_path = $this->make_zip(
+			array(
+				'config.xml' => '<?xml version="1.0"?><theme><title>Nameless</title><version>1.0</version></theme>',
+				'style.css'  => 'body{}',
+			)
+		);
+
+		$result = ExeLearning_Styles_Service::install_from_zip( $zip_path, 'Fallback Style.zip' );
+
+		wp_delete_file( $zip_path );
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'style_missing_name', $result->get_error_code() );
+		$this->assertSame( array(), ExeLearning_Styles_Service::get_registry()['uploaded'] );
+	}
+
+	/**
+	 * The per-file manifest lists real files only; directories in the package
+	 * are not published as fetchable assets.
+	 */
+	public function test_the_file_manifest_lists_files_and_skips_directories() {
+		$zip_path = wp_tempnam( 'manifest.zip' );
+		wp_delete_file( $zip_path );
+		$zip = new ZipArchive();
+		$zip->open( $zip_path, ZipArchive::CREATE );
+		$zip->addFromString( 'config.xml', $this->sample_config_xml( 'manifest' ) );
+		$zip->addFromString( 'style.css', 'body{}' );
+		$zip->addFromString( 'css/print.css', 'p{}' );
+		$zip->addEmptyDir( 'empty' );
+		$zip->close();
+
+		ExeLearning_Styles_Service::install_from_zip( $zip_path, 'manifest.zip' );
+		wp_delete_file( $zip_path );
+
+		$files = ExeLearning_Styles_Service::list_uploaded_files( 'manifest' );
+
+		$this->assertSame( array( 'config.xml', 'css/print.css', 'style.css' ), $files );
+		$this->assertSame( array(), ExeLearning_Styles_Service::list_uploaded_files( 'never-installed' ) );
+	}
+
+	/**
+	 * The icon scan only picks up image files at the top of icons/, ignoring
+	 * nested folders and non-image files.
+	 */
+	public function test_the_icon_scan_ignores_subfolders_and_other_files() {
+		$zip_path = wp_tempnam( 'icons.zip' );
+		wp_delete_file( $zip_path );
+		$zip = new ZipArchive();
+		$zip->open( $zip_path, ZipArchive::CREATE );
+		$zip->addFromString( 'config.xml', $this->sample_config_xml( 'icony' ) );
+		$zip->addFromString( 'style.css', 'body{}' );
+		$zip->addFromString( 'icons/note.png', 'PNG' );
+		$zip->addFromString( 'icons/notes.txt', 'not an icon' );
+		$zip->addFromString( 'icons/nested/deep.png', 'PNG' );
+		$zip->close();
+
+		ExeLearning_Styles_Service::install_from_zip( $zip_path, 'icons.zip' );
+		wp_delete_file( $zip_path );
+
+		$icons = ExeLearning_Styles_Service::scan_uploaded_icons( 'icony', 'https://example.org/icony' );
+
+		$this->assertSame( array( 'note' ), array_keys( $icons ) );
+		$this->assertSame( 'https://example.org/icony/icons/note.png', $icons['note']['value'] );
+		$this->assertSame( array(), ExeLearning_Styles_Service::scan_uploaded_icons( 'never-installed', 'https://example.org/x' ) );
+	}
+
 }


### PR DESCRIPTION
## Coverage

**Before** — CI run on `main` ([a1b875f](https://github.com/exelearning/wp-exelearning/actions/runs/30827239549)):

```
 Summary:
  Classes: 44.83% (13/29)
  Methods: 75.00% (195/260)
  Lines:   84.82% (2693/3175)
```

**After** — CI run on this branch ([30831328299](https://github.com/exelearning/wp-exelearning/actions/runs/30831328299)):

```
 Summary:
  Classes: 62.07% (18/29)
  Methods: 88.46% (230/260)
  Lines:   94.17% (2990/3175)
```

87 new tests (820 → 907), 1980 assertions. `MIN_COVERAGE` raised from 74 to 94.
Local and CI produce the same figure, so the floor is reproducible.

**No production code changed.** Nothing in the new tests uncovered a bug.

## What is now covered

**Content proxy delivery** (`tests/unit/ContentProxyServeTest.php`, new) — 61.60% → 94.68%.
`serve_content()` ends in `exit()`, so the tests drive the private `serve_file()`
it delegates to: HTML reference rewriting (sibling pages through the proxy,
assets straight from uploads), CSS `url()` resolution relative to the
stylesheet's own directory, SVG and binary assets streamed verbatim, absolute
and external references left alone, a symlink that escapes the extraction
directory refused with 403, and the query arguments a stale-hash redirect
carries forward (dropping `rest_route`).

**REST `/create` and `/save`** (`tests/unit/RestApiUploadTest.php`, new) — 82.02% → 97.82%.
The transactional save end to end: the file is replaced, metadata points at a
fresh extraction, the superseded hash is retired as a redirectable alias, and
`exelearning_before_elpx_save` / `exelearning_after_elpx_save` fire with the
right arguments. Every rollback path is covered too — invalid new content
(original file, metadata and extraction untouched), a truncated copy, a target
that cannot be written, a failed `/create` leaving no orphan attachment, and a
concurrent save refused with 409 on both the transient and the object-cache
lock.

Getting there needed one piece of scaffolding: `wp_handle_upload()` rejects any
file that did not arrive through a real multipart POST, which no CLI test can
produce. The tests install an `$overrides['upload_error_handler']` — the seam
`_wp_handle_upload()` hands control to, returning whatever it produces — that
places the file where WordPress would have put it. Everything the plugin does
after that runs unmodified.

**Editor screen** (`tests/unit/EditorPageTest.php`, new) — 81.48% → 98.52%.
The guards in front of the standalone editor: missing and forged nonces, a user
without `upload_files`, a missing attachment, a non-`.elpx` file, and a user who
may upload but cannot edit that particular attachment. Also the request takeover
itself — output buffered from the constructor, renderer scheduled at `admin_init`
priority -999, and every buffer discarded before the page is rendered.

**Export bootstrap payload** (`tests/unit/ExportBootstrapPayloadTest.php`, new) — 45.21% → 80.82%.
The configuration injected into the bundled editor template: valid JSON in
`window.__WP_EXE_CONFIG__`, the bridge script, insertion inside `<head>`, a
single `<base>` tag, and `./` asset paths rewritten to absolute plugin URLs.

**Settings screen** (`tests/unit/AdminSettingsScreenTest.php`, new) — 82.48% → 94.59%.
Contextual help tab and sidebar, assets enqueued on this screen only, the
screen-load callback wiring, and the missing-editor notice — which is raised
only when the bundle really is absent, so the `editor-missing=1` marker cannot
fake a warning on a healthy install.

**Error and edge branches added to the existing suites:**

- `Elp_Upload_Handler` 93.68% → 100%: a failed extraction rejects the upload,
  deletes the stored file and leaves no orphaned directory; an unusable uploads
  directory is reported.
- `Media_Library` 98.05% → 100%: bulk reprocess counts an attachment the user
  cannot edit as a failure, and reports a broken `.elpx` as failed rather than
  skipped.
- `Shortcodes` 98.95% → 100% and `Elp_Upload_Block` 99.46% → 100%: the
  `download_formats` attribute selects the offered formats and drops unknown ids.
- `Elp_File_Service` 92.72% → 97.09%: the uncompressed-size guard, an
  uncreatable destination, an entry that cannot be written, directory entries,
  and an unopenable archive.
- `Reprocessor` 88.96% → 95.71%: candidate classification, the eligibility
  content gate, the candidate scan, cleanup after a failed extraction.
- `Style_Package` 91.56% → 96.00% and `Styles_Service` 92.89% → 95.56%: malformed
  `config.xml`, root-level subdirectories, wrapper-folder stripping, unsafe
  entries during extraction, prefix handling, the file manifest and the icon scan.
- `Download_Button_Renderer` 97.25% → 99.08%: slug fallback for an untitled
  attachment and unknown format ids.
- `Admin_Styles` 68.18% → 77.27%: a temp path that did not arrive through an
  upload is refused.

## What is still not covered, and why

The remaining 185 statements are not reachable from PHPUnit:

- **`admin/views/editor-bootstrap.php` (90 statements, 49% of the gap)** — the
  standalone editor template. It tears down every output buffer, redirects, and
  ends in `exit()`; it only runs inside a real wp-admin request. Its guards live
  in `ExeLearning_Editor::render_editor_page()`, which is now covered.
- **`exit()` paths** — `Content_Proxy::serve_content()` after a successful
  `serve_file()`, `Editor::render_editor_page()` after the `include`,
  `Export_Bootstrap::maybe_render()` after composing the page.
- **`Admin_Styles::handle_upload()` past its `is_uploaded_file()` gate** (10
  statements) — that function consults the SAPI's upload list, which is empty
  under CLI, so nothing after the check can run. The check itself is now tested.
- **Defensive I/O failure branches** — `getFromIndex()` returning false,
  `file_put_contents()` failing, `statIndex()` returning false. Tests run as
  root in wp-env, so permission-based failures cannot be provoked; where a
  failure could be forced structurally (mkdir under a regular file, copy onto a
  directory) it now is.
- **Response headers** — `Content_Proxy::send_headers()` runs in the tests but
  its output cannot be asserted: the CLI runner has already flushed WordPress'
  bootstrap banner, so every `header()` call is a no-op that neither
  `headers_list()` nor `xdebug_get_headers()` records. The CSP and framing
  policy stay covered by the E2E suite only.
- **PHP < 8 code** (`libxml_disable_entity_loader`) and
  `exelearning_run()` / `uninstall.php`, which run before or outside the
  measured request.

Ignoring `editor-bootstrap.php`, coverage of the PHP classes is 96.92%
(2990/3085).

One incidental finding, left as is: `ExeLearning_Content_Proxy::is_html_path()`
is private, static and never called — dead code superseded by
`is_proxied_path()`. It is 3 of the uncovered statements.

## Checks

- `make test` — 907 tests, 1980 assertions, green (1 skipped: the export
  bootstrap template test that only applies when the editor bundle is absent;
  its counterpart runs instead).
- `make lint` — clean.
- PHPMD — clean.



---

## Added: the assert-nothing tests are gone

Ten tests in the existing suite ended in `$this->assertTrue( true )` — they pass whatever the code under them does. They predate this branch, but leaving them next to 2,300 lines of new tests would have been odd, so they are fixed here.

**Four were calling empty stubs.** `ExeLearning::run()`, `Post_Types::register_post_types()`, `Activator::activate()` and `Deactivator::deactivate()` have no body beyond a comment, so there is nothing to assert — those tests are deleted. The `I18n` one went too: `test_load_textdomain_resolves_bundled_spanish_translation` already covers the real contract.

`register_post_types()` is the exception: registering **no** post type is the documented decision (ELP packages are attachments), so the test is inverted to assert that calling it adds no post type at all. That guards the design instead of the empty body.

**Six had a real contract nobody was asserting:**

| Test | Now asserts |
|---|---|
| media modal skips other hooks | assets stay out of non-media screens (the old comment admitted it could not check this — the process-global `did_action( 'wp_enqueue_media' )` counter is cleared for the duration) |
| delete folder, no metadata | an unrelated extraction survives |
| delete folder, missing dir | same, plus the stored hash survives |
| `recursive_delete` missing path | a sibling directory is not taken with it |
| editor page registered | lands in `$_registered_pages`, never attaches to a real parent menu |
| *(new)* editor page capability | a user without `upload_files` does not get the page |

**Every new assertion was verified by breaking the production code**, which is the only way to know a test is worth having. Forcing the enqueue past its hook check, lowering the editor page capability to `read`, and making the folder delete ignore the stored hash each turn the corresponding test red; all three mutations were reverted.

**904 tests / 1984 assertions**, from 907 / 1978 — three fewer tests, six more assertions. Coverage moves 94.17% → **94.08%**, still over the gate; the difference is exactly the empty stub bodies that no longer get called by a test that never checked them.



---

## Added: one ruleset decides what PHPCS checks

`composer phpcs` ran `phpcs --standard=WordPress .` with its own `--ignore` list, while `make lint` and CI used `.phpcs.xml.dist`. The two checked different things, so a clean `make lint` said nothing about `composer phpcs`.

Both now go through the ruleset, which already declares its own scope:

```
composer phpcs  = phpcs  --standard=.phpcs.xml.dist
composer phpcbf = phpcbf --standard=.phpcs.xml.dist
make lint / fix → composer phpcs / phpcbf
```

Same arrangement in all four sibling plugins. The repo's own rules — the `exelearning` text domain, the `wp-content/uploads` and `languages/` relative-path exclusions, the `bin/` exclusion — are untouched; only the plumbing is shared.

`make lint` and `composer phpcs` both exit 0.



---

## Added: pin the coding standard

Verifying that all four plugins use [WordPress/WordPress-Coding-Standards](https://github.com/WordPress/WordPress-Coding-Standards) exposed a resolution trap. `wp-coding-standards/wpcs` and `squizlabs/php_codesniffer` were both `*`, which does not mean "the newest": WPCS 3.4.1 requires `php_codesniffer ^3.13.5`, and with both unconstrained Composer backtracks instead of raising the sniffer.

```
$ composer update wp-coding-standards/wpcs --dry-run
  - Downgrading wp-coding-standards/wpcs (3.4.0 => 0.14.0)
```

`composer.lock` is not committed, so CI resolves fresh every run and could pick up that 2018 ruleset. Pinning to `^3.4` / `^3.13.5` keeps the modern standard; the code passes it unchanged (`composer phpcs` exits 0). Same constraints as the three sibling plugins.

### Still worth a separate decision

`phpcompatibility/phpcompatibility-wp` sits in `require-dev` but **no ruleset references it**, so it currently does nothing.



---

## Added: the Plugin Check step could never fail

The target captured the exit code of `wp plugin check` and failed on non-zero. That never fires: **the command exits 0 even when it reports errors.**

Verified by injecting a forbidden `eval()` into a sibling plugin — the checker printed three `ERROR` lines and still exited 0. So this CI step has been passing unconditionally.

It now reads the output and counts `ERROR` lines, the approach `wp-documentate` already used. This plugin has no Plugin Check errors, so the result is unchanged today; what changes is that a future one gets caught instead of sailing through.



---

## And then the Plugin Check, once able to fail, said this

```
0  0  ERROR  no_plugin_readme  The plugin readme.txt does not exist.
```

`readme.txt` is right there in the repo root. The checker simply had **no files left to look at**.

The exclusion list named `exelearning` — the editor submodule directory. But the plugin is installed under that same name, so the rule matched the plugin's **own root** and excluded everything in it. The Plugin Check step has been scanning zero files.

This is the same trap `.phpcs.xml.dist` already documents at length for PHPCS, where an absolute-type pattern matched the checkout location and silently excluded every file. Same shape, different tool.

### Verified, not guessed

On a wp-env started on free ports with plugin-check 2.0.0 (port 8888 was held by an unrelated project, so nothing of anyone else's was touched):

| exclusion list | result |
|---|---|
| `tests,exelearning,dist` (old) | only `no_plugin_readme` — nothing scanned |
| `tests,dist` | real files appear, real errors in `bin/po-update.php` |
| `tests,bin` (new) | walks the plugin, **no errors** |

Neither the submodule nor `dist/` contains a single PHP file, so excluding them was never necessary in the first place. `tests/` and `bin/` are the only two directories that hold PHP and are not shipped.



---

## Added: the PHP minimum is declared where WordPress reads it, and checked

`readme.txt` said `Requires PHP: 8.0`, but **`exelearning.php` carried no `Requires PHP` header at all** — and that is the one WordPress reads to stop activation on an unsupported install. `readme.txt` only matters to the .org directory, so the plugin was unprotected exactly where it counts. Added, along with `"php": ">=8.0"` in `composer.json`.

The minimum is now checked instead of asserted. `phpcompatibility-wp` was already in `require-dev` with **no ruleset referencing it**, so it had never run once. The ruleset now pulls in `PHPCompatibilityWP` with `testVersion 8.0-`.

The code passes unchanged — **zero issues against 8.0**. And the check demonstrably runs: the same ruleset pointed at 5.6 reports 29 issues across 5 files.

For reviewers: CI exercises 8.3 only, so 8.0–8.2 is verified statically here but not executed. `wp-decker` took the same shape in its own PR.

### One consequence worth knowing

Adding a header line shifted the line numbers the POT references, so the committed catalogs stopped matching `make-pot` and the translation gate failed. Regenerated in its own commit; the diff is nothing but `#: exelearning.php:14` becoming `:15`, with no msgid or translation touched.
