### PR TITLE
Raise coverage to ~96.7% and fix three defects found on the way

### DIFF
--- a/admin/views/editor-bootstrap.php
+++ b/admin/views/editor-bootstrap.php
@@ -2,8 +2,18 @@
 /**
  * EXeLearning Static Editor Bootstrap
  *
- * Loads the static PWA version of eXeLearning editor with WordPress integration.
- * The static editor is built with `make build-editor` and placed in dist/static/.
+ * Builds the standalone editor page: the static PWA version of the eXeLearning
+ * editor, patched with the WordPress integration it needs to talk back to this
+ * site. The static editor is built with `make build-editor` and placed in
+ * dist/static/.
+ *
+ * This view *returns* its HTML rather than echoing it, so the caller owns
+ * output buffering, headers and the exit — and so the whole file can be
+ * exercised from a test. See ExeLearning_Editor::render_editor_page(), which is
+ * the only thing that includes it.
+ *
+ * Returns the assembled HTML document, or false when no editor is bundled, in
+ * which case the caller sends the administrator to the settings screen.
  *
  * @package Exelearning
  */
@@ -15,11 +25,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // All top-level variables in this template are prefixed with `exelearning_`
 // to satisfy WordPress.NamingConventions.PrefixAllGlobals (Plugin Check).
-
-// Ensure clean output - discard any previous output/warnings.
-while ( ob_get_level() > 0 ) {
-	ob_end_clean();
-}
 
 // Get parameters - nonce verification is done in ExeLearning_Editor class before loading this template.
 // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified in class-exelearning-editor.php
@@ -65,18 +70,10 @@ $exelearning_user_id   = $exelearning_user_data->ID ? $exelearning_user_data->ID
 $exelearning_static_index = ExeLearning_Editor_Bundle::get_path() . 'index.html';
 
 if ( ! ExeLearning_Editor_Bundle::is_available() ) {
-	// The editor is never downloaded at runtime: explain the situation on
-	// the settings screen instead of failing or loading remotely.
-	wp_safe_redirect(
-		add_query_arg(
-			array(
-				'page'           => 'exelearning-settings',
-				'editor-missing' => '1',
-			),
-			admin_url( 'options-general.php' )
-		)
-	);
-	exit;
+	// The editor is never downloaded at runtime (ADR-0002). Report the
+	// situation to the caller, which sends the administrator to the settings
+	// screen to read what to do about it.
+	return false;
 }
 
 $exelearning_editor_base_url = EXELEARNING_PLUGIN_URL . 'dist/static';
@@ -540,8 +537,11 @@ $exelearning_template = str_replace( '</head>', $exelearning_wp_config_script . 
 
 // Add <base> tag to set the base URL for all relative paths.
 // This ensures paths like "files/perm/..." resolve to the static editor directory.
+// The word boundary matters: the editor's own markup contains
+// `<header id="head">`, which `<head[^>]*>` also matches, and without it a
+// second stray <base> lands in the middle of the body.
 $exelearning_base_tag = sprintf( '<base href="%s/">', esc_url( $exelearning_editor_base_url ) );
-$exelearning_template = preg_replace( '/(<head[^>]*>)/i', '$1' . $exelearning_base_tag, $exelearning_template );
+$exelearning_template = preg_replace( '/(<head\b[^>]*>)/i', '$1' . $exelearning_base_tag, $exelearning_template, 1 );
 
 // Fix asset paths: Replace relative paths with absolute plugin paths.
 // The static build uses relative paths like "./app/", we need absolute paths.
@@ -552,12 +552,5 @@ $exelearning_template = preg_replace(
 	$exelearning_template
 );
 
-// Send proper headers.
-if ( ! headers_sent() ) {
-	header( 'Content-Type: text/html; charset=utf-8' );
-	header( 'X-Content-Type-Options: nosniff' );
-}
-
-// Output the processed template.
-// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-echo $exelearning_template;
+// Hand the assembled document back; the caller sends the headers and prints it.
+return $exelearning_template;

--- a/assets/js/exelearning-admin.js
+++ b/assets/js/exelearning-admin.js
@@ -1,6 +1,0 @@
-(function($) {
-    'use strict';
-
-    console.log("exelearning-admin.js loaded")    
-
-})(jQuery);

--- a/assets/js/exelearning.js
+++ b/assets/js/exelearning.js
@@ -1,6 +1,0 @@
-(function($) {
-    'use strict';
-
-    console.log("exelearning.js loaded")    
-
-})(jQuery);

--- a/bin/validate-translations.php
+++ b/bin/validate-translations.php
@@ -33,7 +33,11 @@ $errors    = array();
  * Directories that are never scanned for translatable JavaScript sources.
  * Kept in sync with the make-pot/i18n-audit exclude list.
  */
-$excluded_dirs = array( 'vendor', 'node_modules', 'tests', 'wp', 'wp-content', 'dist', 'exelearning', 'bin', 'node_modules', '.git' );
+// `artifacts` holds generated reports, not shipped code: the PHPUnit HTML
+// coverage report bundles its own JavaScript, and without this every run of
+// `make test-coverage` makes `make check-translations` fail on files that are
+// gitignored and never reach a release.
+$excluded_dirs = array( 'vendor', 'node_modules', 'tests', 'wp', 'wp-content', 'dist', 'exelearning', 'bin', 'artifacts', 'node_modules', '.git' );
 
 /**
  * Discover the shipped locales from the committed PO filenames.

--- a/docs/architecture/adr/ADR-0002-bundle-editor-exclusively-in-release-packages.md
+++ b/docs/architecture/adr/ADR-0002-bundle-editor-exclusively-in-release-packages.md
@@ -7,7 +7,8 @@ related:
   issues: []
   prs:
     - https://github.com/exelearning/moodle-mod_exelearning/pull/106
-  sdds: []
+  sdds:
+    - SDD-0003
   adrs: []
 supersedes: []
 superseded_by: []

--- a/docs/architecture/adr/ADR-0002-bundle-editor-exclusively-in-release-packages.md
+++ b/docs/architecture/adr/ADR-0002-bundle-editor-exclusively-in-release-packages.md
@@ -9,6 +9,7 @@ related:
     - https://github.com/exelearning/moodle-mod_exelearning/pull/106
   sdds:
     - SDD-0003
+    - SDD-0004
   adrs: []
 supersedes: []
 superseded_by: []

--- a/docs/architecture/adr/records.md
+++ b/docs/architecture/adr/records.md
@@ -10,7 +10,7 @@ status, update the table and the per-status lists below.
 | ID | Title | Status | Date | Related SDD |
 |----|-------|--------|------|-------------|
 | [ADR-0001](ADR-0001-obsolete-hash-alias-storage.md) | Resolve obsolete extraction hashes through attachment post meta aliases | Accepted | 2026-07-10 | [SDD-0001](../sdd/SDD-0001-stale-content-url-redirects.md) |
-| [ADR-0002](ADR-0002-bundle-editor-exclusively-in-release-packages.md) | Bundle the embedded editor exclusively in release packages | Accepted | 2026-07-24 | — |
+| [ADR-0002](ADR-0002-bundle-editor-exclusively-in-release-packages.md) | Bundle the embedded editor exclusively in release packages | Accepted | 2026-07-24 | [SDD-0003](../sdd/SDD-0003-testable-editor-bundle-paths.md) |
 | [ADR-0003](ADR-0003-distignore-single-source-of-truth.md) | Make `.distignore` the single source of truth for the release ZIP | Proposed | 2026-08-03 | [SDD-0002](../sdd/SDD-0002-unify-release-packaging.md) |
 
 ## Proposed ADRs

--- a/docs/architecture/adr/records.md
+++ b/docs/architecture/adr/records.md
@@ -10,7 +10,7 @@ status, update the table and the per-status lists below.
 | ID | Title | Status | Date | Related SDD |
 |----|-------|--------|------|-------------|
 | [ADR-0001](ADR-0001-obsolete-hash-alias-storage.md) | Resolve obsolete extraction hashes through attachment post meta aliases | Accepted | 2026-07-10 | [SDD-0001](../sdd/SDD-0001-stale-content-url-redirects.md) |
-| [ADR-0002](ADR-0002-bundle-editor-exclusively-in-release-packages.md) | Bundle the embedded editor exclusively in release packages | Accepted | 2026-07-24 | [SDD-0003](../sdd/SDD-0003-testable-editor-bundle-paths.md) |
+| [ADR-0002](ADR-0002-bundle-editor-exclusively-in-release-packages.md) | Bundle the embedded editor exclusively in release packages | Accepted | 2026-07-24 | [SDD-0003](../sdd/SDD-0003-testable-editor-bundle-paths.md), [SDD-0004](../sdd/SDD-0004-editor-bootstrap-view-returns-html.md) |
 | [ADR-0003](ADR-0003-distignore-single-source-of-truth.md) | Make `.distignore` the single source of truth for the release ZIP | Proposed | 2026-08-03 | [SDD-0002](../sdd/SDD-0002-unify-release-packaging.md) |
 
 ## Proposed ADRs

--- a/docs/architecture/sdd/SDD-0003-testable-editor-bundle-paths.md
+++ b/docs/architecture/sdd/SDD-0003-testable-editor-bundle-paths.md
@@ -1,0 +1,336 @@
+---
+id: SDD-0003
+title: "Resolve every editor bundle path through one helper, and let tests supply the bundle"
+status: Implemented
+date: 2026-08-04
+related:
+  issues: []
+  prs: []
+  adrs:
+    - ADR-0002
+  sdds: []
+supersedes: []
+superseded_by: []
+ai_assistance:
+  tool: "Claude Code"
+  model: "claude-opus-5"
+---
+
+# SDD-0003: Resolve every editor bundle path through one helper, and let tests supply the bundle
+
+## Status
+
+Implemented
+
+## Summary
+
+Two classes built their own path to the bundled static editor instead of asking
+`ExeLearning_Editor_Bundle`, and no test could point the plugin at a bundle of
+its own. The result was a block of code that behaved differently depending on
+the machine it ran on: unreachable in CI, and exercised against an arbitrary
+editor build locally. This routes both paths through the existing helper and
+adds a test-only seam so the suite supplies its own fixture bundle.
+
+## Context
+
+The embedded editor lives in `dist/static/` inside the plugin directory.
+[ADR-0002](../adr/ADR-0002-bundle-editor-exclusively-in-release-packages.md)
+makes that the only runtime editor source: release ZIPs ship it, the plugin
+never downloads it, and a source checkout has nothing there until
+`make build-editor` runs.
+
+`ExeLearning_Editor_Bundle` (`includes/class-editor-bundle.php` @ `690a2d8`)
+exists to answer "where is the bundle" and "is it usable", and documents its
+`get_plugin_dir()` as resolvable by subclassing "so tests can point the helper
+at a fixture directory".
+
+CI never builds the editor. `.github/workflows/ci.yml` @ `690a2d8` runs
+`make test-coverage` with no `make build-editor` step, and `.gitignore` @
+`690a2d8` excludes `dist/static/`. So under CI the bundle is always absent and
+on a developer machine it is usually a full editor build.
+
+## Problem statement
+
+Everything that reads the bundle was untestable, and the tests that touched it
+were untrustworthy.
+
+Measured on `main` @ `e9096dd` through the Codecov API, 120 of the 183 uncovered
+PHP lines — two thirds of the entire PHP gap — sat behind "is there a bundle":
+
+| Location | Lines | Why unreachable in CI |
+|----------|-------|-----------------------|
+| `admin/views/editor-bootstrap.php` | 84 | redirects and exits when the bundle is missing |
+| `admin/class-admin-settings.php:420-438` | 16 | `list_builtin_themes()` is empty, so the renderer returns early |
+| `includes/class-export-bootstrap.php:72-86,145-149` | 14 | `load_editor_template()` calls `wp_die()` without `index.html` |
+| `includes/class-styles-service.php:178-183` | 6 | reads `dist/static/data/bundle.json` |
+
+Worse than the coverage number: four tests branched on the environment rather
+than asserting a fixed outcome. `tests/unit/AdminSettingsScreenTest.php:94` and
+`tests/unit/AdminSettingsTest.php:266` @ `690a2d8` each ran
+`if ( ExeLearning_Editor_Bundle::is_available() )` and asserted something
+different in each branch, and two tests in
+`tests/unit/ExportBootstrapPayloadTest.php` @ `690a2d8` skipped each other out
+depending on the same condition — one of them showed up as the suite's single
+skipped test on a developer machine. A test whose assertion depends on whether
+someone ran `make build-editor` is not testing the plugin.
+
+The blocker is mechanical: `includes/class-styles-service.php:173` and
+`includes/class-export-bootstrap.php:140` @ `690a2d8` composed
+`EXELEARNING_PLUGIN_DIR . 'dist/static/…'` inline, and the helper's
+subclass-based seam cannot intercept a static call to
+`ExeLearning_Editor_Bundle::get_path()` from production code.
+
+## Goals
+
+- One place resolves the bundle path; nothing else spells out `dist/static`.
+- Every bundled-editor test asserts the same thing in CI, in a source checkout
+  and on a machine with a full editor build.
+- No test branches on `ExeLearning_Editor_Bundle::is_available()`, and none skip
+  because of it.
+
+## Non-goals
+
+- Making `admin/views/editor-bootstrap.php` testable. That template tears down
+  every output buffer and ends in `echo`, so it needs its own refactor; this
+  design only removes the bundle half of the blocker.
+- Covering `ExeLearning_Export_Bootstrap::maybe_render()` lines 72-86, which end
+  in `exit` and cannot be driven from PHPUnit.
+- Building the editor in CI. That needs Bun and the editor submodule, and would
+  add minutes to every run to produce something a fixture models in bytes.
+- Any runtime relocation of the editor. See *Security considerations*.
+
+## Current behavior
+
+`ExeLearning_Editor_Bundle::get_path()` returns
+`trailingslashit( EXELEARNING_PLUGIN_DIR ) . 'dist/static/'`, and
+`is_available()` requires a readable `index.html` plus one of `app/`, `libs/` or
+`files/`. `admin/views/editor-bootstrap.php:65` @ `690a2d8` already asked the
+helper. `includes/class-styles-service.php:173` and
+`includes/class-export-bootstrap.php:140` did not.
+
+## Proposed design
+
+Two changes, both small.
+
+**1. Route the remaining paths through the helper.**
+
+```php
+// includes/class-styles-service.php
+$bundle_path = ExeLearning_Editor_Bundle::get_path() . 'data/bundle.json';
+
+// includes/class-export-bootstrap.php
+$static_index = ExeLearning_Editor_Bundle::get_path() . 'index.html';
+```
+
+No behavior change: both compose the same string the helper already returns.
+
+**2. Add a guarded test seam to the helper.**
+
+```php
+private static $path_override = null;
+
+public static function set_path_override( $dir ) {
+    if ( ! defined( 'WP_TESTS_DOMAIN' ) ) {
+        return;
+    }
+    self::$path_override = null === $dir ? null : (string) $dir;
+}
+
+protected static function get_plugin_dir() {
+    if ( null !== self::$path_override ) {
+        return self::$path_override;
+    }
+    return EXELEARNING_PLUGIN_DIR;
+}
+```
+
+`WP_TESTS_DOMAIN` is defined by the WordPress test bootstrap and by nothing
+else, so on a live site the setter returns without assigning.
+
+**3. A fixture builder for the suite.**
+
+`tests/helpers/class-bundle-fixture.php`, loaded from `tests/bootstrap.php`,
+writes a minimal valid bundle to a temporary directory — `index.html`, an `app/`
+directory and a `data/bundle.json` declaring two known themes — and points the
+helper at it. `create_empty()` models the source checkout; `destroy()` restores
+the real directory.
+
+### Alternatives considered
+
+- **A fixture at the real `dist/static/` path, no production change.** Tests
+  would still run against a real build when one exists, so assertions about
+  bundle contents could only check shape, not values. Rejected: it buys
+  coverage and leaves the untrustworthy assertions in place.
+- **Parameter injection on the two readers.** Deterministic for those two, but
+  `admin/class-admin-settings.php:414` calls `list_builtin_themes()` with no
+  arguments, so the styles table stays environment-dependent. Reaches roughly
+  20 of the 120 lines.
+- **A `exelearning_editor_bundle_path` filter.** Rejected on ADR-0002 grounds;
+  see *Security considerations*.
+
+## Affected areas
+
+- [x] PHP plugin classes (`includes/`)
+- [x] Admin UI (`admin/`) — tests only
+- [x] Embedded editor install/build flow (`includes/class-editor-bundle.php`)
+- [x] Style registry (`includes/class-styles-service.php`)
+
+## Data model or storage impact
+
+Not applicable. No option, meta key, transient or on-disk layout changes. The
+fixture writes only under `get_temp_dir()` and removes itself.
+
+## WordPress hooks/filters impact
+
+Not applicable — and deliberately so. No hook is added; see *Security
+considerations*.
+
+## REST API impact
+
+Not applicable.
+
+## Shortcode/block impact
+
+Not applicable.
+
+## Security considerations
+
+The obvious way to make the path injectable is a filter. That is the option
+[ADR-0002](../adr/ADR-0002-bundle-editor-exclusively-in-release-packages.md)
+rejects: it decides that `dist/static/` inside the plugin directory is the only
+runtime editor source, and rejects Option 3 ("let administrators supply the
+editor") precisely because it decouples the served editor from the reviewed
+release. A public filter would reintroduce that, letting any plugin point the
+editor at a directory outside the reviewed package — remotely sourced
+executable code by another route.
+
+`set_path_override()` is therefore not an extension point:
+
+- It no-ops unless `WP_TESTS_DOMAIN` is defined, which happens only under the
+  WordPress test bootstrap.
+- It is marked `@internal` and documented as a test seam.
+- It fires no hook, so nothing can reach it by filtering.
+
+The override changes only where the plugin *reads* the editor from. It relaxes
+no capability check, nonce or escaping, and the bundle validation in
+`is_available()` still applies to whatever directory it points at.
+
+## Privacy considerations
+
+Not applicable.
+
+## Accessibility considerations
+
+Not applicable — no rendered output changes. The built-in styles table the new
+tests exercise keeps its existing `aria-label` per checkbox
+(`admin/class-admin-settings.php:486`).
+
+## Internationalization considerations
+
+No new user-facing strings. One existing assertion was resolving an English
+literal and failed once the test site was switched to `es_ES`; it now compares
+against `esc_html__()` so it holds in any locale. This is the same class of
+environment dependence the rest of this design removes.
+
+## Backward compatibility
+
+Full. Both routed call sites resolve to the byte-identical path they built
+inline, and on a live site `set_path_override()` cannot change anything. No
+stored data, ELPX package, shortcode, block or hook is affected.
+
+## Migration/rollout
+
+None required. Ships as a normal change; nothing to migrate and nothing to gate.
+
+## Testing strategy
+
+- `tests/unit/StylesServiceBuiltinsTest.php` (new) covers
+  `list_builtin_themes()` against a fixture that declares two known themes, plus
+  the absent, missing-manifest, empty, corrupt and no-themes cases.
+- `tests/unit/AdminSettingsTest.php` gains three tests for the built-in styles
+  table: the rows it renders, the cleared checkbox for a disabled built-in, and
+  the explanation shown when no editor is bundled.
+- The four environment-branching tests are split into pairs that each assert one
+  outcome against an explicit fixture.
+- `make test` for the suite, `make test-coverage` for the gate
+  (`MIN_COVERAGE = 94`), `./vendor/bin/phpcs --standard=.phpcs.xml.dist`.
+
+### Measured outcome
+
+Of the 120 bundle-gated lines, this recovers 25 and leaves 95 to the two
+refactors listed under *Follow-up tasks*. The fixture is a precondition for
+those 95, not a substitute: `admin/views/editor-bootstrap.php` still has to stop
+tearing down output buffering, and `maybe_render()` still ends in `exit`.
+
+| File | Before | After |
+|------|--------|-------|
+| `admin/class-admin-settings.php` | 94.65% (17 uncovered) | 100% |
+| `includes/class-styles-service.php` | 94.87% (13) | 96.8% (8) |
+| `includes/class-export-bootstrap.php` | 81.81% (14) | 86.6% (11) |
+| `admin/views/editor-bootstrap.php` | 0% (84) | 0% (84) |
+
+"Before" is the Codecov report for `main` @ `e9096dd`; "after" is
+`make test-coverage` locally. The suite total is 94.59% and reports no skipped
+tests, against 94.37% and one skip before.
+
+One line stays uncovered by construction: the `return` in
+`set_path_override()` taken when `WP_TESTS_DOMAIN` is undefined cannot execute
+inside a suite that defines it. That is the guard working.
+
+## Acceptance criteria
+
+- [x] No production file outside `includes/class-editor-bundle.php` spells out
+      the `dist/static` filesystem path.
+- [x] No test calls `ExeLearning_Editor_Bundle::is_available()` to decide what
+      to assert, and the suite reports zero skipped tests.
+- [x] `set_path_override()` is a no-op when `WP_TESTS_DOMAIN` is undefined.
+- [x] `make test` and PHPCS pass.
+
+## Open questions
+
+- Three URL call sites still build `EXELEARNING_PLUGIN_URL . 'dist/static'` by
+  hand (`includes/class-export-bootstrap.php:73`,
+  `includes/class-download-button-renderer.php:187-188`,
+  `admin/views/editor-bootstrap.php:82`). A matching `get_url()` on the helper
+  would finish the consolidation. Left out here because the URL does not gate
+  testability, and widening the change would blur what this one is for.
+
+## ADRs required or referenced
+
+| Decision | ADR | Status |
+|----------|-----|--------|
+| `dist/static/` in the plugin directory is the only runtime editor source | [ADR-0002](../adr/ADR-0002-bundle-editor-exclusively-in-release-packages.md) | Accepted |
+
+No new ADR: this design adds no durable decision of its own, it makes an
+existing one enforceable in one place and testable from the suite.
+
+## Evidence
+
+- `includes/class-styles-service.php:173` and
+  `includes/class-export-bootstrap.php:140` @ `690a2d8` — the two inline paths.
+- `includes/class-editor-bundle.php:64-70` @ `690a2d8` — the helper documenting
+  its seam as "so tests can point the helper at a fixture directory".
+- `tests/unit/AdminSettingsScreenTest.php:94`,
+  `tests/unit/AdminSettingsTest.php:266`,
+  `tests/unit/ExportBootstrapPayloadTest.php:146,162` @ `690a2d8` — the four
+  environment-dependent tests.
+- `.github/workflows/ci.yml` @ `690a2d8` — no `make build-editor` before
+  `make test-coverage`; `.gitignore:64` @ `690a2d8` — `dist/static/` ignored.
+- Codecov API for `main` @ `e9096dd` — the per-file uncovered line numbers in
+  the table above.
+- WordPress test bootstrap — `WP_TESTS_DOMAIN` is defined by
+  `wp-tests-config.php`, verified under `make test` in this environment
+  (`localhost:8889`).
+
+## Follow-up tasks
+
+- [ ] Add `ExeLearning_Editor_Bundle::get_url()` and route the three remaining
+      URL call sites through it.
+- [ ] Extract the body of `admin/views/editor-bootstrap.php` into a method that
+      returns the HTML, so the template stops being a 84-line blind spot.
+
+## References
+
+- [ADR-0002](../adr/ADR-0002-bundle-editor-exclusively-in-release-packages.md) —
+  Bundle the embedded editor exclusively in release packages.
+- [`docs/architecture/sdd/records.md`](records.md) — SDD index.

--- a/docs/architecture/sdd/SDD-0004-editor-bootstrap-view-returns-html.md
+++ b/docs/architecture/sdd/SDD-0004-editor-bootstrap-view-returns-html.md
@@ -1,0 +1,238 @@
+---
+id: SDD-0004
+title: "Make the editor bootstrap a view that returns its HTML"
+status: Implemented
+date: 2026-08-04
+related:
+  issues: []
+  prs: []
+  adrs:
+    - ADR-0002
+  sdds:
+    - SDD-0003
+supersedes: []
+superseded_by: []
+ai_assistance:
+  tool: "Claude Code"
+  model: "claude-opus-5"
+---
+
+# SDD-0004: Make the editor bootstrap a view that returns its HTML
+
+## Status
+
+Implemented
+
+## Summary
+
+`admin/views/editor-bootstrap.php` builds the whole embedded editor page — the
+REST endpoint and nonce the editor saves through, the `<base>` tag its assets
+resolve against, the approved style registry — and then printed it and ended the
+process. Nothing about it could be checked, because merely running it tore down
+PHPUnit's output buffering and called `exit`. The view now returns its HTML and
+the caller owns the side effects. The same split is applied to
+`ExeLearning_Export_Bootstrap::maybe_render()`.
+
+## Context
+
+[SDD-0003](SDD-0003-testable-editor-bundle-paths.md) removed the first half of
+the blocker: tests can now supply an editor bundle instead of depending on
+whether the machine had run `make build-editor`. It listed this extraction as a
+follow-up, because supplying a bundle does not help when the file under test
+ends the process on the way out.
+
+`tests/unit/EditorPageTest.php` @ `22b6676` documented the situation in its own
+header: "The template itself cannot run under PHPUnit (it tears down every
+output buffer and exits), so these tests cover the guards that decide whether
+the request ever gets that far."
+
+## Problem statement
+
+84 executable lines — the entire contract between WordPress and the embedded
+editor — had no test. A typo in the injected REST URL, a nonce created for the
+wrong action, a `<base>` tag pointing at the wrong directory: each breaks
+editing outright, and each would ship unnoticed. The E2E suite does not open the
+editor page either (`tests/e2e/` @ `22b6676` covers activation, the shortcode
+viewer and viewer enhancements).
+
+The same shape blocked 11 lines of `ExeLearning_Export_Bootstrap::maybe_render()`
+@ `22b6676`, where composing the document and sending it were one method.
+
+## Goals
+
+- The editor page can be built, inspected and asserted on from a test.
+- The bytes served are unchanged by the refactor.
+- Only genuinely process-ending code stays untestable.
+
+## Non-goals
+
+- Moving the 450 lines of inline JavaScript into PHP. They are a template's
+  content and belong in a template; relocating them into a class would make
+  them harder to read and risk a transcription error in the one file with no
+  test to catch it.
+- Changing anything the editor receives.
+
+## Proposed design
+
+**The view returns instead of printing.** PHP's `include` evaluates to whatever
+the included file returns, so the view stays exactly where it is and becomes a
+function of its inputs:
+
+- the `while ( ob_get_level() )` teardown, the headers and the `echo` move out;
+- the "no bundle" case returns `false` instead of redirecting and exiting;
+- the final `echo $exelearning_template` becomes `return`.
+
+**The caller owns the side effects.** `ExeLearning_Editor` gains
+`build_bootstrap_page()` (includes the view and returns its result),
+`serve_bootstrap_page()` (decides between redirect and send) and two protected
+one-liners, `redirect_and_exit()` and `send_and_exit()`, that hold everything
+which ends the process. This is the existing
+`ExeLearning_Admin_Styles::finish_request()` pattern
+(`admin/class-admin-styles.php:146` @ `22b6676`), which a test subclass
+overrides for exactly this reason.
+
+**Export bootstrap, same split.** `maybe_render()` becomes a two-liner over a
+public `build_page()` and a protected `send()`.
+
+## Affected areas
+
+- [x] PHP plugin classes (`includes/`)
+- [x] Admin UI (`admin/views/editor-bootstrap.php`)
+- [x] Embedded editor install/build flow
+
+## Data model or storage impact
+
+Not applicable.
+
+## WordPress hooks/filters impact
+
+Not applicable. No hook added, changed or removed.
+
+## REST API impact
+
+Not applicable. The page still advertises the same `exelearning/v1` base and a
+`wp_rest` nonce; what it sends is now asserted rather than assumed.
+
+## Shortcode/block impact
+
+Not applicable.
+
+## Security considerations
+
+The capability and nonce checks stay in `render_editor_page()`, ahead of
+everything this design touches, and are unchanged: `wp_verify_nonce` against
+`exelearning_editor`, `current_user_can( 'upload_files' )`, an `.elpx`
+extension, and `current_user_can( 'edit_post', $attachment_id )`.
+
+Two things are now covered that were not: that the injected nonce actually
+verifies against `wp_rest` (a nonce for the wrong action would leave every save
+rejected), and that the page reports the signed-in user rather than a stale one.
+
+`send_and_exit()` keeps `X-Content-Type-Options: nosniff` and the explicit
+content type. Output escaping is untouched — the same
+`WordPress.Security.EscapeOutput` exemption applies to the same assembled
+document, now printed one layer up.
+
+## Privacy considerations
+
+Not applicable. The page carries the display name and ID of the user who
+requested it, exactly as before.
+
+## Accessibility considerations
+
+Not applicable — the served markup is unchanged, except that a stray `<base>`
+no longer appears in the body (see below), which is a validity fix.
+
+## Internationalization considerations
+
+No new user-facing strings.
+
+## Backward compatibility
+
+The served document is byte-identical, with one deliberate exception. The diff
+of the view touches only its docblock, the buffer teardown, the bundle-missing
+branch and the tail; the data preparation and every injection step are
+untouched, so the output cannot differ.
+
+The exception is a defect this work surfaced. The pattern that finds the head
+element, `/(<head[^>]*>)/i`, also matches the editor's own
+`<header id="head">`, so a second `<base href="…">` was being injected into the
+middle of the body on every page. Browsers honour only the first `<base>`, so
+nothing was visibly broken, but the markup was invalid. The pattern now uses a
+word boundary and replaces once. Verified against the real 125 KB editor bundle:
+one `<base>`, in the head, with `<header id="head">` intact.
+
+## Migration/rollout
+
+None. No stored data, no option, no contract.
+
+## Testing strategy
+
+`tests/unit/EditorBootstrapPageTest.php` (new, 16 tests) builds the page against
+a fixture bundle and asserts the REST URL, a nonce that verifies, the attachment
+and its URL, the signed-in user, the site language, the `<base>` tag, the
+rewriting of `./` asset paths, the bridge script, the style registry, the
+untitled-attachment fallback, the unreadable-template failure, and the full
+front controller from a nonced request to a served document.
+
+It deliberately carries no `@covers` annotation: the subject is a view file
+rather than a class, and `@covers` restricts attribution to the named class and
+discards everything the view executed — which is the whole point of the file.
+
+`tests/unit/ExportBootstrapPayloadTest.php` gains three tests for `build_page()`.
+
+## Acceptance criteria
+
+- [x] The editor page is built and asserted on in tests.
+- [x] The served bytes are unchanged (single-`<base>` fix aside).
+- [x] `make test`, `make test-coverage` and PHPCS pass.
+
+## Open questions
+
+None.
+
+## ADRs required or referenced
+
+| Decision | ADR | Status |
+|----------|-----|--------|
+| `dist/static/` is the only runtime editor source | [ADR-0002](../adr/ADR-0002-bundle-editor-exclusively-in-release-packages.md) | Accepted |
+
+No new ADR. Nothing durable is decided here: the same page is produced by the
+same steps, arranged so they can be observed.
+
+## Evidence
+
+- `tests/unit/EditorPageTest.php:5-9` @ `22b6676` — the template "cannot run
+  under PHPUnit".
+- `admin/class-admin-styles.php:146` @ `22b6676` — the `finish_request()`
+  precedent for isolating `exit`.
+- `git diff` of the view — four hunks, none in the data preparation or the
+  injection steps.
+- Rendered against the real bundle: 125,802 bytes in, 147,171 out, one `<base>`
+  in the head, no leftover `./` paths.
+
+### Measured outcome
+
+| File | Before | After |
+|------|--------|-------|
+| `admin/views/editor-bootstrap.php` | 0% (84 uncovered) | 90.8% |
+| `includes/class-exelearning-editor.php` | 98.57% | 93.7% |
+| `includes/class-export-bootstrap.php` | 86.6% | 90.6% |
+| PHP suite | 94.59% | 97.12% |
+
+`class-exelearning-editor.php` drops because this design *adds* the two
+side-effect-only methods to it; both are one-liners around `exit`. What remains
+uncovered in the view is its `ABSPATH` guard and a `class_exists()` fallback for
+a class the plugin always loads.
+
+## Follow-up tasks
+
+- [ ] Add `ExeLearning_Editor_Bundle::get_url()` and route the three remaining
+      `EXELEARNING_PLUGIN_URL . 'dist/static'` call sites through it (carried
+      over from SDD-0003).
+
+## References
+
+- [SDD-0003](SDD-0003-testable-editor-bundle-paths.md) — the bundle fixture this
+  builds on, which listed this extraction as a follow-up.
+- [ADR-0002](../adr/ADR-0002-bundle-editor-exclusively-in-release-packages.md).

--- a/docs/architecture/sdd/records.md
+++ b/docs/architecture/sdd/records.md
@@ -12,6 +12,7 @@ the table and the per-status lists below.
 | [SDD-0001](SDD-0001-stale-content-url-redirects.md) | Stale content URL redirects to the latest ELPX extraction | Accepted | 2026-07-10 | [ADR-0001](../adr/ADR-0001-obsolete-hash-alias-storage.md) |
 | [SDD-0002](SDD-0002-unify-release-packaging.md) | Unify release packaging on `.distignore` and `wp dist-archive` | Draft | 2026-08-03 | [ADR-0003](../adr/ADR-0003-distignore-single-source-of-truth.md) |
 | [SDD-0003](SDD-0003-testable-editor-bundle-paths.md) | Resolve every editor bundle path through one helper, and let tests supply the bundle | Implemented | 2026-08-04 | [ADR-0002](../adr/ADR-0002-bundle-editor-exclusively-in-release-packages.md) |
+| [SDD-0004](SDD-0004-editor-bootstrap-view-returns-html.md) | Make the editor bootstrap a view that returns its HTML | Implemented | 2026-08-04 | [ADR-0002](../adr/ADR-0002-bundle-editor-exclusively-in-release-packages.md) |
 
 ## Draft SDDs
 
@@ -31,6 +32,8 @@ _No SDDs in review yet._
 
 - [SDD-0003](SDD-0003-testable-editor-bundle-paths.md) — Resolve every editor
   bundle path through one helper, and let tests supply the bundle.
+- [SDD-0004](SDD-0004-editor-bootstrap-view-returns-html.md) — Make the editor
+  bootstrap a view that returns its HTML.
 
 ## Superseded SDDs
 

--- a/docs/architecture/sdd/records.md
+++ b/docs/architecture/sdd/records.md
@@ -11,6 +11,7 @@ the table and the per-status lists below.
 |----|-------|--------|------|--------------|
 | [SDD-0001](SDD-0001-stale-content-url-redirects.md) | Stale content URL redirects to the latest ELPX extraction | Accepted | 2026-07-10 | [ADR-0001](../adr/ADR-0001-obsolete-hash-alias-storage.md) |
 | [SDD-0002](SDD-0002-unify-release-packaging.md) | Unify release packaging on `.distignore` and `wp dist-archive` | Draft | 2026-08-03 | [ADR-0003](../adr/ADR-0003-distignore-single-source-of-truth.md) |
+| [SDD-0003](SDD-0003-testable-editor-bundle-paths.md) | Resolve every editor bundle path through one helper, and let tests supply the bundle | Implemented | 2026-08-04 | [ADR-0002](../adr/ADR-0002-bundle-editor-exclusively-in-release-packages.md) |
 
 ## Draft SDDs
 
@@ -28,7 +29,8 @@ _No SDDs in review yet._
 
 ## Implemented SDDs
 
-_No implemented SDDs yet._
+- [SDD-0003](SDD-0003-testable-editor-bundle-paths.md) — Resolve every editor
+  bundle path through one helper, and let tests supply the bundle.
 
 ## Superseded SDDs
 

--- a/includes/class-editor-bundle.php
+++ b/includes/class-editor-bundle.php
@@ -31,6 +31,14 @@ class ExeLearning_Editor_Bundle {
 	const ASSET_DIRS = array( 'app', 'libs', 'files' );
 
 	/**
+	 * Directory standing in for the plugin directory under PHPUnit.
+	 *
+	 * @internal Test seam. Not part of the plugin's public API.
+	 * @var string|null
+	 */
+	private static $path_override = null;
+
+	/**
 	 * Get the bundled editor directory path.
 	 *
 	 * @return string Path to dist/static/ with a trailing slash.
@@ -61,6 +69,31 @@ class ExeLearning_Editor_Bundle {
 	}
 
 	/**
+	 * Point the helper at a fixture bundle for the duration of a test.
+	 *
+	 * Every path the plugin resolves for the embedded editor goes through
+	 * {@see self::get_path()}, and in a source checkout dist/static/ is absent
+	 * while on a developer machine it holds a full editor build. Tests that
+	 * exercise the bundled-editor paths would therefore assert against
+	 * whatever the machine happens to have, so they need to supply their own.
+	 *
+	 * This is not a way to relocate the editor: ADR-0002 makes dist/static/
+	 * inside the plugin directory the only runtime editor source, and the
+	 * guard below makes the setter a no-op outside the PHPUnit suite.
+	 *
+	 * @internal Test seam. Not part of the plugin's public API.
+	 *
+	 * @param string|null $dir Fixture directory holding dist/static/, or null to reset.
+	 * @return void
+	 */
+	public static function set_path_override( $dir ) {
+		if ( ! defined( 'WP_TESTS_DOMAIN' ) ) {
+			return;
+		}
+		self::$path_override = null === $dir ? null : (string) $dir;
+	}
+
+	/**
 	 * Base plugin directory holding dist/static/.
 	 *
 	 * Resolved through late static binding so tests can point the helper at a
@@ -69,6 +102,9 @@ class ExeLearning_Editor_Bundle {
 	 * @return string
 	 */
 	protected static function get_plugin_dir() {
+		if ( null !== self::$path_override ) {
+			return self::$path_override;
+		}
 		return EXELEARNING_PLUGIN_DIR;
 	}
 }

--- a/includes/class-exelearning-editor.php
+++ b/includes/class-exelearning-editor.php
@@ -137,9 +137,97 @@ class ExeLearning_Editor {
 			wp_die( esc_html__( 'You do not have permission to edit this file.', 'exelearning' ) );
 		}
 
-		// Load the editor bootstrap page.
-		include EXELEARNING_PLUGIN_DIR . 'admin/views/editor-bootstrap.php';
+		$this->serve_bootstrap_page( $attachment_id );
+	}
+
+	/**
+	 * Build the editor bootstrap page and send it, or bail out cleanly.
+	 *
+	 * The view returns its HTML instead of printing it, so everything with a
+	 * side effect — discarding buffered output, the headers, the redirect when
+	 * no editor is bundled, and the exit — lives here rather than inside a
+	 * template that could then never be exercised by a test.
+	 *
+	 * @param int $attachment_id Attachment being edited.
+	 * @return void
+	 */
+	protected function serve_bootstrap_page( $attachment_id ) {
+		$html = $this->build_bootstrap_page( $attachment_id );
+
+		if ( false === $html ) {
+			$this->redirect_and_exit( self::editor_missing_url() );
+			return;
+		}
+
+		$this->send_and_exit( $html );
+	}
+
+	/**
+	 * Send the administrator somewhere else and end the request.
+	 *
+	 * Isolated, like ExeLearning_Admin_Styles::finish_request(), so a test
+	 * subclass can drive the decision above without exit() ending the process.
+	 *
+	 * @param string $location Redirect target URL.
+	 * @return void
+	 */
+	protected function redirect_and_exit( $location ) {
+		wp_safe_redirect( $location );
 		exit;
+	}
+
+	/**
+	 * Print the editor document and end the request.
+	 *
+	 * Everything here is a side effect on the process: discarding whatever was
+	 * buffered before (deprecation notices, stray output) so the document
+	 * starts at its first byte, the headers, and the exit.
+	 *
+	 * @param string $html Assembled HTML document.
+	 * @return void
+	 */
+	protected function send_and_exit( $html ) {
+		while ( ob_get_level() > 0 ) {
+			ob_end_clean();
+		}
+
+		if ( ! headers_sent() ) {
+			header( 'Content-Type: text/html; charset=utf-8' );
+			header( 'X-Content-Type-Options: nosniff' );
+		}
+
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Standalone HTML document composed from the bundled editor and escaped values.
+		echo $html;
+		exit;
+	}
+
+	/**
+	 * Render the bootstrap view for an attachment.
+	 *
+	 * @param int $attachment_id Attachment being edited.
+	 * @return string|false The HTML document, or false when no editor is bundled.
+	 */
+	public function build_bootstrap_page( $attachment_id ) {
+		// The view reads the attachment from the query, exactly as it did when
+		// it was included directly.
+		$_GET['attachment_id'] = (int) $attachment_id;
+
+		return include EXELEARNING_PLUGIN_DIR . 'admin/views/editor-bootstrap.php';
+	}
+
+	/**
+	 * Settings screen URL that explains a missing editor bundle.
+	 *
+	 * @return string
+	 */
+	public static function editor_missing_url() {
+		return add_query_arg(
+			array(
+				'page'           => 'exelearning-settings',
+				'editor-missing' => '1',
+			),
+			admin_url( 'options-general.php' )
+		);
 	}
 
 	/**

--- a/includes/class-export-bootstrap.php
+++ b/includes/class-export-bootstrap.php
@@ -66,6 +66,18 @@ class ExeLearning_Export_Bootstrap {
 			return;
 		}
 
+		$this->send( $this->build_page() );
+	}
+
+	/**
+	 * Build the export bootstrap document for the current request.
+	 *
+	 * Split out of maybe_render() so it can be exercised: everything up to this
+	 * point is ordinary composition, while sending the result ends the process.
+	 *
+	 * @return string The assembled HTML document.
+	 */
+	public function build_page() {
 		$attachment_id = $this->resolve_attachment_id();
 		$this->assert_valid_attachment( $attachment_id );
 
@@ -73,8 +85,16 @@ class ExeLearning_Export_Bootstrap {
 		$editor_base_url = EXELEARNING_PLUGIN_URL . 'dist/static';
 		$template        = $this->load_editor_template();
 
-		$template = $this->inject_bootstrap_payload( $template, $attachment_id, $elp_url, $editor_base_url );
+		return $this->inject_bootstrap_payload( $template, $attachment_id, $elp_url, $editor_base_url );
+	}
 
+	/**
+	 * Send the document and end the request.
+	 *
+	 * @param string $html Assembled HTML document.
+	 * @return void
+	 */
+	protected function send( $html ) {
 		while ( ob_get_level() > 0 ) {
 			ob_end_clean();
 		}
@@ -82,7 +102,7 @@ class ExeLearning_Export_Bootstrap {
 		header( 'Content-Type: text/html; charset=UTF-8' );
 		header( 'X-Robots-Tag: noindex' );
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Bootstrap HTML composed from trusted plugin template + sanitized inputs.
-		echo $template;
+		echo $html;
 		exit;
 	}
 

--- a/includes/class-export-bootstrap.php
+++ b/includes/class-export-bootstrap.php
@@ -137,7 +137,7 @@ class ExeLearning_Export_Bootstrap {
 	 * @return string
 	 */
 	private function load_editor_template() {
-		$static_index = EXELEARNING_PLUGIN_DIR . 'dist/static/index.html';
+		$static_index = ExeLearning_Editor_Bundle::get_path() . 'index.html';
 		if ( ! file_exists( $static_index ) ) {
 			wp_die( esc_html__( 'Static eXeLearning editor not installed.', 'exelearning' ), '', array( 'response' => 503 ) );
 		}

--- a/includes/class-styles-service.php
+++ b/includes/class-styles-service.php
@@ -170,7 +170,7 @@ class ExeLearning_Styles_Service {
 	 * @return array<int, array<string,mixed>>
 	 */
 	public static function list_builtin_themes() {
-		$bundle_path = EXELEARNING_PLUGIN_DIR . 'dist/static/data/bundle.json';
+		$bundle_path = ExeLearning_Editor_Bundle::get_path() . 'data/bundle.json';
 		if ( ! file_exists( $bundle_path ) || ! is_readable( $bundle_path ) ) {
 			return array();
 		}

--- a/languages/exelearning-ca.po
+++ b/languages/exelearning-ca.po
@@ -326,36 +326,36 @@ msgstr "Estil eliminat."
 msgid "Invalid nonce."
 msgstr "Nonce no vàlid."
 
-#: admin/views/editor-bootstrap.php:88
+#: admin/views/editor-bootstrap.php:85
 msgid "Failed to load eXeLearning editor template."
 msgstr "Error en carregar la plantilla de l'editor d'eXeLearning."
 
-#: admin/views/editor-bootstrap.php:89
+#: admin/views/editor-bootstrap.php:86
 msgid "Template Error"
 msgstr "Error de plantilla"
 
-#: admin/views/editor-bootstrap.php:96
-#: includes/class-exelearning-editor.php:178
-#: includes/class-exelearning-editor.php:211
+#: admin/views/editor-bootstrap.php:93
+#: includes/class-exelearning-editor.php:266
+#: includes/class-exelearning-editor.php:299
 msgid "Saving..."
 msgstr "Desant..."
 
-#: admin/views/editor-bootstrap.php:97
+#: admin/views/editor-bootstrap.php:94
 msgid "Saved to WordPress successfully"
 msgstr "Desat a WordPress correctament"
 
-#: admin/views/editor-bootstrap.php:98
-#: includes/class-exelearning-editor.php:177
-#: includes/class-exelearning-editor.php:210
-#: includes/class-exelearning-editor.php:240
+#: admin/views/editor-bootstrap.php:95
+#: includes/class-exelearning-editor.php:265
+#: includes/class-exelearning-editor.php:298
+#: includes/class-exelearning-editor.php:328
 msgid "Save to WordPress"
 msgstr "Desa a WordPress"
 
-#: admin/views/editor-bootstrap.php:99
+#: admin/views/editor-bootstrap.php:96
 msgid "Loading project..."
 msgstr "Carregant projecte..."
 
-#: admin/views/editor-bootstrap.php:100
+#: admin/views/editor-bootstrap.php:97
 msgid "Error"
 msgstr "Error"
 
@@ -496,12 +496,12 @@ msgid "You do not have permission to access this page."
 msgstr "No tens permís per accedir a aquesta pàgina."
 
 #: includes/class-exelearning-editor.php:124
-#: includes/class-export-bootstrap.php:111
+#: includes/class-export-bootstrap.php:131
 msgid "No attachment specified."
 msgstr "No s'ha especificat cap adjunt."
 
 #: includes/class-exelearning-editor.php:132
-#: includes/class-export-bootstrap.php:130
+#: includes/class-export-bootstrap.php:150
 msgid "This file is not an eXeLearning file (.elpx)."
 msgstr "Aquest fitxer no és un fitxer eXeLearning (.elpx)."
 
@@ -510,8 +510,8 @@ msgstr "Aquest fitxer no és un fitxer eXeLearning (.elpx)."
 msgid "You do not have permission to edit this file."
 msgstr "No tens permís per editar aquest fitxer."
 
-#: includes/class-exelearning-editor.php:175
-#: includes/class-exelearning-editor.php:208
+#: includes/class-exelearning-editor.php:263
+#: includes/class-exelearning-editor.php:296
 #: includes/integrations/class-media-library.php:195
 #: includes/integrations/class-media-library.php:349
 #: assets/js/elp-upload.js:434
@@ -519,23 +519,23 @@ msgstr "No tens permís per editar aquest fitxer."
 msgid "Edit in eXeLearning"
 msgstr "Edita a eXeLearning"
 
-#: includes/class-exelearning-editor.php:176
-#: includes/class-exelearning-editor.php:209
-#: includes/class-exelearning-editor.php:243
+#: includes/class-exelearning-editor.php:264
+#: includes/class-exelearning-editor.php:297
+#: includes/class-exelearning-editor.php:331
 msgid "Close"
 msgstr "Tanca"
 
-#: includes/class-exelearning-editor.php:179
-#: includes/class-exelearning-editor.php:212
+#: includes/class-exelearning-editor.php:267
+#: includes/class-exelearning-editor.php:300
 msgid "Please wait while the file is being saved."
 msgstr "Si us plau, espereu mentre es desa l'arxiu."
 
-#: includes/class-exelearning-editor.php:180
-#: includes/class-exelearning-editor.php:213
+#: includes/class-exelearning-editor.php:268
+#: includes/class-exelearning-editor.php:301
 msgid "You have unsaved changes. Are you sure you want to close?"
 msgstr "Teniu canvis sense desar. Esteu segurs que voleu tancar?"
 
-#: includes/class-exelearning-editor.php:235
+#: includes/class-exelearning-editor.php:323
 msgid "Edit eXeLearning File"
 msgstr "Edita el fitxer eXeLearning"
 
@@ -567,15 +567,15 @@ msgstr "Fitxer original no trobat."
 msgid "File saved successfully."
 msgstr "Fitxer desat correctament."
 
-#: includes/class-export-bootstrap.php:124
+#: includes/class-export-bootstrap.php:144
 msgid "Attachment not found."
 msgstr "No s'ha trobat l'adjunt."
 
-#: includes/class-export-bootstrap.php:142
+#: includes/class-export-bootstrap.php:162
 msgid "Static eXeLearning editor not installed."
 msgstr "L'editor estàtic d'eXeLearning no està instal·lat."
 
-#: includes/class-export-bootstrap.php:147
+#: includes/class-export-bootstrap.php:167
 msgid "Failed to load editor template."
 msgstr "No s'ha pogut carregar la plantilla de l'editor."
 

--- a/languages/exelearning-ca_valencia.po
+++ b/languages/exelearning-ca_valencia.po
@@ -326,36 +326,36 @@ msgstr "Estil eliminat."
 msgid "Invalid nonce."
 msgstr "Nonce no vàlid."
 
-#: admin/views/editor-bootstrap.php:88
+#: admin/views/editor-bootstrap.php:85
 msgid "Failed to load eXeLearning editor template."
 msgstr "Error en carregar la plantilla de l'editor d'eXeLearning."
 
-#: admin/views/editor-bootstrap.php:89
+#: admin/views/editor-bootstrap.php:86
 msgid "Template Error"
 msgstr "Error de plantilla"
 
-#: admin/views/editor-bootstrap.php:96
-#: includes/class-exelearning-editor.php:178
-#: includes/class-exelearning-editor.php:211
+#: admin/views/editor-bootstrap.php:93
+#: includes/class-exelearning-editor.php:266
+#: includes/class-exelearning-editor.php:299
 msgid "Saving..."
 msgstr "Guardant..."
 
-#: admin/views/editor-bootstrap.php:97
+#: admin/views/editor-bootstrap.php:94
 msgid "Saved to WordPress successfully"
 msgstr "Guardat en WordPress correctament"
 
-#: admin/views/editor-bootstrap.php:98
-#: includes/class-exelearning-editor.php:177
-#: includes/class-exelearning-editor.php:210
-#: includes/class-exelearning-editor.php:240
+#: admin/views/editor-bootstrap.php:95
+#: includes/class-exelearning-editor.php:265
+#: includes/class-exelearning-editor.php:298
+#: includes/class-exelearning-editor.php:328
 msgid "Save to WordPress"
 msgstr "Guardar en WordPress"
 
-#: admin/views/editor-bootstrap.php:99
+#: admin/views/editor-bootstrap.php:96
 msgid "Loading project..."
 msgstr "Carregant projecte..."
 
-#: admin/views/editor-bootstrap.php:100
+#: admin/views/editor-bootstrap.php:97
 msgid "Error"
 msgstr "Error"
 
@@ -496,12 +496,12 @@ msgid "You do not have permission to access this page."
 msgstr "No tens permís per a accedir a esta pàgina."
 
 #: includes/class-exelearning-editor.php:124
-#: includes/class-export-bootstrap.php:111
+#: includes/class-export-bootstrap.php:131
 msgid "No attachment specified."
 msgstr "No s'ha especificat cap adjunt."
 
 #: includes/class-exelearning-editor.php:132
-#: includes/class-export-bootstrap.php:130
+#: includes/class-export-bootstrap.php:150
 msgid "This file is not an eXeLearning file (.elpx)."
 msgstr "Este fitxer no és un fitxer eXeLearning (.elpx)."
 
@@ -510,8 +510,8 @@ msgstr "Este fitxer no és un fitxer eXeLearning (.elpx)."
 msgid "You do not have permission to edit this file."
 msgstr "No tens permís per a editar este fitxer."
 
-#: includes/class-exelearning-editor.php:175
-#: includes/class-exelearning-editor.php:208
+#: includes/class-exelearning-editor.php:263
+#: includes/class-exelearning-editor.php:296
 #: includes/integrations/class-media-library.php:195
 #: includes/integrations/class-media-library.php:349
 #: assets/js/elp-upload.js:434
@@ -519,23 +519,23 @@ msgstr "No tens permís per a editar este fitxer."
 msgid "Edit in eXeLearning"
 msgstr "Editar en eXeLearning"
 
-#: includes/class-exelearning-editor.php:176
-#: includes/class-exelearning-editor.php:209
-#: includes/class-exelearning-editor.php:243
+#: includes/class-exelearning-editor.php:264
+#: includes/class-exelearning-editor.php:297
+#: includes/class-exelearning-editor.php:331
 msgid "Close"
 msgstr "Tancar"
 
-#: includes/class-exelearning-editor.php:179
-#: includes/class-exelearning-editor.php:212
+#: includes/class-exelearning-editor.php:267
+#: includes/class-exelearning-editor.php:300
 msgid "Please wait while the file is being saved."
 msgstr "Per favor, espereu mentre es guarda l'arxiu."
 
-#: includes/class-exelearning-editor.php:180
-#: includes/class-exelearning-editor.php:213
+#: includes/class-exelearning-editor.php:268
+#: includes/class-exelearning-editor.php:301
 msgid "You have unsaved changes. Are you sure you want to close?"
 msgstr "Teniu canvis sense guardar. Esteu segurs que voleu tancar?"
 
-#: includes/class-exelearning-editor.php:235
+#: includes/class-exelearning-editor.php:323
 msgid "Edit eXeLearning File"
 msgstr "Editar el fitxer eXeLearning"
 
@@ -567,15 +567,15 @@ msgstr "Fitxer original no trobat."
 msgid "File saved successfully."
 msgstr "Fitxer guardat correctament."
 
-#: includes/class-export-bootstrap.php:124
+#: includes/class-export-bootstrap.php:144
 msgid "Attachment not found."
 msgstr "No s'ha trobat l'adjunt."
 
-#: includes/class-export-bootstrap.php:142
+#: includes/class-export-bootstrap.php:162
 msgid "Static eXeLearning editor not installed."
 msgstr "L'editor estàtic d'eXeLearning no està instal·lat."
 
-#: includes/class-export-bootstrap.php:147
+#: includes/class-export-bootstrap.php:167
 msgid "Failed to load editor template."
 msgstr "No s'ha pogut carregar la plantilla de l'editor."
 

--- a/languages/exelearning-de_DE.po
+++ b/languages/exelearning-de_DE.po
@@ -326,36 +326,36 @@ msgstr "Stil gelöscht."
 msgid "Invalid nonce."
 msgstr "Ungültiger Nonce."
 
-#: admin/views/editor-bootstrap.php:88
+#: admin/views/editor-bootstrap.php:85
 msgid "Failed to load eXeLearning editor template."
 msgstr "Fehler beim Laden der eXeLearning-Editor-Vorlage."
 
-#: admin/views/editor-bootstrap.php:89
+#: admin/views/editor-bootstrap.php:86
 msgid "Template Error"
 msgstr "Vorlagenfehler"
 
-#: admin/views/editor-bootstrap.php:96
-#: includes/class-exelearning-editor.php:178
-#: includes/class-exelearning-editor.php:211
+#: admin/views/editor-bootstrap.php:93
+#: includes/class-exelearning-editor.php:266
+#: includes/class-exelearning-editor.php:299
 msgid "Saving..."
 msgstr "Speichern..."
 
-#: admin/views/editor-bootstrap.php:97
+#: admin/views/editor-bootstrap.php:94
 msgid "Saved to WordPress successfully"
 msgstr "Erfolgreich in WordPress gespeichert"
 
-#: admin/views/editor-bootstrap.php:98
-#: includes/class-exelearning-editor.php:177
-#: includes/class-exelearning-editor.php:210
-#: includes/class-exelearning-editor.php:240
+#: admin/views/editor-bootstrap.php:95
+#: includes/class-exelearning-editor.php:265
+#: includes/class-exelearning-editor.php:298
+#: includes/class-exelearning-editor.php:328
 msgid "Save to WordPress"
 msgstr "In WordPress speichern"
 
-#: admin/views/editor-bootstrap.php:99
+#: admin/views/editor-bootstrap.php:96
 msgid "Loading project..."
 msgstr "Projekt wird geladen..."
 
-#: admin/views/editor-bootstrap.php:100
+#: admin/views/editor-bootstrap.php:97
 msgid "Error"
 msgstr "Fehler"
 
@@ -496,12 +496,12 @@ msgid "You do not have permission to access this page."
 msgstr "Sie haben keine Berechtigung, auf diese Seite zuzugreifen."
 
 #: includes/class-exelearning-editor.php:124
-#: includes/class-export-bootstrap.php:111
+#: includes/class-export-bootstrap.php:131
 msgid "No attachment specified."
 msgstr "Kein Anhang angegeben."
 
 #: includes/class-exelearning-editor.php:132
-#: includes/class-export-bootstrap.php:130
+#: includes/class-export-bootstrap.php:150
 msgid "This file is not an eXeLearning file (.elpx)."
 msgstr "Diese Datei ist keine eXeLearning-Datei (.elpx)."
 
@@ -510,8 +510,8 @@ msgstr "Diese Datei ist keine eXeLearning-Datei (.elpx)."
 msgid "You do not have permission to edit this file."
 msgstr "Sie haben keine Berechtigung, diese Datei zu bearbeiten."
 
-#: includes/class-exelearning-editor.php:175
-#: includes/class-exelearning-editor.php:208
+#: includes/class-exelearning-editor.php:263
+#: includes/class-exelearning-editor.php:296
 #: includes/integrations/class-media-library.php:195
 #: includes/integrations/class-media-library.php:349
 #: assets/js/elp-upload.js:434
@@ -519,23 +519,23 @@ msgstr "Sie haben keine Berechtigung, diese Datei zu bearbeiten."
 msgid "Edit in eXeLearning"
 msgstr "In eXeLearning bearbeiten"
 
-#: includes/class-exelearning-editor.php:176
-#: includes/class-exelearning-editor.php:209
-#: includes/class-exelearning-editor.php:243
+#: includes/class-exelearning-editor.php:264
+#: includes/class-exelearning-editor.php:297
+#: includes/class-exelearning-editor.php:331
 msgid "Close"
 msgstr "Schließen"
 
-#: includes/class-exelearning-editor.php:179
-#: includes/class-exelearning-editor.php:212
+#: includes/class-exelearning-editor.php:267
+#: includes/class-exelearning-editor.php:300
 msgid "Please wait while the file is being saved."
 msgstr "Bitte warten Sie, während die Datei gespeichert wird."
 
-#: includes/class-exelearning-editor.php:180
-#: includes/class-exelearning-editor.php:213
+#: includes/class-exelearning-editor.php:268
+#: includes/class-exelearning-editor.php:301
 msgid "You have unsaved changes. Are you sure you want to close?"
 msgstr "Sie haben ungespeicherte Änderungen. Möchten Sie wirklich schließen?"
 
-#: includes/class-exelearning-editor.php:235
+#: includes/class-exelearning-editor.php:323
 msgid "Edit eXeLearning File"
 msgstr "eXeLearning-Datei bearbeiten"
 
@@ -567,15 +567,15 @@ msgstr "Originaldatei nicht gefunden."
 msgid "File saved successfully."
 msgstr "Datei erfolgreich gespeichert."
 
-#: includes/class-export-bootstrap.php:124
+#: includes/class-export-bootstrap.php:144
 msgid "Attachment not found."
 msgstr "Anhang nicht gefunden."
 
-#: includes/class-export-bootstrap.php:142
+#: includes/class-export-bootstrap.php:162
 msgid "Static eXeLearning editor not installed."
 msgstr "Statischer eXeLearning-Editor nicht installiert."
 
-#: includes/class-export-bootstrap.php:147
+#: includes/class-export-bootstrap.php:167
 msgid "Failed to load editor template."
 msgstr "Editor-Vorlage konnte nicht geladen werden."
 

--- a/languages/exelearning-eo.po
+++ b/languages/exelearning-eo.po
@@ -326,36 +326,36 @@ msgstr "Stilo forigita."
 msgid "Invalid nonce."
 msgstr "Nevalida nonce."
 
-#: admin/views/editor-bootstrap.php:88
+#: admin/views/editor-bootstrap.php:85
 msgid "Failed to load eXeLearning editor template."
 msgstr "Malsukcesis ŝargi la redaktilan ŝablonon de eXeLearning."
 
-#: admin/views/editor-bootstrap.php:89
+#: admin/views/editor-bootstrap.php:86
 msgid "Template Error"
 msgstr "Ŝablona eraro"
 
-#: admin/views/editor-bootstrap.php:96
-#: includes/class-exelearning-editor.php:178
-#: includes/class-exelearning-editor.php:211
+#: admin/views/editor-bootstrap.php:93
+#: includes/class-exelearning-editor.php:266
+#: includes/class-exelearning-editor.php:299
 msgid "Saving..."
 msgstr "Konservante..."
 
-#: admin/views/editor-bootstrap.php:97
+#: admin/views/editor-bootstrap.php:94
 msgid "Saved to WordPress successfully"
 msgstr "Sukcese konservita en WordPress"
 
-#: admin/views/editor-bootstrap.php:98
-#: includes/class-exelearning-editor.php:177
-#: includes/class-exelearning-editor.php:210
-#: includes/class-exelearning-editor.php:240
+#: admin/views/editor-bootstrap.php:95
+#: includes/class-exelearning-editor.php:265
+#: includes/class-exelearning-editor.php:298
+#: includes/class-exelearning-editor.php:328
 msgid "Save to WordPress"
 msgstr "Konservi en WordPress"
 
-#: admin/views/editor-bootstrap.php:99
+#: admin/views/editor-bootstrap.php:96
 msgid "Loading project..."
 msgstr "Ŝargante projekton..."
 
-#: admin/views/editor-bootstrap.php:100
+#: admin/views/editor-bootstrap.php:97
 msgid "Error"
 msgstr "Eraro"
 
@@ -496,12 +496,12 @@ msgid "You do not have permission to access this page."
 msgstr "Vi ne havas permeson aliri ĉi tiun paĝon."
 
 #: includes/class-exelearning-editor.php:124
-#: includes/class-export-bootstrap.php:111
+#: includes/class-export-bootstrap.php:131
 msgid "No attachment specified."
 msgstr "Neniu kunsendaĵo specifita."
 
 #: includes/class-exelearning-editor.php:132
-#: includes/class-export-bootstrap.php:130
+#: includes/class-export-bootstrap.php:150
 msgid "This file is not an eXeLearning file (.elpx)."
 msgstr "Ĉi tiu dosiero ne estas eXeLearning-dosiero (.elpx)."
 
@@ -510,8 +510,8 @@ msgstr "Ĉi tiu dosiero ne estas eXeLearning-dosiero (.elpx)."
 msgid "You do not have permission to edit this file."
 msgstr "Vi ne havas permeson redakti ĉi tiun dosieron."
 
-#: includes/class-exelearning-editor.php:175
-#: includes/class-exelearning-editor.php:208
+#: includes/class-exelearning-editor.php:263
+#: includes/class-exelearning-editor.php:296
 #: includes/integrations/class-media-library.php:195
 #: includes/integrations/class-media-library.php:349
 #: assets/js/elp-upload.js:434
@@ -519,23 +519,23 @@ msgstr "Vi ne havas permeson redakti ĉi tiun dosieron."
 msgid "Edit in eXeLearning"
 msgstr "Redakti en eXeLearning"
 
-#: includes/class-exelearning-editor.php:176
-#: includes/class-exelearning-editor.php:209
-#: includes/class-exelearning-editor.php:243
+#: includes/class-exelearning-editor.php:264
+#: includes/class-exelearning-editor.php:297
+#: includes/class-exelearning-editor.php:331
 msgid "Close"
 msgstr "Fermi"
 
-#: includes/class-exelearning-editor.php:179
-#: includes/class-exelearning-editor.php:212
+#: includes/class-exelearning-editor.php:267
+#: includes/class-exelearning-editor.php:300
 msgid "Please wait while the file is being saved."
 msgstr "Bonvolu atendi dum la dosiero estas konservata."
 
-#: includes/class-exelearning-editor.php:180
-#: includes/class-exelearning-editor.php:213
+#: includes/class-exelearning-editor.php:268
+#: includes/class-exelearning-editor.php:301
 msgid "You have unsaved changes. Are you sure you want to close?"
 msgstr "Vi havas nekonservitajn ŝanĝojn. Ĉu vi certas, ke vi volas fermi?"
 
-#: includes/class-exelearning-editor.php:235
+#: includes/class-exelearning-editor.php:323
 msgid "Edit eXeLearning File"
 msgstr "Redakti eXeLearning-dosieron"
 
@@ -567,15 +567,15 @@ msgstr "Originala dosiero ne trovita."
 msgid "File saved successfully."
 msgstr "Dosiero sukcese konservita."
 
-#: includes/class-export-bootstrap.php:124
+#: includes/class-export-bootstrap.php:144
 msgid "Attachment not found."
 msgstr "Aldonaĵo ne trovita."
 
-#: includes/class-export-bootstrap.php:142
+#: includes/class-export-bootstrap.php:162
 msgid "Static eXeLearning editor not installed."
 msgstr "La statika eXeLearning-redaktilo ne estas instalita."
 
-#: includes/class-export-bootstrap.php:147
+#: includes/class-export-bootstrap.php:167
 msgid "Failed to load editor template."
 msgstr "Ne eblis ŝargi la redaktilan ŝablonon."
 

--- a/languages/exelearning-es_ES.po
+++ b/languages/exelearning-es_ES.po
@@ -326,36 +326,36 @@ msgstr "Estilo eliminado."
 msgid "Invalid nonce."
 msgstr "Nonce no válido."
 
-#: admin/views/editor-bootstrap.php:88
+#: admin/views/editor-bootstrap.php:85
 msgid "Failed to load eXeLearning editor template."
 msgstr "Error al cargar la plantilla del editor de eXeLearning."
 
-#: admin/views/editor-bootstrap.php:89
+#: admin/views/editor-bootstrap.php:86
 msgid "Template Error"
 msgstr "Error de plantilla"
 
-#: admin/views/editor-bootstrap.php:96
-#: includes/class-exelearning-editor.php:178
-#: includes/class-exelearning-editor.php:211
+#: admin/views/editor-bootstrap.php:93
+#: includes/class-exelearning-editor.php:266
+#: includes/class-exelearning-editor.php:299
 msgid "Saving..."
 msgstr "Guardando..."
 
-#: admin/views/editor-bootstrap.php:97
+#: admin/views/editor-bootstrap.php:94
 msgid "Saved to WordPress successfully"
 msgstr "Guardado en WordPress correctamente"
 
-#: admin/views/editor-bootstrap.php:98
-#: includes/class-exelearning-editor.php:177
-#: includes/class-exelearning-editor.php:210
-#: includes/class-exelearning-editor.php:240
+#: admin/views/editor-bootstrap.php:95
+#: includes/class-exelearning-editor.php:265
+#: includes/class-exelearning-editor.php:298
+#: includes/class-exelearning-editor.php:328
 msgid "Save to WordPress"
 msgstr "Guardar en WordPress"
 
-#: admin/views/editor-bootstrap.php:99
+#: admin/views/editor-bootstrap.php:96
 msgid "Loading project..."
 msgstr "Cargando proyecto..."
 
-#: admin/views/editor-bootstrap.php:100
+#: admin/views/editor-bootstrap.php:97
 msgid "Error"
 msgstr "Error"
 
@@ -496,12 +496,12 @@ msgid "You do not have permission to access this page."
 msgstr "No tienes permiso para acceder a esta página."
 
 #: includes/class-exelearning-editor.php:124
-#: includes/class-export-bootstrap.php:111
+#: includes/class-export-bootstrap.php:131
 msgid "No attachment specified."
 msgstr "No se especificó ningún adjunto."
 
 #: includes/class-exelearning-editor.php:132
-#: includes/class-export-bootstrap.php:130
+#: includes/class-export-bootstrap.php:150
 msgid "This file is not an eXeLearning file (.elpx)."
 msgstr "Este archivo no es un archivo eXeLearning (.elpx)."
 
@@ -510,8 +510,8 @@ msgstr "Este archivo no es un archivo eXeLearning (.elpx)."
 msgid "You do not have permission to edit this file."
 msgstr "No tienes permiso para editar este archivo."
 
-#: includes/class-exelearning-editor.php:175
-#: includes/class-exelearning-editor.php:208
+#: includes/class-exelearning-editor.php:263
+#: includes/class-exelearning-editor.php:296
 #: includes/integrations/class-media-library.php:195
 #: includes/integrations/class-media-library.php:349
 #: assets/js/elp-upload.js:434
@@ -519,23 +519,23 @@ msgstr "No tienes permiso para editar este archivo."
 msgid "Edit in eXeLearning"
 msgstr "Editar en eXeLearning"
 
-#: includes/class-exelearning-editor.php:176
-#: includes/class-exelearning-editor.php:209
-#: includes/class-exelearning-editor.php:243
+#: includes/class-exelearning-editor.php:264
+#: includes/class-exelearning-editor.php:297
+#: includes/class-exelearning-editor.php:331
 msgid "Close"
 msgstr "Cerrar"
 
-#: includes/class-exelearning-editor.php:179
-#: includes/class-exelearning-editor.php:212
+#: includes/class-exelearning-editor.php:267
+#: includes/class-exelearning-editor.php:300
 msgid "Please wait while the file is being saved."
 msgstr "Por favor, espere mientras se guarda el archivo."
 
-#: includes/class-exelearning-editor.php:180
-#: includes/class-exelearning-editor.php:213
+#: includes/class-exelearning-editor.php:268
+#: includes/class-exelearning-editor.php:301
 msgid "You have unsaved changes. Are you sure you want to close?"
 msgstr "Tiene cambios sin guardar. ¿Está seguro de que desea cerrar?"
 
-#: includes/class-exelearning-editor.php:235
+#: includes/class-exelearning-editor.php:323
 msgid "Edit eXeLearning File"
 msgstr "Editar archivo eXeLearning"
 
@@ -567,15 +567,15 @@ msgstr "Archivo original no encontrado."
 msgid "File saved successfully."
 msgstr "Archivo guardado correctamente."
 
-#: includes/class-export-bootstrap.php:124
+#: includes/class-export-bootstrap.php:144
 msgid "Attachment not found."
 msgstr "Adjunto no encontrado."
 
-#: includes/class-export-bootstrap.php:142
+#: includes/class-export-bootstrap.php:162
 msgid "Static eXeLearning editor not installed."
 msgstr "El editor estático de eXeLearning no está instalado."
 
-#: includes/class-export-bootstrap.php:147
+#: includes/class-export-bootstrap.php:167
 msgid "Failed to load editor template."
 msgstr "No se pudo cargar la plantilla del editor."
 

--- a/languages/exelearning-eu.po
+++ b/languages/exelearning-eu.po
@@ -326,36 +326,36 @@ msgstr "Estiloa ezabatu da."
 msgid "Invalid nonce."
 msgstr "Nonce baliogabea."
 
-#: admin/views/editor-bootstrap.php:88
+#: admin/views/editor-bootstrap.php:85
 msgid "Failed to load eXeLearning editor template."
 msgstr "Errorea eXeLearning editorearen txantiloia kargatzean."
 
-#: admin/views/editor-bootstrap.php:89
+#: admin/views/editor-bootstrap.php:86
 msgid "Template Error"
 msgstr "Txantiloi errorea"
 
-#: admin/views/editor-bootstrap.php:96
-#: includes/class-exelearning-editor.php:178
-#: includes/class-exelearning-editor.php:211
+#: admin/views/editor-bootstrap.php:93
+#: includes/class-exelearning-editor.php:266
+#: includes/class-exelearning-editor.php:299
 msgid "Saving..."
 msgstr "Gordetzen..."
 
-#: admin/views/editor-bootstrap.php:97
+#: admin/views/editor-bootstrap.php:94
 msgid "Saved to WordPress successfully"
 msgstr "WordPressen behar bezala gorde da"
 
-#: admin/views/editor-bootstrap.php:98
-#: includes/class-exelearning-editor.php:177
-#: includes/class-exelearning-editor.php:210
-#: includes/class-exelearning-editor.php:240
+#: admin/views/editor-bootstrap.php:95
+#: includes/class-exelearning-editor.php:265
+#: includes/class-exelearning-editor.php:298
+#: includes/class-exelearning-editor.php:328
 msgid "Save to WordPress"
 msgstr "Gorde WordPressen"
 
-#: admin/views/editor-bootstrap.php:99
+#: admin/views/editor-bootstrap.php:96
 msgid "Loading project..."
 msgstr "Proiektua kargatzen..."
 
-#: admin/views/editor-bootstrap.php:100
+#: admin/views/editor-bootstrap.php:97
 msgid "Error"
 msgstr "Errorea"
 
@@ -496,12 +496,12 @@ msgid "You do not have permission to access this page."
 msgstr "Ez duzu orrialde honetara sartzeko baimenik."
 
 #: includes/class-exelearning-editor.php:124
-#: includes/class-export-bootstrap.php:111
+#: includes/class-export-bootstrap.php:131
 msgid "No attachment specified."
 msgstr "Ez da erantskinik zehaztu."
 
 #: includes/class-exelearning-editor.php:132
-#: includes/class-export-bootstrap.php:130
+#: includes/class-export-bootstrap.php:150
 msgid "This file is not an eXeLearning file (.elpx)."
 msgstr "Fitxategi hau ez da eXeLearning fitxategia (.elpx)."
 
@@ -510,8 +510,8 @@ msgstr "Fitxategi hau ez da eXeLearning fitxategia (.elpx)."
 msgid "You do not have permission to edit this file."
 msgstr "Ez duzu fitxategi hau editatzeko baimenik."
 
-#: includes/class-exelearning-editor.php:175
-#: includes/class-exelearning-editor.php:208
+#: includes/class-exelearning-editor.php:263
+#: includes/class-exelearning-editor.php:296
 #: includes/integrations/class-media-library.php:195
 #: includes/integrations/class-media-library.php:349
 #: assets/js/elp-upload.js:434
@@ -519,23 +519,23 @@ msgstr "Ez duzu fitxategi hau editatzeko baimenik."
 msgid "Edit in eXeLearning"
 msgstr "Editatu eXeLearningen"
 
-#: includes/class-exelearning-editor.php:176
-#: includes/class-exelearning-editor.php:209
-#: includes/class-exelearning-editor.php:243
+#: includes/class-exelearning-editor.php:264
+#: includes/class-exelearning-editor.php:297
+#: includes/class-exelearning-editor.php:331
 msgid "Close"
 msgstr "Itxi"
 
-#: includes/class-exelearning-editor.php:179
-#: includes/class-exelearning-editor.php:212
+#: includes/class-exelearning-editor.php:267
+#: includes/class-exelearning-editor.php:300
 msgid "Please wait while the file is being saved."
 msgstr "Mesedez, itxaron fitxategia gordetzen den bitartean."
 
-#: includes/class-exelearning-editor.php:180
-#: includes/class-exelearning-editor.php:213
+#: includes/class-exelearning-editor.php:268
+#: includes/class-exelearning-editor.php:301
 msgid "You have unsaved changes. Are you sure you want to close?"
 msgstr "Gorde gabeko aldaketak dituzu. Ziur zaude itxi nahi duzula?"
 
-#: includes/class-exelearning-editor.php:235
+#: includes/class-exelearning-editor.php:323
 msgid "Edit eXeLearning File"
 msgstr "Editatu eXeLearning fitxategia"
 
@@ -567,15 +567,15 @@ msgstr "Jatorrizko fitxategia ez da aurkitu."
 msgid "File saved successfully."
 msgstr "Fitxategia behar bezala gorde da."
 
-#: includes/class-export-bootstrap.php:124
+#: includes/class-export-bootstrap.php:144
 msgid "Attachment not found."
 msgstr "Ez da eranskina aurkitu."
 
-#: includes/class-export-bootstrap.php:142
+#: includes/class-export-bootstrap.php:162
 msgid "Static eXeLearning editor not installed."
 msgstr "eXeLearning editore estatikoa ez dago instalatuta."
 
-#: includes/class-export-bootstrap.php:147
+#: includes/class-export-bootstrap.php:167
 msgid "Failed to load editor template."
 msgstr "Ezin izan da editorearen txantiloia kargatu."
 

--- a/languages/exelearning-gl_ES.po
+++ b/languages/exelearning-gl_ES.po
@@ -326,36 +326,36 @@ msgstr "Estilo eliminado."
 msgid "Invalid nonce."
 msgstr "Nonce non válido."
 
-#: admin/views/editor-bootstrap.php:88
+#: admin/views/editor-bootstrap.php:85
 msgid "Failed to load eXeLearning editor template."
 msgstr "Erro ao cargar o modelo do editor de eXeLearning."
 
-#: admin/views/editor-bootstrap.php:89
+#: admin/views/editor-bootstrap.php:86
 msgid "Template Error"
 msgstr "Erro de modelo"
 
-#: admin/views/editor-bootstrap.php:96
-#: includes/class-exelearning-editor.php:178
-#: includes/class-exelearning-editor.php:211
+#: admin/views/editor-bootstrap.php:93
+#: includes/class-exelearning-editor.php:266
+#: includes/class-exelearning-editor.php:299
 msgid "Saving..."
 msgstr "Gardando..."
 
-#: admin/views/editor-bootstrap.php:97
+#: admin/views/editor-bootstrap.php:94
 msgid "Saved to WordPress successfully"
 msgstr "Gardado en WordPress correctamente"
 
-#: admin/views/editor-bootstrap.php:98
-#: includes/class-exelearning-editor.php:177
-#: includes/class-exelearning-editor.php:210
-#: includes/class-exelearning-editor.php:240
+#: admin/views/editor-bootstrap.php:95
+#: includes/class-exelearning-editor.php:265
+#: includes/class-exelearning-editor.php:298
+#: includes/class-exelearning-editor.php:328
 msgid "Save to WordPress"
 msgstr "Gardar en WordPress"
 
-#: admin/views/editor-bootstrap.php:99
+#: admin/views/editor-bootstrap.php:96
 msgid "Loading project..."
 msgstr "Cargando proxecto..."
 
-#: admin/views/editor-bootstrap.php:100
+#: admin/views/editor-bootstrap.php:97
 msgid "Error"
 msgstr "Erro"
 
@@ -496,12 +496,12 @@ msgid "You do not have permission to access this page."
 msgstr "Non tes permiso para acceder a esta páxina."
 
 #: includes/class-exelearning-editor.php:124
-#: includes/class-export-bootstrap.php:111
+#: includes/class-export-bootstrap.php:131
 msgid "No attachment specified."
 msgstr "Non se especificou ningún adxunto."
 
 #: includes/class-exelearning-editor.php:132
-#: includes/class-export-bootstrap.php:130
+#: includes/class-export-bootstrap.php:150
 msgid "This file is not an eXeLearning file (.elpx)."
 msgstr "Este ficheiro non é un ficheiro eXeLearning (.elpx)."
 
@@ -510,8 +510,8 @@ msgstr "Este ficheiro non é un ficheiro eXeLearning (.elpx)."
 msgid "You do not have permission to edit this file."
 msgstr "Non tes permiso para editar este ficheiro."
 
-#: includes/class-exelearning-editor.php:175
-#: includes/class-exelearning-editor.php:208
+#: includes/class-exelearning-editor.php:263
+#: includes/class-exelearning-editor.php:296
 #: includes/integrations/class-media-library.php:195
 #: includes/integrations/class-media-library.php:349
 #: assets/js/elp-upload.js:434
@@ -519,23 +519,23 @@ msgstr "Non tes permiso para editar este ficheiro."
 msgid "Edit in eXeLearning"
 msgstr "Editar en eXeLearning"
 
-#: includes/class-exelearning-editor.php:176
-#: includes/class-exelearning-editor.php:209
-#: includes/class-exelearning-editor.php:243
+#: includes/class-exelearning-editor.php:264
+#: includes/class-exelearning-editor.php:297
+#: includes/class-exelearning-editor.php:331
 msgid "Close"
 msgstr "Pechar"
 
-#: includes/class-exelearning-editor.php:179
-#: includes/class-exelearning-editor.php:212
+#: includes/class-exelearning-editor.php:267
+#: includes/class-exelearning-editor.php:300
 msgid "Please wait while the file is being saved."
 msgstr "Por favor, agarde mentres se garda o ficheiro."
 
-#: includes/class-exelearning-editor.php:180
-#: includes/class-exelearning-editor.php:213
+#: includes/class-exelearning-editor.php:268
+#: includes/class-exelearning-editor.php:301
 msgid "You have unsaved changes. Are you sure you want to close?"
 msgstr "Ten cambios sen gardar. Está seguro de que desexa pechar?"
 
-#: includes/class-exelearning-editor.php:235
+#: includes/class-exelearning-editor.php:323
 msgid "Edit eXeLearning File"
 msgstr "Editar ficheiro eXeLearning"
 
@@ -567,15 +567,15 @@ msgstr "Ficheiro orixinal non atopado."
 msgid "File saved successfully."
 msgstr "Ficheiro gardado correctamente."
 
-#: includes/class-export-bootstrap.php:124
+#: includes/class-export-bootstrap.php:144
 msgid "Attachment not found."
 msgstr "Non se atopou o anexo."
 
-#: includes/class-export-bootstrap.php:142
+#: includes/class-export-bootstrap.php:162
 msgid "Static eXeLearning editor not installed."
 msgstr "O editor estático de eXeLearning non está instalado."
 
-#: includes/class-export-bootstrap.php:147
+#: includes/class-export-bootstrap.php:167
 msgid "Failed to load editor template."
 msgstr "Non se puido cargar o modelo do editor."
 

--- a/languages/exelearning-it_IT.po
+++ b/languages/exelearning-it_IT.po
@@ -326,36 +326,36 @@ msgstr "Stile eliminato."
 msgid "Invalid nonce."
 msgstr "Nonce non valido."
 
-#: admin/views/editor-bootstrap.php:88
+#: admin/views/editor-bootstrap.php:85
 msgid "Failed to load eXeLearning editor template."
 msgstr "Errore nel caricamento del modello dell'editor eXeLearning."
 
-#: admin/views/editor-bootstrap.php:89
+#: admin/views/editor-bootstrap.php:86
 msgid "Template Error"
 msgstr "Errore del modello"
 
-#: admin/views/editor-bootstrap.php:96
-#: includes/class-exelearning-editor.php:178
-#: includes/class-exelearning-editor.php:211
+#: admin/views/editor-bootstrap.php:93
+#: includes/class-exelearning-editor.php:266
+#: includes/class-exelearning-editor.php:299
 msgid "Saving..."
 msgstr "Salvataggio in corso..."
 
-#: admin/views/editor-bootstrap.php:97
+#: admin/views/editor-bootstrap.php:94
 msgid "Saved to WordPress successfully"
 msgstr "Salvato in WordPress con successo"
 
-#: admin/views/editor-bootstrap.php:98
-#: includes/class-exelearning-editor.php:177
-#: includes/class-exelearning-editor.php:210
-#: includes/class-exelearning-editor.php:240
+#: admin/views/editor-bootstrap.php:95
+#: includes/class-exelearning-editor.php:265
+#: includes/class-exelearning-editor.php:298
+#: includes/class-exelearning-editor.php:328
 msgid "Save to WordPress"
 msgstr "Salva in WordPress"
 
-#: admin/views/editor-bootstrap.php:99
+#: admin/views/editor-bootstrap.php:96
 msgid "Loading project..."
 msgstr "Caricamento progetto..."
 
-#: admin/views/editor-bootstrap.php:100
+#: admin/views/editor-bootstrap.php:97
 msgid "Error"
 msgstr "Errore"
 
@@ -496,12 +496,12 @@ msgid "You do not have permission to access this page."
 msgstr "Non hai il permesso di accedere a questa pagina."
 
 #: includes/class-exelearning-editor.php:124
-#: includes/class-export-bootstrap.php:111
+#: includes/class-export-bootstrap.php:131
 msgid "No attachment specified."
 msgstr "Nessun allegato specificato."
 
 #: includes/class-exelearning-editor.php:132
-#: includes/class-export-bootstrap.php:130
+#: includes/class-export-bootstrap.php:150
 msgid "This file is not an eXeLearning file (.elpx)."
 msgstr "Questo file non è un file eXeLearning (.elpx)."
 
@@ -510,8 +510,8 @@ msgstr "Questo file non è un file eXeLearning (.elpx)."
 msgid "You do not have permission to edit this file."
 msgstr "Non hai il permesso di modificare questo file."
 
-#: includes/class-exelearning-editor.php:175
-#: includes/class-exelearning-editor.php:208
+#: includes/class-exelearning-editor.php:263
+#: includes/class-exelearning-editor.php:296
 #: includes/integrations/class-media-library.php:195
 #: includes/integrations/class-media-library.php:349
 #: assets/js/elp-upload.js:434
@@ -519,23 +519,23 @@ msgstr "Non hai il permesso di modificare questo file."
 msgid "Edit in eXeLearning"
 msgstr "Modifica in eXeLearning"
 
-#: includes/class-exelearning-editor.php:176
-#: includes/class-exelearning-editor.php:209
-#: includes/class-exelearning-editor.php:243
+#: includes/class-exelearning-editor.php:264
+#: includes/class-exelearning-editor.php:297
+#: includes/class-exelearning-editor.php:331
 msgid "Close"
 msgstr "Chiudi"
 
-#: includes/class-exelearning-editor.php:179
-#: includes/class-exelearning-editor.php:212
+#: includes/class-exelearning-editor.php:267
+#: includes/class-exelearning-editor.php:300
 msgid "Please wait while the file is being saved."
 msgstr "Attendere prego, il file è in fase di salvataggio."
 
-#: includes/class-exelearning-editor.php:180
-#: includes/class-exelearning-editor.php:213
+#: includes/class-exelearning-editor.php:268
+#: includes/class-exelearning-editor.php:301
 msgid "You have unsaved changes. Are you sure you want to close?"
 msgstr "Hai modifiche non salvate. Sei sicuro di voler chiudere?"
 
-#: includes/class-exelearning-editor.php:235
+#: includes/class-exelearning-editor.php:323
 msgid "Edit eXeLearning File"
 msgstr "Modifica file eXeLearning"
 
@@ -567,15 +567,15 @@ msgstr "File originale non trovato."
 msgid "File saved successfully."
 msgstr "File salvato con successo."
 
-#: includes/class-export-bootstrap.php:124
+#: includes/class-export-bootstrap.php:144
 msgid "Attachment not found."
 msgstr "Allegato non trovato."
 
-#: includes/class-export-bootstrap.php:142
+#: includes/class-export-bootstrap.php:162
 msgid "Static eXeLearning editor not installed."
 msgstr "Editor statico eXeLearning non installato."
 
-#: includes/class-export-bootstrap.php:147
+#: includes/class-export-bootstrap.php:167
 msgid "Failed to load editor template."
 msgstr "Impossibile caricare il modello dell'editor."
 

--- a/languages/exelearning-pt_PT.po
+++ b/languages/exelearning-pt_PT.po
@@ -326,36 +326,36 @@ msgstr "Estilo eliminado."
 msgid "Invalid nonce."
 msgstr "Nonce inválido."
 
-#: admin/views/editor-bootstrap.php:88
+#: admin/views/editor-bootstrap.php:85
 msgid "Failed to load eXeLearning editor template."
 msgstr "Erro ao carregar o modelo do editor eXeLearning."
 
-#: admin/views/editor-bootstrap.php:89
+#: admin/views/editor-bootstrap.php:86
 msgid "Template Error"
 msgstr "Erro de modelo"
 
-#: admin/views/editor-bootstrap.php:96
-#: includes/class-exelearning-editor.php:178
-#: includes/class-exelearning-editor.php:211
+#: admin/views/editor-bootstrap.php:93
+#: includes/class-exelearning-editor.php:266
+#: includes/class-exelearning-editor.php:299
 msgid "Saving..."
 msgstr "A guardar..."
 
-#: admin/views/editor-bootstrap.php:97
+#: admin/views/editor-bootstrap.php:94
 msgid "Saved to WordPress successfully"
 msgstr "Guardado no WordPress com sucesso"
 
-#: admin/views/editor-bootstrap.php:98
-#: includes/class-exelearning-editor.php:177
-#: includes/class-exelearning-editor.php:210
-#: includes/class-exelearning-editor.php:240
+#: admin/views/editor-bootstrap.php:95
+#: includes/class-exelearning-editor.php:265
+#: includes/class-exelearning-editor.php:298
+#: includes/class-exelearning-editor.php:328
 msgid "Save to WordPress"
 msgstr "Guardar no WordPress"
 
-#: admin/views/editor-bootstrap.php:99
+#: admin/views/editor-bootstrap.php:96
 msgid "Loading project..."
 msgstr "A carregar projeto..."
 
-#: admin/views/editor-bootstrap.php:100
+#: admin/views/editor-bootstrap.php:97
 msgid "Error"
 msgstr "Erro"
 
@@ -496,12 +496,12 @@ msgid "You do not have permission to access this page."
 msgstr "Não tem permissão para aceder a esta página."
 
 #: includes/class-exelearning-editor.php:124
-#: includes/class-export-bootstrap.php:111
+#: includes/class-export-bootstrap.php:131
 msgid "No attachment specified."
 msgstr "Nenhum anexo especificado."
 
 #: includes/class-exelearning-editor.php:132
-#: includes/class-export-bootstrap.php:130
+#: includes/class-export-bootstrap.php:150
 msgid "This file is not an eXeLearning file (.elpx)."
 msgstr "Este ficheiro não é um ficheiro eXeLearning (.elpx)."
 
@@ -510,8 +510,8 @@ msgstr "Este ficheiro não é um ficheiro eXeLearning (.elpx)."
 msgid "You do not have permission to edit this file."
 msgstr "Não tem permissão para editar este ficheiro."
 
-#: includes/class-exelearning-editor.php:175
-#: includes/class-exelearning-editor.php:208
+#: includes/class-exelearning-editor.php:263
+#: includes/class-exelearning-editor.php:296
 #: includes/integrations/class-media-library.php:195
 #: includes/integrations/class-media-library.php:349
 #: assets/js/elp-upload.js:434
@@ -519,23 +519,23 @@ msgstr "Não tem permissão para editar este ficheiro."
 msgid "Edit in eXeLearning"
 msgstr "Editar no eXeLearning"
 
-#: includes/class-exelearning-editor.php:176
-#: includes/class-exelearning-editor.php:209
-#: includes/class-exelearning-editor.php:243
+#: includes/class-exelearning-editor.php:264
+#: includes/class-exelearning-editor.php:297
+#: includes/class-exelearning-editor.php:331
 msgid "Close"
 msgstr "Fechar"
 
-#: includes/class-exelearning-editor.php:179
-#: includes/class-exelearning-editor.php:212
+#: includes/class-exelearning-editor.php:267
+#: includes/class-exelearning-editor.php:300
 msgid "Please wait while the file is being saved."
 msgstr "Por favor, aguarde enquanto o ficheiro está a ser guardado."
 
-#: includes/class-exelearning-editor.php:180
-#: includes/class-exelearning-editor.php:213
+#: includes/class-exelearning-editor.php:268
+#: includes/class-exelearning-editor.php:301
 msgid "You have unsaved changes. Are you sure you want to close?"
 msgstr "Tem alterações não guardadas. Tem a certeza de que pretende fechar?"
 
-#: includes/class-exelearning-editor.php:235
+#: includes/class-exelearning-editor.php:323
 msgid "Edit eXeLearning File"
 msgstr "Editar ficheiro eXeLearning"
 
@@ -567,15 +567,15 @@ msgstr "Ficheiro original não encontrado."
 msgid "File saved successfully."
 msgstr "Ficheiro guardado com sucesso."
 
-#: includes/class-export-bootstrap.php:124
+#: includes/class-export-bootstrap.php:144
 msgid "Attachment not found."
 msgstr "Anexo não encontrado."
 
-#: includes/class-export-bootstrap.php:142
+#: includes/class-export-bootstrap.php:162
 msgid "Static eXeLearning editor not installed."
 msgstr "Editor estático eXeLearning não instalado."
 
-#: includes/class-export-bootstrap.php:147
+#: includes/class-export-bootstrap.php:167
 msgid "Failed to load editor template."
 msgstr "Falha ao carregar o modelo do editor."
 

--- a/languages/exelearning-ro_RO.po
+++ b/languages/exelearning-ro_RO.po
@@ -326,36 +326,36 @@ msgstr "Stil șters."
 msgid "Invalid nonce."
 msgstr "Nonce invalid."
 
-#: admin/views/editor-bootstrap.php:88
+#: admin/views/editor-bootstrap.php:85
 msgid "Failed to load eXeLearning editor template."
 msgstr "Eroare la încărcarea șablonului editorului eXeLearning."
 
-#: admin/views/editor-bootstrap.php:89
+#: admin/views/editor-bootstrap.php:86
 msgid "Template Error"
 msgstr "Eroare de șablon"
 
-#: admin/views/editor-bootstrap.php:96
-#: includes/class-exelearning-editor.php:178
-#: includes/class-exelearning-editor.php:211
+#: admin/views/editor-bootstrap.php:93
+#: includes/class-exelearning-editor.php:266
+#: includes/class-exelearning-editor.php:299
 msgid "Saving..."
 msgstr "Se salvează..."
 
-#: admin/views/editor-bootstrap.php:97
+#: admin/views/editor-bootstrap.php:94
 msgid "Saved to WordPress successfully"
 msgstr "Salvat în WordPress cu succes"
 
-#: admin/views/editor-bootstrap.php:98
-#: includes/class-exelearning-editor.php:177
-#: includes/class-exelearning-editor.php:210
-#: includes/class-exelearning-editor.php:240
+#: admin/views/editor-bootstrap.php:95
+#: includes/class-exelearning-editor.php:265
+#: includes/class-exelearning-editor.php:298
+#: includes/class-exelearning-editor.php:328
 msgid "Save to WordPress"
 msgstr "Salvează în WordPress"
 
-#: admin/views/editor-bootstrap.php:99
+#: admin/views/editor-bootstrap.php:96
 msgid "Loading project..."
 msgstr "Se încarcă proiectul..."
 
-#: admin/views/editor-bootstrap.php:100
+#: admin/views/editor-bootstrap.php:97
 msgid "Error"
 msgstr "Eroare"
 
@@ -496,12 +496,12 @@ msgid "You do not have permission to access this page."
 msgstr "Nu aveți permisiunea de a accesa această pagină."
 
 #: includes/class-exelearning-editor.php:124
-#: includes/class-export-bootstrap.php:111
+#: includes/class-export-bootstrap.php:131
 msgid "No attachment specified."
 msgstr "Niciun atașament specificat."
 
 #: includes/class-exelearning-editor.php:132
-#: includes/class-export-bootstrap.php:130
+#: includes/class-export-bootstrap.php:150
 msgid "This file is not an eXeLearning file (.elpx)."
 msgstr "Acest fișier nu este un fișier eXeLearning (.elpx)."
 
@@ -510,8 +510,8 @@ msgstr "Acest fișier nu este un fișier eXeLearning (.elpx)."
 msgid "You do not have permission to edit this file."
 msgstr "Nu aveți permisiunea de a edita acest fișier."
 
-#: includes/class-exelearning-editor.php:175
-#: includes/class-exelearning-editor.php:208
+#: includes/class-exelearning-editor.php:263
+#: includes/class-exelearning-editor.php:296
 #: includes/integrations/class-media-library.php:195
 #: includes/integrations/class-media-library.php:349
 #: assets/js/elp-upload.js:434
@@ -519,23 +519,23 @@ msgstr "Nu aveți permisiunea de a edita acest fișier."
 msgid "Edit in eXeLearning"
 msgstr "Editează în eXeLearning"
 
-#: includes/class-exelearning-editor.php:176
-#: includes/class-exelearning-editor.php:209
-#: includes/class-exelearning-editor.php:243
+#: includes/class-exelearning-editor.php:264
+#: includes/class-exelearning-editor.php:297
+#: includes/class-exelearning-editor.php:331
 msgid "Close"
 msgstr "Închide"
 
-#: includes/class-exelearning-editor.php:179
-#: includes/class-exelearning-editor.php:212
+#: includes/class-exelearning-editor.php:267
+#: includes/class-exelearning-editor.php:300
 msgid "Please wait while the file is being saved."
 msgstr "Vă rugăm așteptați în timp ce fișierul este salvat."
 
-#: includes/class-exelearning-editor.php:180
-#: includes/class-exelearning-editor.php:213
+#: includes/class-exelearning-editor.php:268
+#: includes/class-exelearning-editor.php:301
 msgid "You have unsaved changes. Are you sure you want to close?"
 msgstr "Aveți modificări nesalvate. Sunteți sigur că doriți să închideți?"
 
-#: includes/class-exelearning-editor.php:235
+#: includes/class-exelearning-editor.php:323
 msgid "Edit eXeLearning File"
 msgstr "Editează fișierul eXeLearning"
 
@@ -567,15 +567,15 @@ msgstr "Fișierul original nu a fost găsit."
 msgid "File saved successfully."
 msgstr "Fișier salvat cu succes."
 
-#: includes/class-export-bootstrap.php:124
+#: includes/class-export-bootstrap.php:144
 msgid "Attachment not found."
 msgstr "Atașamentul nu a fost găsit."
 
-#: includes/class-export-bootstrap.php:142
+#: includes/class-export-bootstrap.php:162
 msgid "Static eXeLearning editor not installed."
 msgstr "Editorul static eXeLearning nu este instalat."
 
-#: includes/class-export-bootstrap.php:147
+#: includes/class-export-bootstrap.php:167
 msgid "Failed to load editor template."
 msgstr "Încărcarea șablonului editorului a eșuat."
 

--- a/languages/exelearning.pot
+++ b/languages/exelearning.pot
@@ -325,36 +325,36 @@ msgstr ""
 msgid "Invalid nonce."
 msgstr ""
 
-#: admin/views/editor-bootstrap.php:88
+#: admin/views/editor-bootstrap.php:85
 msgid "Failed to load eXeLearning editor template."
 msgstr ""
 
-#: admin/views/editor-bootstrap.php:89
+#: admin/views/editor-bootstrap.php:86
 msgid "Template Error"
 msgstr ""
 
-#: admin/views/editor-bootstrap.php:96
-#: includes/class-exelearning-editor.php:178
-#: includes/class-exelearning-editor.php:211
+#: admin/views/editor-bootstrap.php:93
+#: includes/class-exelearning-editor.php:266
+#: includes/class-exelearning-editor.php:299
 msgid "Saving..."
 msgstr ""
 
-#: admin/views/editor-bootstrap.php:97
+#: admin/views/editor-bootstrap.php:94
 msgid "Saved to WordPress successfully"
 msgstr ""
 
-#: admin/views/editor-bootstrap.php:98
-#: includes/class-exelearning-editor.php:177
-#: includes/class-exelearning-editor.php:210
-#: includes/class-exelearning-editor.php:240
+#: admin/views/editor-bootstrap.php:95
+#: includes/class-exelearning-editor.php:265
+#: includes/class-exelearning-editor.php:298
+#: includes/class-exelearning-editor.php:328
 msgid "Save to WordPress"
 msgstr ""
 
-#: admin/views/editor-bootstrap.php:99
+#: admin/views/editor-bootstrap.php:96
 msgid "Loading project..."
 msgstr ""
 
-#: admin/views/editor-bootstrap.php:100
+#: admin/views/editor-bootstrap.php:97
 msgid "Error"
 msgstr ""
 
@@ -495,12 +495,12 @@ msgid "You do not have permission to access this page."
 msgstr ""
 
 #: includes/class-exelearning-editor.php:124
-#: includes/class-export-bootstrap.php:111
+#: includes/class-export-bootstrap.php:131
 msgid "No attachment specified."
 msgstr ""
 
 #: includes/class-exelearning-editor.php:132
-#: includes/class-export-bootstrap.php:130
+#: includes/class-export-bootstrap.php:150
 msgid "This file is not an eXeLearning file (.elpx)."
 msgstr ""
 
@@ -509,8 +509,8 @@ msgstr ""
 msgid "You do not have permission to edit this file."
 msgstr ""
 
-#: includes/class-exelearning-editor.php:175
-#: includes/class-exelearning-editor.php:208
+#: includes/class-exelearning-editor.php:263
+#: includes/class-exelearning-editor.php:296
 #: includes/integrations/class-media-library.php:195
 #: includes/integrations/class-media-library.php:349
 #: assets/js/elp-upload.js:434
@@ -518,23 +518,23 @@ msgstr ""
 msgid "Edit in eXeLearning"
 msgstr ""
 
-#: includes/class-exelearning-editor.php:176
-#: includes/class-exelearning-editor.php:209
-#: includes/class-exelearning-editor.php:243
+#: includes/class-exelearning-editor.php:264
+#: includes/class-exelearning-editor.php:297
+#: includes/class-exelearning-editor.php:331
 msgid "Close"
 msgstr ""
 
-#: includes/class-exelearning-editor.php:179
-#: includes/class-exelearning-editor.php:212
+#: includes/class-exelearning-editor.php:267
+#: includes/class-exelearning-editor.php:300
 msgid "Please wait while the file is being saved."
 msgstr ""
 
-#: includes/class-exelearning-editor.php:180
-#: includes/class-exelearning-editor.php:213
+#: includes/class-exelearning-editor.php:268
+#: includes/class-exelearning-editor.php:301
 msgid "You have unsaved changes. Are you sure you want to close?"
 msgstr ""
 
-#: includes/class-exelearning-editor.php:235
+#: includes/class-exelearning-editor.php:323
 msgid "Edit eXeLearning File"
 msgstr ""
 
@@ -566,15 +566,15 @@ msgstr ""
 msgid "File saved successfully."
 msgstr ""
 
-#: includes/class-export-bootstrap.php:124
+#: includes/class-export-bootstrap.php:144
 msgid "Attachment not found."
 msgstr ""
 
-#: includes/class-export-bootstrap.php:142
+#: includes/class-export-bootstrap.php:162
 msgid "Static eXeLearning editor not installed."
 msgstr ""
 
-#: includes/class-export-bootstrap.php:147
+#: includes/class-export-bootstrap.php:167
 msgid "Failed to load editor template."
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,177 @@
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@playwright/test": "^1.62.0",
+        "@testing-library/react": "^16.3.2",
         "@vitest/coverage-v8": "^4.1.10",
+        "@wordpress/blocks": "^15.25.0",
+        "@wordpress/components": "^38.0.0",
+        "@wordpress/element": "^8.4.0",
         "@wordpress/env": "^11.11.0",
+        "@wordpress/i18n": "^6.25.0",
         "happy-dom": "^20.10.2",
         "jquery": "^3.7.1",
         "nunjucks": "^3.2.4",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
         "vitest": "^4.1.8"
+      }
+    },
+    "node_modules/@ariakit/components": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@ariakit/components/-/components-0.1.9.tgz",
+      "integrity": "sha512-Rmj5gcdfNQ4r4z5FzHHeC9OFRu9HSCVXDCDz8ak/vNHBrGmjeZ6Q3LOup61Eh+/GsT6cc2TDIQ6i8X1aB6y0BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/store": "0.1.7",
+        "@ariakit/utils": "0.1.5"
+      }
+    },
+    "node_modules/@ariakit/react": {
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.36.tgz",
+      "integrity": "sha512-QKxSc6KvTHObB9khmaQlr6XOvjKyZSHr4JWnZTDwRFDgUAzz79a+p2vApCHFlqadqV1QeGezap5cxHrOysoNOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/react-components": "0.4.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ariakit"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@ariakit/react-components": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-components/-/react-components-0.4.0.tgz",
+      "integrity": "sha512-dYymiYvAbyu6a/ehqYN2ZeieiMSYt0CMAj2BnDRUI/dZ9vLF32cv9PQMcgXXyqn0ILpqu79PQs53vVEZ+Z+0rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/components": "0.1.9",
+        "@ariakit/react-store": "0.1.8",
+        "@ariakit/react-utils": "0.2.3",
+        "@ariakit/store": "0.1.7",
+        "@ariakit/utils": "0.1.5",
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@ariakit/react-store": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-store/-/react-store-0.1.8.tgz",
+      "integrity": "sha512-VYZ1LTUVMrNUi4jP37Npvhe3mcAzKdznqnBSVeh1Jjsbcgw0JlN88oy6UpdoJPvLKWOZHVYr62Sqn7xE0GrsqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/react-utils": "0.2.3",
+        "@ariakit/store": "0.1.7",
+        "@ariakit/utils": "0.1.5",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@ariakit/react-utils": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-utils/-/react-utils-0.2.3.tgz",
+      "integrity": "sha512-fDaheb/7QEusanZb2oRT7mO55GTpQUyBOdjvQF5RPh3/CM15lm0TejLKN5bl1obmU5HRuByvckQmQvSyr8n/dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/store": "0.1.7",
+        "@ariakit/utils": "0.1.5"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@ariakit/store": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@ariakit/store/-/store-0.1.7.tgz",
+      "integrity": "sha512-/GcxscA9QTo2F+IFbFPvoyj1N8hzXBnaYsQt9UxRiJgCFPQ2jIe4i6QgPXdOZEZUuqYdyuvjcQrg7MDm9vpvCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/utils": "0.1.5"
+      }
+    },
+    "node_modules/@ariakit/utils": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@ariakit/utils/-/utils-0.1.5.tgz",
+      "integrity": "sha512-BQebYH9nV1VZttZwoq/fsxcxIJjc8oW2bNV6yJDHLZ8OF8UtM15drFN0JOL8Jwn7jeeD7Ev+tIC8pUijJEditQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -54,6 +219,75 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@babel/types": {
       "version": "7.29.8",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
@@ -68,6 +302,68 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@base-ui/react": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.7.0.tgz",
+      "integrity": "sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@base-ui/utils": "0.3.2",
+        "@floating-ui/react-dom": "^2.1.9",
+        "@floating-ui/utils": "^0.2.12",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@date-fns/tz": "^1.2.0",
+        "@types/react": "^17 || ^18 || ^19",
+        "date-fns": "^4.0.0",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@date-fns/tz": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui/utils": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.2.tgz",
+      "integrity": "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@floating-ui/utils": "^0.2.12",
+        "reselect": "^5.2.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@bcoe/v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
@@ -77,6 +373,20 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
+      "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@date-fns/utc": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/utc/-/utc-2.1.1.tgz",
+      "integrity": "sha512-SlJDfG6RPeEX8wEVv6ZB3kak4MmbtyiI2qX/5zuKdordbrhB/iaJ58GVMZgJ6P1sJaM1gMgENFYYeg1JWrCFrA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "2.0.0-alpha.3",
@@ -114,6 +424,241 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/css": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.14.1",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
+      "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/is-prop-valid": "^1.3.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@inquirer/ansi": {
       "version": "1.0.2",
@@ -541,6 +1086,17 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1912,6 +2468,107 @@
         "node": ">=10"
       }
     },
+    "node_modules/@tabby_ai/hijri-converter": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz",
+      "integrity": "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@tannin/compile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
+      "integrity": "sha512-n8m9eNDfoNZoxdvWiTfW/hSPhehzLJ3zW7f8E7oT6mCROoMNWCB4TYtv041+2FMAxweiE0j7i1jubQU4MEC/Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tannin/evaluate": "^1.2.0",
+        "@tannin/postfix": "^1.1.0"
+      }
+    },
+    "node_modules/@tannin/evaluate": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.2.0.tgz",
+      "integrity": "sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tannin/plural-forms": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.1.0.tgz",
+      "integrity": "sha512-xl9R2mDZO/qiHam1AgMnAES6IKIg7OBhcXqy6eDsRCdXuxAFPcjrej9HMjyCLE0DJ/8cHf0i5OQTstuBRhpbHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tannin/compile": "^1.1.0"
+      }
+    },
+    "node_modules/@tannin/postfix": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
+      "integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tannin/sprintf": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@tannin/sprintf/-/sprintf-1.3.3.tgz",
+      "integrity": "sha512-RwARl+hFwhzy0tg9atWcchLFvoQiOh4rrP7uG2N5E4W80BPCUX0ElcUR9St43fxB9EfjsW2df9Qp+UsTbvQDjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -1922,6 +2579,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.161",
@@ -1975,6 +2640,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/gradient-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-1.1.0.tgz",
+      "integrity": "sha512-SaEcbgQscHtGJ1QL+ajgDTmmqU2f6T+00jZRcFlVHUW2Asivc84LNUev/UQFyu117AsdyrtI+qpwLvgjJXJxmw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/highlight-words-core": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/highlight-words-core/-/highlight-words-core-1.2.3.tgz",
+      "integrity": "sha512-PWNU/NR0CaYEsK38mcCTyDzeS2TlEGK9kRhRMz1i86jVAe836ZlA3gl6QYpu+CG6IpfNKTgWpEnJuRededvC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -2003,6 +2682,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/mousetrap": {
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.6.15.tgz",
+      "integrity": "sha512-qL0hyIMNPow317QWW/63RvL1x5MVMV+Ru3NaY9f/CuEpCqrmb7WeuK2071ZY5hczOnm38qExWM2i2WtkXLSqFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -2018,6 +2704,41 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@types/responselike": {
@@ -2045,6 +2766,26 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -2191,6 +2932,359 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@wordpress/a11y": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.52.0.tgz",
+      "integrity": "sha512-0KlDa/vSASriu84+z+a/XA2teaau6t6rCH6PEqMXoW5a6EbP2e/REpZRumbu0VzV5MRO5kpxfD+fVYNYz9BdlA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/dom-ready": "^4.52.0",
+        "@wordpress/i18n": "^6.25.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/autop": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.52.0.tgz",
+      "integrity": "sha512-BZUmljM4MFod1p01dRVsZUoW5GR9JfwIBrJ1kYG3nPtTwyVHZcgCo2An9n+oUQbXv3gA+ah/ZJ4DIZrqEFf0IQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/base-styles": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-12.0.0.tgz",
+      "integrity": "sha512-BqSA9qZrBM9FBXFmQYvYCigA8ytkmlNFZ8+H0FscEnLWXkyCRwvHm4dE6LL53lmclKUGRMKlTZOUe1l8hfBQ5g==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/blob": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.52.0.tgz",
+      "integrity": "sha512-IBC0lVXiGioaeLXlX092Xqr6WNQiNoYYf60LnE23YGMy1e4unpiCHtW3kcqBmiKuLdkrDitC55uV6EMHnUOM3g==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/block-serialization-default-parser": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.52.0.tgz",
+      "integrity": "sha512-k+kOLRTS5sYSFLC1Pe4kSwrflTfelKhAEm4+MUyjsrQL3WtewC1eUKyLcBZy/n5LOy1UoGMDtnjkVB/ZbjwGYQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/blocks": {
+      "version": "15.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.25.0.tgz",
+      "integrity": "sha512-u1QOrS1/ljWCovuJu90EAJUPfhsxgzSbF4j8eE82FiW/VglqqH2ASr60V3BhIR4GNVpZPgNiVGwVsGu5iIf9Tw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/autop": "^4.52.0",
+        "@wordpress/blob": "^4.52.0",
+        "@wordpress/block-serialization-default-parser": "^5.52.0",
+        "@wordpress/data": "^10.52.0",
+        "@wordpress/deprecated": "^4.52.0",
+        "@wordpress/dom": "^4.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/hooks": "^4.52.0",
+        "@wordpress/html-entities": "^4.52.0",
+        "@wordpress/i18n": "^6.25.0",
+        "@wordpress/is-shallow-equal": "^5.52.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/rich-text": "^7.52.0",
+        "@wordpress/shortcode": "^4.52.0",
+        "@wordpress/warning": "^3.52.0",
+        "change-case": "^4.1.2",
+        "colord": "^2.9.3",
+        "fast-deep-equal": "^3.1.3",
+        "hpq": "^1.3.0",
+        "is-plain-object": "^5.0.0",
+        "marked": "^18.0.3",
+        "memize": "^2.1.1",
+        "react-is": "^18.3.0",
+        "remove-accents": "^0.5.0",
+        "simple-html-tokenizer": "^0.5.7",
+        "uuid": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/components": {
+      "version": "38.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-38.0.0.tgz",
+      "integrity": "sha512-FdmfeLB0cUH8Vwmp1Sz0o7mnhmg0kir2oouuvkcVtPgwHfCnsOgvg1ZelYdaQz+F6MyAsCY1mKQn100A9npUDA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.32",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "^2.0.8",
+        "@types/gradient-parser": "^1.1.0",
+        "@types/highlight-words-core": "^1.2.1",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.52.0",
+        "@wordpress/base-styles": "^12.0.0",
+        "@wordpress/compose": "^8.5.0",
+        "@wordpress/date": "^5.52.0",
+        "@wordpress/deprecated": "^4.52.0",
+        "@wordpress/dom": "^4.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/escape-html": "^3.52.0",
+        "@wordpress/hooks": "^4.52.0",
+        "@wordpress/html-entities": "^4.52.0",
+        "@wordpress/i18n": "^6.25.0",
+        "@wordpress/icons": "^15.3.0",
+        "@wordpress/is-shallow-equal": "^5.52.0",
+        "@wordpress/keycodes": "^4.52.0",
+        "@wordpress/primitives": "^4.52.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/rich-text": "^7.52.0",
+        "@wordpress/style-runtime": "^0.8.0",
+        "@wordpress/ui": "^0.19.0",
+        "@wordpress/warning": "^3.52.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.9.3",
+        "csstype": "^3.2.3",
+        "date-fns": "^4.4.0",
+        "deepmerge": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "^1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.1",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/components/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@wordpress/compose": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.5.0.tgz",
+      "integrity": "sha512-giYS22Tbhtr3Lj4lK6lxzGqV6EkM2QeVBiP7+c9r2F9rnQN3F6A8cN4gQM5sVGdgIOlps9tw+dsn9OHzIFVwIg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^4.52.0",
+        "@wordpress/dom": "^4.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/is-shallow-equal": "^5.52.0",
+        "@wordpress/keycodes": "^4.52.0",
+        "@wordpress/priority-queue": "^3.52.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/undo-manager": "^1.52.0",
+        "change-case": "^4.1.2",
+        "mousetrap": "^1.6.5",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/compose/node_modules/use-memo-one": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
+      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/data": {
+      "version": "10.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.52.0.tgz",
+      "integrity": "sha512-7Nx66TfUkYZDdXL4wn2/DjIJOYRsKdi8Gvv24Warv9rZ1pwTNoFXFDagvc3UoCOjn0pM8+pFNbd7a9TJH8oQzg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/compose": "^8.5.0",
+        "@wordpress/deprecated": "^4.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/is-shallow-equal": "^5.52.0",
+        "@wordpress/priority-queue": "^3.52.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/redux-routine": "^5.52.0",
+        "deepmerge": "^4.3.1",
+        "equivalent-key-map": "^0.2.2",
+        "is-plain-object": "^5.0.0",
+        "is-promise": "^4.0.0",
+        "redux": "^5.0.1",
+        "rememo": "^4.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/data/node_modules/use-memo-one": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
+      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/date": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.52.0.tgz",
+      "integrity": "sha512-JRAXv2CQwUiJq9k2n/iUqblo9rX3LUFJ03lA4zRy4+bxcSiMdpXvYrpZfUTp3W4I1Oc/fPZIYQY0HB3XNyjUWw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/deprecated": "^4.52.0",
+        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.40"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/deprecated": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.52.0.tgz",
+      "integrity": "sha512-94oHBKPty4pp6L5510LWDwJwNqFhikxLfwN6VUcDOQzj3itkc0MQ4ZQhmsfBy3Y6IRxSGx+p2bjSQvA4D+M96A==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/hooks": "^4.52.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/dom": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.52.0.tgz",
+      "integrity": "sha512-LUY9nI9h6blk4xBuG83KgyfTnx7PMs/g6ZVzY/SOaCcOc2P3zOfzacADq/vxQydbZpcwtLM6juzgnNta6AX95w==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/deprecated": "^4.52.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/dom-ready": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.52.0.tgz",
+      "integrity": "sha512-dAsch1oeyRV4kwoQuqdr6dXisGAs09OtvGOk09Ke+QC0fTTPzxdKUw+c4M1nk0AmCeyZfqAqYYGCMm4n241QeQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/element": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.4.0.tgz",
+      "integrity": "sha512-/LzW+0MpSmKfYiESoXUQtjBPqOPyvqUm17GigQR5c0Z8Wj2NiklP72x4XaF02uSkau1ru1Z9lP8NWEGjwBwLsA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@types/react": "^18.3.27",
+        "@types/react-dom": "^18.3.1",
+        "@wordpress/deprecated": "^4.52.0",
+        "@wordpress/escape-html": "^3.52.0",
+        "change-case": "^4.1.2",
+        "is-plain-object": "^5.0.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/env": {
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-11.11.0.tgz",
@@ -2215,6 +3309,350 @@
       "bin": {
         "wp-env": "bin/wp-env"
       },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/escape-html": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.52.0.tgz",
+      "integrity": "sha512-sW8X839Xu8aiJlCGF48MM3iYrcXspuiY0By8iTpXKpnUdd2u0SL9HRR0ALSAsOf2ujOeWm/x58ODMSchovRWGw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/hooks": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.52.0.tgz",
+      "integrity": "sha512-EbV/nJTerhqwNW3DLvvGutJfNyXcmBHXuWyJpv1NypzT80k21jPGP79HBE5Z0A2oAI2kIBp6Klaa4O8uEjq/sw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/html-entities": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.52.0.tgz",
+      "integrity": "sha512-SM0XH+EgCi20Ptqv5WGkM8d2CAlThWRO/BVMeXzu6RLlcHKLMXNQZvW2waXCZtUpto8hlVZT9Dzg8z37sj4OiQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/i18n": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.25.0.tgz",
+      "integrity": "sha512-UcyUT8CJgEkhjzEGTVV6kw0Qi4OraF0I9J9FBLmTda/1Wi1o6rLAXZBm2aJrP740ezFxPneHH92aQF4Z5xZqcQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@tannin/sprintf": "^1.3.2",
+        "@wordpress/hooks": "^4.52.0",
+        "gettext-parser": "^1.3.1",
+        "tannin": "^1.2.0"
+      },
+      "bin": {
+        "pot-to-php": "tools/pot-to-php.js"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/icons": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.3.0.tgz",
+      "integrity": "sha512-An7jPqTSmJpjmeSa6EYohE9m/4gUE+bkrgQekqkcOPAlOISpG/jv3Zq+pVeZXCQz206zYF+feTvmLEW+/vXAeg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/primitives": "^4.52.0",
+        "change-case": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/is-shallow-equal": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.52.0.tgz",
+      "integrity": "sha512-LMIBLLTZ+vvq0DlYebL4d9XaCu16PNnhPGSn8QqsMPmBzwBYOjO0/btMLpYbs9rRc8k1QKBDWvw8eddvRVsYxA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/keycodes": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.52.0.tgz",
+      "integrity": "sha512-KRvwViTTdxUDgikYaCm+qnXSH2UlFuCDjAIvtjjcen8oRviSkeMv6bPn1T2vqFRKcVgt88xTtKlvI8l5U99o2Q==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.25.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/primitives": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.52.0.tgz",
+      "integrity": "sha512-rgB+Q1i97AY8AECLAEhvV/bGw9sOV6CKtUaY90t7nuv6M+ZgXqwQLRRWVaXWFUsthcZ2y4sTIbKfxwVJV+JQ6g==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^8.4.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/priority-queue": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.52.0.tgz",
+      "integrity": "sha512-aYnVXxV5j4D73tRld2n1D3G6cKLfSwKWcTnktJ7XlmiswW7xlaAqvn4FyBjwmIe20pZw0A7xLH5xCuQcqOM7nw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "requestidlecallback": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/private-apis": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.52.0.tgz",
+      "integrity": "sha512-gFcmBXSti73Y4uEx++5qUNDaH/o0/2ijrHEJkY5e/df4RtmxVSQOIVxftRiI4m9thCWfJMoehMMreJxhwx6Qtg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/redux-routine": {
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.52.0.tgz",
+      "integrity": "sha512-MpyNAKpfQAk8IWJ3Cwzc/p1dVEUl/iYxL6GCTX/y7K3c8qYd7csU4o5kuK9lfeqgVVI+d0y6rzBZiTaL2Z6Ojw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "is-plain-object": "^5.0.0",
+        "is-promise": "^4.0.0",
+        "rungen": "^0.3.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "redux": ">=4"
+      }
+    },
+    "node_modules/@wordpress/rich-text": {
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.52.0.tgz",
+      "integrity": "sha512-zyd7w4hs8TV+nWrC/hbULg4lKJQyxpd5AolFfOHAJmKM2LrU/Lvlobz9oyGuTrZ/HXdkFs3wzPMwS/VGydSjHw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/a11y": "^4.52.0",
+        "@wordpress/compose": "^8.5.0",
+        "@wordpress/data": "^10.52.0",
+        "@wordpress/deprecated": "^4.52.0",
+        "@wordpress/dom": "^4.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/escape-html": "^3.52.0",
+        "@wordpress/i18n": "^6.25.0",
+        "@wordpress/keycodes": "^4.52.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "colord": "^2.9.3"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/shortcode": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.52.0.tgz",
+      "integrity": "sha512-6vTLq3WxPMaE6pvxvvUzbcSeNzvqcghF4ngX1bXlSVIwMXVDgwsTFA4yc6LoI9BFBDZt9UZ+KN22wcdqnDr9Ug==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "memize": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/style-runtime": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.8.0.tgz",
+      "integrity": "sha512-gqe5cnsDLwH2NQ//VyUtzS4pcht0iR64hP+3u6p5/pPvwA2ySGn71mJ/7+O2X7sUG5drxNp6+4Kl3LWOzkKYng==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/@wordpress/theme": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-1.1.0.tgz",
+      "integrity": "sha512-SWEGYY/HnSzmKDJnDhWVfxUDyLlJkz9EtpfAWhgPcCLSaZVc/pp99Fxr+/ueB2mHlQ9gpaWCPAMBxq8knDCbXw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/compose": "^8.5.0",
+        "@wordpress/deprecated": "^4.52.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/style-runtime": "^0.8.0",
+        "colorjs.io": "^0.7.1",
+        "memize": "^2.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.13.0",
+        "npm": ">=10.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "esbuild": ">=0.27.2 <1.0.0",
+        "postcss": "^8.0.0",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19",
+        "stylelint": "^16 || ^17",
+        "vite": "^7 || ^8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "stylelint": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/ui": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.19.0.tgz",
+      "integrity": "sha512-ck0BcuWu96vbpim0rFUI0kDLaUgLyRmbhkgfhgYFyHm2klzyRxhbakNTc6qqj7xCQ0Wsy9SwCqDCuCHltZpXkA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@base-ui/react": "^1.6.0",
+        "@wordpress/a11y": "^4.52.0",
+        "@wordpress/compose": "^8.5.0",
+        "@wordpress/element": "^8.4.0",
+        "@wordpress/i18n": "^6.25.0",
+        "@wordpress/icons": "^15.3.0",
+        "@wordpress/keycodes": "^4.52.0",
+        "@wordpress/primitives": "^4.52.0",
+        "@wordpress/private-apis": "^1.52.0",
+        "@wordpress/style-runtime": "^0.8.0",
+        "@wordpress/theme": "^1.1.0",
+        "clsx": "^2.1.1",
+        "tabbable": "^6.4.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.13.0",
+        "npm": ">=10.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "^18 || ^19",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wordpress/undo-manager": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.52.0.tgz",
+      "integrity": "sha512-6hI0WWDOtLLVEkWqQokCoQRz5Pba9UNtgt5MV4hHGe5x0mzsowj+GWHedppf8UCVZ2ex3cde7fThaRKMCackrQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/is-shallow-equal": "^5.52.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/warning": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.52.0.tgz",
+      "integrity": "sha512-BjJ+Jte1g2nMITI1IHq0NwMpm/qlFOV1L+gNe0vFQmGKEcXiQ0DjrHQNtA8hV+Mgt9zSWRNS71Fgonht3r72Ew==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
@@ -2546,6 +3984,17 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -2603,6 +4052,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
       }
     },
     "node_modules/balanced-match": {
@@ -2790,6 +4255,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/capital-case": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+      "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2815,6 +4313,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/chardet": {
@@ -2955,6 +4474,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2975,6 +4504,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colord": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorjs.io": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.7.1.tgz",
+      "integrity": "sha512-LY7OHnJZxHwT5UlzNa9bbhHHDbzB6yE5+3MIPwJEQKRvSCt/T4G7epsj+9j2BExUIIfXFIJGsIXUKdfrK9Q5tA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/color"
+      }
+    },
     "node_modules/commander": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
@@ -2983,6 +4530,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
       }
     },
     "node_modules/content-disposition": {
@@ -3039,6 +4598,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/crc-32": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
@@ -3066,6 +4652,31 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-jalali": {
+      "version": "4.1.0-0",
+      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -3104,6 +4715,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/defaults": {
@@ -3164,6 +4785,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -3203,6 +4835,25 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/dunder-proto": {
@@ -3261,6 +4912,29 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -3282,6 +4956,23 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/equivalent-key-map": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/equivalent-key-map/-/equivalent-key-map-0.2.2.tgz",
+      "integrity": "sha512-xvHeyCDbZzkpN4VHQj/n+j2lOwL0VWszG30X4cOrc9Y7Tuo2qCdZK/0AMod23Z5dCtNUbaju6p0rwOhHUk05ew==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-define-property": {
@@ -3525,6 +5216,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -3566,6 +5264,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fresh": {
@@ -3697,6 +5423,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gettext-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+      "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encoding": "^0.1.12",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -3764,6 +5501,15 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/gradient-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-1.2.0.tgz",
+      "integrity": "sha512-6ABGa9CR7WR/0pAJicBy5SJkiikbFM6kf/JjykwX7x+t+s8ORWVnlbi6FkHeFFb36yWsjUpHqSYrygd7ofEUqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/happy-dom": {
       "version": "20.11.1",
@@ -3871,6 +5617,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/highlight-words-core": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.3.tgz",
+      "integrity": "sha512-m1O9HW3/GNHxzSIXWw1wCNXXsgLlxrP0OI6+ycGUhiUHkikqW3OrwVHz+lxeNBe5yqLESdIcj8PowHQ2zLvUvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hpq": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/hpq/-/hpq-1.4.0.tgz",
+      "integrity": "sha512-ycJQMRaRPBcfnoT1gS5I1XCvbbw9KO94Y0vkwksuOjcJMqNZtb03MF2tCItLI2mQbkZWSSeFinoRDPmjzv4tKg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -3947,6 +5735,23 @@
         "node": ">= 4"
       }
     },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -3984,6 +5789,13 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -3995,6 +5807,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module/node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -4016,6 +5857,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
@@ -4130,10 +5988,30 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -4500,6 +6378,13 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -4630,6 +6515,36 @@
         "node": ">=4"
       }
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loose-envify/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -4649,6 +6564,17 @@
       "license": "ISC",
       "engines": {
         "node": "18 >=18.20 || 20 || >=22"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -4689,6 +6615,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/marked": {
+      "version": "18.0.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.9.tgz",
+      "integrity": "sha512-/Sa4qiiHZxf0/FQdBBowr9q4r10krCwMvpK48FUBdXdUXScDxiQGR9zCPrFgRVR5LU3iySOiIjy09ZQvADir1w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4708,6 +6647,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/memize": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
+      "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
@@ -4831,6 +6777,53 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mousetrap": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
+      "integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA==",
+      "dev": true,
+      "license": "Apache-2.0 WITH LLVM-exception"
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -4882,6 +6875,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/normalize-url": {
@@ -5079,6 +7083,49 @@
       "dev": true,
       "license": "(MIT AND Zlib)"
     },
+    "node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -5087,6 +7134,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/path-expression-matcher": {
@@ -5114,6 +7183,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
@@ -5145,6 +7221,16 @@
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -5254,6 +7340,44 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -5357,6 +7481,85 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/re-resizable": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.11.2.tgz",
+      "integrity": "sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-colorful": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.8.0.tgz",
+      "integrity": "sha512-Wy9OzPfjSN9bF12OB8N7UQvlsZ0I+7wHxpN+bV5BjNQGxOj6IiwkRjevJK9yOBjJWGQvAaf1OXtn8rUeEatAng==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/react-day-picker": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.14.0.tgz",
+      "integrity": "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.4.1",
+        "@tabby_ai/hijri-converter": "1.0.5",
+        "date-fns": "^4.1.0",
+        "date-fns-jalali": "4.1.0-0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -5371,6 +7574,34 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rememo": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+      "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/remove-accents": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/requestidlecallback": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
+      "integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -5392,12 +7623,51 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/responselike": {
       "version": "2.0.1",
@@ -5483,6 +7753,13 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
+    "node_modules/rungen": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/rungen/-/rungen-0.3.2.tgz",
+      "integrity": "sha512-zWl10xu2D7zoR8zSC2U6bg5bYF6T/Wk7rxwp8IPaJH7f0Ge21G03kNHVgHR7tyVkSSfAOG0Rqf/Cl38JftSmtw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -5519,6 +7796,16 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/semver": {
@@ -5565,6 +7852,18 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
     },
     "node_modules/serve-static": {
       "version": "1.16.3",
@@ -5837,6 +8136,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/simple-html-tokenizer": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
+      "integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5998,6 +8325,13 @@
       ],
       "license": "MIT"
     },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6009,6 +8343,36 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tannin": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
+      "integrity": "sha512-U7GgX/RcSeUETbV7gYgoz8PD7Ni4y95pgIP/Z6ayI3CfhSujwKEBlGFTCRN+Aqnuyf4AN2yHL+L8x+TCGjb9uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tannin/plural-forms": "^1.1.0"
       }
     },
     "node_modules/tinybench": {
@@ -6105,8 +8469,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -6182,6 +8545,26 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -6190,6 +8573,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -6207,6 +8600,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -5,11 +5,18 @@
   "private": true,
   "devDependencies": {
     "@playwright/test": "^1.62.0",
+    "@testing-library/react": "^16.3.2",
     "@vitest/coverage-v8": "^4.1.10",
+    "@wordpress/blocks": "^15.25.0",
+    "@wordpress/components": "^38.0.0",
+    "@wordpress/element": "^8.4.0",
     "@wordpress/env": "^11.11.0",
+    "@wordpress/i18n": "^6.25.0",
     "happy-dom": "^20.10.2",
     "jquery": "^3.7.1",
     "nunjucks": "^3.2.4",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "vitest": "^4.1.8"
   },
   "scripts": {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -37,3 +37,7 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';
+
+// Shared test helpers. Loaded after WordPress so they can use its functions,
+// and kept out of tests/unit/ because the suite only picks up *Test.php there.
+require_once __DIR__ . '/helpers/class-bundle-fixture.php';

--- a/tests/helpers/class-bundle-fixture.php
+++ b/tests/helpers/class-bundle-fixture.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Fixture builder for the bundled static editor.
+ *
+ * A source checkout has no dist/static/ and a developer machine has a full
+ * editor build, so every code path that reads the bundle behaves differently
+ * depending on where the suite runs: in CI those paths are unreachable, and
+ * locally they return whatever the installed editor happens to contain. Tests
+ * that care about them build their own bundle here and point
+ * {@see ExeLearning_Editor_Bundle} at it, so the assertions mean the same
+ * thing on both.
+ *
+ * @package Exelearning
+ */
+
+/**
+ * Class ExeLearning_Bundle_Fixture.
+ */
+class ExeLearning_Bundle_Fixture {
+
+	/**
+	 * Directory currently standing in for the plugin directory.
+	 *
+	 * @var string
+	 */
+	private static $dir = '';
+
+	/**
+	 * Themes the default fixture bundle.json declares.
+	 *
+	 * @var array<int, array<string,string>>
+	 */
+	const DEFAULT_THEMES = array(
+		array(
+			'name'    => 'base',
+			'title'   => 'Base',
+			'version' => '1.0.0',
+			'author'  => 'eXeLearning',
+		),
+		array(
+			'name'    => 'pukao',
+			'title'   => 'Pukao',
+			'version' => '2.1.0',
+			'author'  => 'eXeLearning',
+		),
+	);
+
+	/**
+	 * Build a minimal but valid editor bundle and make the plugin use it.
+	 *
+	 * Valid means what ExeLearning_Editor_Bundle::is_available() requires: a
+	 * readable index.html plus at least one asset directory.
+	 *
+	 * @param array|null $themes Theme entries for data/bundle.json, or null for
+	 *                           {@see self::DEFAULT_THEMES}. Pass an empty array
+	 *                           for a bundle that declares no themes.
+	 * @return string The fixture plugin directory (the parent of dist/static/).
+	 */
+	public static function create( $themes = null ) {
+		self::destroy();
+
+		self::$dir = trailingslashit( get_temp_dir() ) . 'exelearning-fixture-' . wp_generate_password( 8, false );
+		$static    = self::$dir . '/dist/static';
+
+		wp_mkdir_p( $static . '/app' );
+		wp_mkdir_p( $static . '/data' );
+
+		file_put_contents( // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			$static . '/index.html',
+			"<!DOCTYPE html>\n<html>\n<head>\n<title>eXeLearning</title>\n</head>\n<body>\n<div id=\"app\"></div>\n</body>\n</html>\n"
+		);
+		file_put_contents( // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			$static . '/data/bundle.json',
+			(string) wp_json_encode( self::bundle_payload( null === $themes ? self::DEFAULT_THEMES : $themes ) )
+		);
+
+		ExeLearning_Editor_Bundle::set_path_override( self::$dir );
+
+		return self::$dir;
+	}
+
+	/**
+	 * Write an arbitrary file into the fixture bundle.
+	 *
+	 * @param string $relative Path below dist/static/.
+	 * @param string $contents File contents.
+	 * @return string Absolute path written.
+	 */
+	public static function write( $relative, $contents ) {
+		$path = self::$dir . '/dist/static/' . ltrim( $relative, '/' );
+		wp_mkdir_p( dirname( $path ) );
+		file_put_contents( $path, $contents ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		return $path;
+	}
+
+	/**
+	 * Delete a file from the fixture bundle.
+	 *
+	 * @param string $relative Path below dist/static/.
+	 * @return void
+	 */
+	public static function delete( $relative ) {
+		$path = self::$dir . '/dist/static/' . ltrim( $relative, '/' );
+		if ( file_exists( $path ) ) {
+			wp_delete_file( $path );
+		}
+	}
+
+	/**
+	 * Point the plugin at a directory that holds no bundle at all.
+	 *
+	 * This is the source-checkout situation: the plugin is installed but
+	 * `make build-editor` has never run.
+	 *
+	 * @return string The empty fixture directory.
+	 */
+	public static function create_empty() {
+		self::destroy();
+
+		self::$dir = trailingslashit( get_temp_dir() ) . 'exelearning-empty-' . wp_generate_password( 8, false );
+		wp_mkdir_p( self::$dir );
+		ExeLearning_Editor_Bundle::set_path_override( self::$dir );
+
+		return self::$dir;
+	}
+
+	/**
+	 * Drop the fixture and hand the plugin back its real directory.
+	 *
+	 * @return void
+	 */
+	public static function destroy() {
+		ExeLearning_Editor_Bundle::set_path_override( null );
+		if ( '' !== self::$dir ) {
+			self::recursive_delete( self::$dir );
+			self::$dir = '';
+		}
+	}
+
+	/**
+	 * Wrap theme entries in the double-nested shape the core build emits.
+	 *
+	 * @param array $themes Theme entries.
+	 * @return array<string,mixed>
+	 */
+	private static function bundle_payload( array $themes ) {
+		return array(
+			'version' => 'fixture',
+			'themes'  => array( 'themes' => $themes ),
+		);
+	}
+
+	/**
+	 * Remove a directory tree.
+	 *
+	 * @param string $dir Directory to delete.
+	 * @return void
+	 */
+	private static function recursive_delete( $dir ) {
+		if ( ! is_dir( $dir ) ) {
+			return;
+		}
+		$entries = array_diff( (array) scandir( $dir ), array( '.', '..' ) );
+		foreach ( $entries as $entry ) {
+			$path = $dir . '/' . $entry;
+			if ( is_dir( $path ) ) {
+				self::recursive_delete( $path );
+			} else {
+				wp_delete_file( $path );
+			}
+		}
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
+		rmdir( $dir );
+	}
+}

--- a/tests/js/elp_upload.test.js
+++ b/tests/js/elp_upload.test.js
@@ -1,0 +1,711 @@
+// Unit tests for assets/js/elp-upload.js, the eXeLearning Gutenberg block.
+//
+// The block is registered against the real WordPress packages rather than
+// hand-written stand-ins: @wordpress/element (React 18, the version WordPress
+// ships), @wordpress/blocks, @wordpress/components and @wordpress/i18n are the
+// same code that runs in the editor, so registerBlockType really validates the
+// block, a real ToggleControl really renders its checkbox, and getByLabelText
+// finds a control only if it was wired up accessibly. A stub would have agreed
+// with whatever the block passed it.
+//
+// One thing is stubbed, because it cannot be anything else: wp.blockEditor.
+// MediaUpload *is* the WordPress media modal, which needs wp.media and the
+// editor data stores; BlockControls and InspectorControls are Slot/Fill pairs
+// whose children render into slots the editor owns. They are replaced with
+// pass-throughs so their children render inline and can be asserted on -- that
+// substitutes editor chrome, not the block's own behaviour.
+//
+// The block is registered once for the file: registerBlockType refuses a name
+// that is already taken, and the module registers on import.
+
+const path = require( 'path' );
+const { pathToFileURL } = require( 'url' );
+const { render, screen, fireEvent, cleanup } = require( '@testing-library/react' );
+const element = require( '@wordpress/element' );
+const blocks = require( '@wordpress/blocks' );
+const components = require( '@wordpress/components' );
+const i18n = require( '@wordpress/i18n' );
+
+const SCRIPT = pathToFileURL(
+	path.resolve( __dirname, '../../assets/js/elp-upload.js' )
+).href;
+
+const BLOCK_NAME = 'exelearning/elp-upload';
+
+/** MediaUpload invocations, so tests can drive onSelect the way the modal does. */
+let mediaUploads = [];
+/** Arguments every setAttributes call received. */
+let attributeUpdates = [];
+/** Anything the block reported to the console. */
+let consoleErrors = [];
+/** downloadFormat() calls made through the shared helper. */
+let downloadCalls = [];
+
+let blockType;
+let originalConsoleLog;
+let originalConsoleError;
+
+beforeAll( async () => {
+	originalConsoleLog = console.log;
+	originalConsoleError = console.error;
+	// The block narrates media selection to the console; keep the suite readable.
+	console.log = () => {};
+	console.error = ( ...args ) => consoleErrors.push( args.join( ' ' ) );
+
+	/** Render children inline instead of into an editor slot. */
+	const passthrough = ( props ) =>
+		element.createElement( element.Fragment, null, props.children );
+
+	global.wp = {
+		element,
+		blocks,
+		components,
+		i18n,
+		blockEditor: {
+			BlockControls: passthrough,
+			InspectorControls: passthrough,
+			MediaUploadCheck: passthrough,
+			// The real one opens the media modal; record the props and expose
+			// its render prop, which is the only part the block controls.
+			MediaUpload: ( props ) => {
+				const entry = { onSelect: props.onSelect, mode: props.mode, allowedTypes: props.allowedTypes };
+				mediaUploads.push( entry );
+				return props.render( { open: () => entry.opened = true } );
+			},
+		},
+	};
+	window.wp = global.wp;
+
+	await import( /* @vite-ignore */ SCRIPT );
+	blockType = blocks.getBlockType( BLOCK_NAME );
+} );
+
+afterAll( () => {
+	console.log = originalConsoleLog;
+	console.error = originalConsoleError;
+	if ( blocks.getBlockType( BLOCK_NAME ) ) {
+		blocks.unregisterBlockType( BLOCK_NAME );
+	}
+	delete global.wp;
+	delete window.wp;
+} );
+
+beforeEach( () => {
+	mediaUploads = [];
+	attributeUpdates = [];
+	consoleErrors = [];
+	downloadCalls = [];
+} );
+
+afterEach( () => {
+	cleanup();
+	delete window.wpExeDownloadConfig;
+	delete window.wpExeDownload;
+	delete window.ExeLearningEditor;
+} );
+
+/**
+ * Render the block's edit component.
+ *
+ * @param {Object}  attributes   Block attributes, merged over the defaults.
+ * @param {boolean} [isSelected] Whether the block is selected in the editor.
+ * @return {Object} Testing Library render result.
+ */
+function renderEdit( attributes, isSelected ) {
+	const defaults = {};
+	Object.keys( blockType.attributes ).forEach( ( key ) => {
+		if ( undefined !== blockType.attributes[ key ].default ) {
+			defaults[ key ] = blockType.attributes[ key ].default;
+		}
+	} );
+
+	return render(
+		element.createElement( blockType.edit, {
+			attributes: { ...defaults, ...attributes },
+			setAttributes: ( update ) => attributeUpdates.push( update ),
+			isSelected: undefined === isSelected ? true : isSelected,
+		} )
+	);
+}
+
+/**
+ * Expand a collapsed settings panel.
+ *
+ * PanelBody renders its children only once open, and "Download options" ships
+ * collapsed, so its controls do not exist until the panel is clicked.
+ *
+ * @param {string} title Panel title.
+ */
+function openPanel( title ) {
+	fireEvent.click( screen.getByRole( 'button', { name: title } ) );
+}
+
+/** Install the shared download helper the frontend script publishes. */
+function installDownloadHelper( behaviour ) {
+	window.wpExeDownload = {
+		downloadFormat: ( params ) => {
+			downloadCalls.push( params );
+			return behaviour ? behaviour() : Promise.resolve();
+		},
+	};
+}
+
+describe( 'elp-upload: the registered block', () => {
+	it( 'registers under its own name in the embed category', () => {
+		expect( blockType ).toBeTruthy();
+		expect( blockType.name ).toBe( BLOCK_NAME );
+		expect( blockType.category ).toBe( 'embed' );
+	} );
+
+	it( 'declares the attributes the shortcode and renderer read back', () => {
+		// These names are a contract: public/class-shortcodes.php and
+		// includes/class-elp-upload-block.php render from the saved attributes,
+		// so renaming one here silently breaks every existing post.
+		expect( Object.keys( blockType.attributes ).sort() ).toEqual( [
+			'align',
+			'attachmentId',
+			'downloadFormats',
+			'fullscreen',
+			'hasPreview',
+			'height',
+			'previewUrl',
+			'showDownload',
+			'teacherModeVisible',
+			'title',
+			'url',
+		] );
+	} );
+
+	it( 'defaults to a closed-down embed rather than an opted-in one', () => {
+		expect( blockType.attributes.teacherModeVisible.default ).toBe( false );
+		expect( blockType.attributes.showDownload.default ).toBe( false );
+		expect( blockType.attributes.fullscreen.default ).toBe( false );
+		expect( blockType.attributes.height.default ).toBe( 600 );
+	} );
+
+	it( 'offers every download format by default', () => {
+		expect( blockType.attributes.downloadFormats.default ).toEqual( [
+			'elpx',
+			'html5',
+			'scorm12',
+			'ims',
+			'epub3',
+		] );
+	} );
+
+	it( 'renders server-side, so save() stores no markup', () => {
+		expect( blockType.save() ).toBeNull();
+		expect( blockType.supports.html ).toBe( false );
+	} );
+} );
+
+describe( 'elp-upload: choosing a file', () => {
+	it( 'offers an upload button and a media library button', () => {
+		renderEdit( {} );
+
+		expect( screen.getByText( 'Upload .elpx File' ) ).toBeTruthy();
+		expect( screen.getByText( 'Media Library' ) ).toBeTruthy();
+		expect( mediaUploads.map( ( m ) => m.mode ) ).toEqual( [ 'upload', 'browse' ] );
+	} );
+
+	it( 'stores the file and its eXeLearning metadata once one is picked', () => {
+		renderEdit( {} );
+
+		mediaUploads[ 0 ].onSelect( {
+			id: 42,
+			url: 'http://example.test/curso.elpx',
+			filename: 'curso.elpx',
+			title: 'Mi curso',
+			exelearning: { preview_url: 'http://example.test/preview/index.html', has_preview: true },
+		} );
+
+		expect( attributeUpdates ).toEqual( [
+			{
+				attachmentId: 42,
+				url: 'http://example.test/curso.elpx',
+				previewUrl: 'http://example.test/preview/index.html',
+				title: 'Mi curso',
+				hasPreview: true,
+			},
+		] );
+	} );
+
+	it( 'accepts a file WordPress reported as a plain zip', () => {
+		// .elpx is a ZIP; depending on the server, WordPress may report it as
+		// application/zip rather than by extension.
+		renderEdit( {} );
+
+		mediaUploads[ 0 ].onSelect( {
+			id: 7,
+			url: 'http://example.test/sin-extension',
+			mime: 'application/zip',
+			title: 'Paquete',
+		} );
+
+		expect( attributeUpdates ).toHaveLength( 1 );
+		expect( attributeUpdates[ 0 ].attachmentId ).toBe( 7 );
+	} );
+
+	it( 'ignores a file that is not an eXeLearning package', () => {
+		renderEdit( {} );
+
+		mediaUploads[ 0 ].onSelect( {
+			id: 9,
+			url: 'http://example.test/foto.jpg',
+			filename: 'foto.jpg',
+			mime: 'image/jpeg',
+		} );
+
+		expect( attributeUpdates ).toEqual( [] );
+	} );
+
+	it( 'ignores a selection with no media behind it', () => {
+		renderEdit( {} );
+
+		mediaUploads[ 0 ].onSelect( null );
+		mediaUploads[ 0 ].onSelect( {} );
+
+		expect( attributeUpdates ).toEqual( [] );
+	} );
+
+	it( 'names an untitled file so the block is not blank', () => {
+		renderEdit( {} );
+
+		mediaUploads[ 0 ].onSelect( {
+			id: 11,
+			url: 'http://example.test/x.elpx',
+			filename: 'x.elpx',
+		} );
+
+		expect( attributeUpdates[ 0 ].title ).toBe( 'x.elpx' );
+	} );
+} );
+
+describe( 'elp-upload: the settings panel', () => {
+	/** Attributes of a block that already has a file. */
+	const WITH_FILE = {
+		attachmentId: 42,
+		url: 'http://example.test/curso.elpx',
+		title: 'Mi curso',
+	};
+
+	it( 'turns the teacher layer selector on through a real control', () => {
+		renderEdit( WITH_FILE );
+
+		fireEvent.click( screen.getByLabelText( 'Show teacher layer selector' ) );
+
+		expect( attributeUpdates ).toEqual( [ { teacherModeVisible: true } ] );
+	} );
+
+	it( 'turns the fullscreen button on', () => {
+		renderEdit( WITH_FILE );
+
+		fireEvent.click( screen.getByLabelText( 'Show fullscreen button' ) );
+
+		expect( attributeUpdates ).toEqual( [ { fullscreen: true } ] );
+	} );
+
+	it( 'turns the download button on', () => {
+		renderEdit( WITH_FILE );
+		openPanel( 'Download options' );
+
+		fireEvent.click( screen.getByLabelText( 'Show download button' ) );
+
+		expect( attributeUpdates ).toEqual( [ { showDownload: true } ] );
+	} );
+
+	it( 'stores a new embed height from the range control', () => {
+		renderEdit( WITH_FILE );
+
+		// RangeControl renders a slider and a number field, both labelled; the
+		// slider is the one carrying the range role.
+		fireEvent.change( screen.getByRole( 'slider', { name: 'Height (px)' } ), {
+			target: { value: '850' },
+		} );
+
+		expect( attributeUpdates ).toEqual( [ { height: 850 } ] );
+	} );
+
+	it( 'reflects the stored state back into the controls', () => {
+		renderEdit( { ...WITH_FILE, teacherModeVisible: true, fullscreen: false } );
+
+		expect( screen.getByLabelText( 'Show teacher layer selector' ).checked ).toBe( true );
+		expect( screen.getByLabelText( 'Show fullscreen button' ).checked ).toBe( false );
+	} );
+
+	it( 'lists a checkbox per download format once downloads are on', () => {
+		renderEdit( { ...WITH_FILE, showDownload: true } );
+		openPanel( 'Download options' );
+
+		expect( screen.getByLabelText( 'Download .elpx' ) ).toBeTruthy();
+		expect( screen.getByLabelText( 'Web (_web.zip)' ) ).toBeTruthy();
+		expect( screen.getByLabelText( 'SCORM 1.2 (_scorm.zip)' ) ).toBeTruthy();
+		expect( screen.getByLabelText( 'IMS Package (_ims.zip)' ) ).toBeTruthy();
+		expect( screen.getByLabelText( 'EPUB3 (.epub)' ) ).toBeTruthy();
+	} );
+
+	it( 'removes a format from the list when its box is cleared', () => {
+		renderEdit( {
+			...WITH_FILE,
+			showDownload: true,
+			downloadFormats: [ 'elpx', 'html5' ],
+		} );
+		openPanel( 'Download options' );
+
+		fireEvent.click( screen.getByLabelText( 'Web (_web.zip)' ) );
+
+		expect( attributeUpdates ).toEqual( [ { downloadFormats: [ 'elpx' ] } ] );
+	} );
+
+	it( 'adds a format back when its box is ticked', () => {
+		renderEdit( {
+			...WITH_FILE,
+			showDownload: true,
+			downloadFormats: [ 'elpx' ],
+		} );
+		openPanel( 'Download options' );
+
+		fireEvent.click( screen.getByLabelText( 'EPUB3 (.epub)' ) );
+
+		expect( attributeUpdates ).toHaveLength( 1 );
+		expect( attributeUpdates[ 0 ].downloadFormats ).toContain( 'epub3' );
+		expect( attributeUpdates[ 0 ].downloadFormats ).toContain( 'elpx' );
+	} );
+} );
+
+describe( 'elp-upload: the edit-mode download button', () => {
+	const WITH_FILE = {
+		attachmentId: 42,
+		url: 'http://example.test/curso.elpx',
+		title: 'Mi curso',
+		showDownload: true,
+	};
+
+	it( 'downloads through the same helper the frontend uses', () => {
+		// Not a second export pipeline: the block reuses window.wpExeDownload so
+		// edit mode and the frontend cannot drift apart.
+		installDownloadHelper();
+		renderEdit( WITH_FILE );
+
+		fireEvent.click( screen.getByText( 'Download .elpx' ) );
+
+		expect( downloadCalls ).toHaveLength( 1 );
+		expect( downloadCalls[ 0 ].format ).toBe( 'elpx' );
+		expect( downloadCalls[ 0 ].attachmentId ).toBe( 42 );
+		expect( downloadCalls[ 0 ].elpUrl ).toBe( 'http://example.test/curso.elpx' );
+		expect( downloadCalls[ 0 ].container ).toBeNull();
+	} );
+
+	it( 'names the file after the block title', () => {
+		installDownloadHelper();
+		renderEdit( { ...WITH_FILE, title: '¡Mi Curso 2026!' } );
+
+		fireEvent.click( screen.getByText( 'Download .elpx' ) );
+
+		expect( downloadCalls[ 0 ].slug ).toBe( 'mi-curso-2026' );
+	} );
+
+	it( 'falls back to the attachment id when the title yields no slug', () => {
+		installDownloadHelper();
+		renderEdit( { ...WITH_FILE, title: '???' } );
+
+		fireEvent.click( screen.getByText( 'Download .elpx' ) );
+
+		expect( downloadCalls[ 0 ].slug ).toBe( 'exelearning-42' );
+	} );
+
+	it( 'says so when the download helper was never loaded', () => {
+		renderEdit( WITH_FILE );
+
+		fireEvent.click( screen.getByText( 'Download .elpx' ) );
+
+		expect( downloadCalls ).toEqual( [] );
+		expect( consoleErrors.join( ' ' ) ).toContain( 'wp-exe-download.js' );
+	} );
+
+	it( 'opens the other formats from the toggle', () => {
+		installDownloadHelper();
+		renderEdit( WITH_FILE );
+
+		const toggle = screen.getByLabelText( 'More download formats' );
+		expect( toggle.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
+
+		fireEvent.click( toggle );
+
+		expect( toggle.getAttribute( 'aria-expanded' ) ).toBe( 'true' );
+	} );
+
+	it( 'shows only the formats the block enabled', () => {
+		installDownloadHelper();
+		renderEdit( { ...WITH_FILE, downloadFormats: [ 'elpx', 'epub3' ] } );
+
+		expect( screen.getByText( 'Download .elpx' ) ).toBeTruthy();
+		expect( screen.getByText( 'EPUB3 (.epub)' ) ).toBeTruthy();
+		expect( screen.queryByText( 'SCORM 1.2 (_scorm.zip)' ) ).toBeNull();
+	} );
+
+	it( 'falls back to the full set when the list was emptied', () => {
+		installDownloadHelper();
+		const { container } = renderEdit( { ...WITH_FILE, downloadFormats: [] } );
+
+		expect( container.querySelector( '.exelearning-download' ) ).not.toBeNull();
+	} );
+
+	it( 'renders no toolbar at all when nothing in the list is a real format', () => {
+		installDownloadHelper();
+		const { container } = renderEdit( {
+			...WITH_FILE,
+			downloadFormats: [ 'formato-que-no-existe' ],
+		} );
+
+		expect( container.querySelector( '.exelearning-download' ) ).toBeNull();
+	} );
+
+	it( 'reports a failed export instead of staying busy', async () => {
+		installDownloadHelper( () => Promise.reject( new Error( 'boom' ) ) );
+		renderEdit( WITH_FILE );
+
+		fireEvent.click( screen.getByText( 'Download .elpx' ) );
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+		expect( screen.getByText( 'Download failed. Please try again.' ) ).toBeTruthy();
+	} );
+} );
+
+describe( 'elp-upload: formats that need the editor installed', () => {
+	const WITH_FILE = {
+		attachmentId: 42,
+		url: 'http://example.test/curso.elpx',
+		title: 'Mi curso',
+		showDownload: true,
+	};
+
+	it( 'disables the client-side formats and explains why', () => {
+		window.wpExeDownloadConfig = { editorInstalled: '' };
+		installDownloadHelper();
+		renderEdit( WITH_FILE );
+
+		const scorm = screen.getByText( 'SCORM 1.2 (_scorm.zip)' ).closest( 'button' );
+		expect( scorm.getAttribute( 'aria-disabled' ) ).toBe( 'true' );
+		expect( scorm.getAttribute( 'title' ) ).toContain( 'Install the eXeLearning editor' );
+	} );
+
+	it( 'keeps .elpx usable, because it is the attachment itself', () => {
+		window.wpExeDownloadConfig = { editorInstalled: '' };
+		installDownloadHelper();
+		renderEdit( WITH_FILE );
+
+		fireEvent.click( screen.getByText( 'Download .elpx' ) );
+
+		expect( downloadCalls ).toHaveLength( 1 );
+	} );
+
+	it( 'refuses to run a disabled format', () => {
+		window.wpExeDownloadConfig = { editorInstalled: '' };
+		installDownloadHelper();
+		renderEdit( WITH_FILE );
+
+		fireEvent.click( screen.getByLabelText( 'More download formats' ) );
+		const scorm = screen.getByText( 'SCORM 1.2 (_scorm.zip)' ).closest( 'button' );
+
+		// The refusal is the button's own disabled attribute, not a handler that
+		// runs and bails: asserting only "nothing downloaded" would pass even if
+		// the wiring were gone entirely.
+		expect( scorm.disabled ).toBe( true );
+		fireEvent.click( scorm );
+		expect( downloadCalls ).toEqual( [] );
+	} );
+
+	it( 'sorts the unusable formats last so the primary slot stays usable', () => {
+		// Mirrors ExeLearning_Download_Button_Renderer::build_items(): with no
+		// editor, the primary button must still be the .elpx one.
+		window.wpExeDownloadConfig = { editorInstalled: '' };
+		installDownloadHelper();
+		renderEdit( { ...WITH_FILE, downloadFormats: [ 'scorm12', 'elpx' ] } );
+
+		const primary = document.querySelector( '.exelearning-download__primary' );
+		expect( primary.textContent ).toContain( 'Download .elpx' );
+	} );
+
+	it( 'reads the stringified true wp_localize_script produces', () => {
+		// wp_localize_script() turns booleans into '1' and '', so a raw truthiness
+		// check on the value would call an absent editor installed.
+		window.wpExeDownloadConfig = { editorInstalled: '1' };
+		installDownloadHelper();
+		renderEdit( WITH_FILE );
+
+		const scorm = screen.getByText( 'SCORM 1.2 (_scorm.zip)' ).closest( 'button' );
+		expect( scorm.getAttribute( 'aria-disabled' ) ).toBeNull();
+	} );
+
+	it( 'assumes the editor is there when the flag was never localized', () => {
+		installDownloadHelper();
+		renderEdit( WITH_FILE );
+
+		const scorm = screen.getByText( 'SCORM 1.2 (_scorm.zip)' ).closest( 'button' );
+		expect( scorm.getAttribute( 'aria-disabled' ) ).toBeNull();
+	} );
+} );
+
+describe( 'elp-upload: the teacher-layer selector in the preview', () => {
+	// The preview iframe is same-origin, so the block hides the editor's own
+	// teacher-mode toggler by injecting a stylesheet into it rather than
+	// reloading the preview. Getting this wrong shows authors a control the
+	// published page will not have.
+	const WITH_PREVIEW = {
+		attachmentId: 42,
+		url: 'http://example.test/curso.elpx',
+		title: 'Mi curso',
+		hasPreview: true,
+		previewUrl: 'http://example.test/preview/index.html',
+	};
+
+	const STYLE_ID = 'exelearning-teacher-mode-style';
+
+	/**
+	 * Give the preview iframe a document the block can write into.
+	 *
+	 * The suite runs with happy-dom's iframe page loading disabled (no unit test
+	 * should fetch anything), which leaves contentDocument null. A detached
+	 * HTML document is the same shape the real same-origin preview exposes.
+	 *
+	 * @param {HTMLElement} iframe The preview iframe.
+	 * @return {Document} The attached document.
+	 */
+	function attachPreviewDocument( iframe ) {
+		const doc = document.implementation.createHTMLDocument( 'preview' );
+		const win = { onbeforeunload: null };
+		Object.defineProperty( iframe, 'contentDocument', { configurable: true, value: doc } );
+		Object.defineProperty( iframe, 'contentWindow', { configurable: true, value: win } );
+		return doc;
+	}
+
+	/**
+	 * Render with a preview whose document the block can reach, and apply.
+	 *
+	 * @param {Object} attributes Block attributes.
+	 * @return {Object} The iframe, its document and the render result.
+	 */
+	function renderWithPreview( attributes ) {
+		const result = renderEdit( { ...WITH_PREVIEW, ...attributes } );
+		const iframe = result.container.querySelector( 'iframe' );
+		const doc = attachPreviewDocument( iframe );
+		// The effect bound a load handler on mount; the preview "loading" is what
+		// re-runs it now that the document exists.
+		fireEvent.load( iframe );
+		return { ...result, iframe, doc };
+	}
+
+	it( 'hides the toggler while the teacher layer is off', () => {
+		const { doc } = renderWithPreview( { teacherModeVisible: false } );
+
+		const style = doc.getElementById( STYLE_ID );
+		expect( style ).not.toBeNull();
+		expect( style.textContent ).toContain( 'visibility: hidden' );
+		expect( style.textContent ).toContain( 'teacher-mode-toggler-wrapper' );
+	} );
+
+	it( 'leaves the toggler alone once the teacher layer is on', () => {
+		const { doc } = renderWithPreview( { teacherModeVisible: true } );
+
+		expect( doc.getElementById( STYLE_ID ) ).toBeNull();
+	} );
+
+	it( 'removes the stylesheet when the author turns the layer on', () => {
+		const { doc, rerender } = renderWithPreview( { teacherModeVisible: false } );
+		expect( doc.getElementById( STYLE_ID ) ).not.toBeNull();
+
+		rerender(
+			element.createElement( blockType.edit, {
+				attributes: {
+					...WITH_PREVIEW,
+					height: 600,
+					align: 'none',
+					showDownload: false,
+					fullscreen: false,
+					downloadFormats: [ 'elpx' ],
+					teacherModeVisible: true,
+				},
+				setAttributes: ( update ) => attributeUpdates.push( update ),
+				isSelected: true,
+			} )
+		);
+
+		expect( doc.getElementById( STYLE_ID ) ).toBeNull();
+	} );
+
+	it( 'injects the stylesheet only once however often the preview reloads', () => {
+		const { doc, iframe } = renderWithPreview( { teacherModeVisible: false } );
+
+		fireEvent.load( iframe );
+		fireEvent.load( iframe );
+
+		expect( doc.querySelectorAll( '#' + STYLE_ID ) ).toHaveLength( 1 );
+	} );
+
+	it( 'stops the preview from raising a leave-site prompt', () => {
+		// An unsaved-changes dialog from the preview would trap the author in the
+		// editor, so the block neutralises the handler and locks the property.
+		const { iframe } = renderWithPreview( { teacherModeVisible: false } );
+
+		iframe.contentWindow.onbeforeunload = () => 'stay?';
+
+		expect( iframe.contentWindow.onbeforeunload ).toBeNull();
+	} );
+
+	it( 'survives a preview it is not allowed to read', () => {
+		const result = renderEdit( { ...WITH_PREVIEW, teacherModeVisible: false } );
+		const iframe = result.container.querySelector( 'iframe' );
+		Object.defineProperty( iframe, 'contentDocument', {
+			configurable: true,
+			get() {
+				throw new Error( 'cross-origin' );
+			},
+		} );
+
+		expect( () => fireEvent.load( iframe ) ).not.toThrow();
+	} );
+} );
+
+describe( 'elp-upload: the block toolbar', () => {
+	const WITH_FILE = {
+		attachmentId: 42,
+		url: 'http://example.test/curso.elpx',
+		title: 'Mi curso',
+	};
+
+	it( 'clears every trace of the file when it is removed', () => {
+		renderEdit( WITH_FILE );
+
+		fireEvent.click( screen.getByLabelText( 'Remove' ) );
+
+		expect( attributeUpdates ).toEqual( [
+			{
+				attachmentId: undefined,
+				url: undefined,
+				previewUrl: undefined,
+				title: undefined,
+				hasPreview: false,
+				teacherModeVisible: false,
+			},
+		] );
+	} );
+
+	it( 'opens the embedded editor for the selected attachment', () => {
+		const opened = [];
+		window.ExeLearningEditor = { open: ( id ) => opened.push( id ) };
+		renderEdit( WITH_FILE );
+
+		fireEvent.click( screen.getByLabelText( 'Edit in eXeLearning' ) );
+
+		expect( opened ).toEqual( [ 42 ] );
+	} );
+
+	it( 'does nothing when the editor modal is not loaded', () => {
+		renderEdit( WITH_FILE );
+
+		expect( () =>
+			fireEvent.click( screen.getByLabelText( 'Edit in eXeLearning' ) )
+		).not.toThrow();
+	} );
+} );

--- a/tests/js/exelearning_media_modal.test.js
+++ b/tests/js/exelearning_media_modal.test.js
@@ -1,0 +1,1058 @@
+// Unit tests for assets/js/exelearning-media-modal.js.
+//
+// The script decorates the Media Library: it swaps .elpx thumbnails for scaled live
+// previews, fills the attachment details panel with metadata, and adds the "Edit in
+// eXeLearning" and "Process as eXeLearning" buttons. All of it is built by string
+// concatenation and injected with jQuery .html()/.after(), which is why esc() exists
+// and why a good part of this file is about it: an attachment title or a piece of
+// .elpx metadata is attacker-controlled -- a contributor who can upload gets to choose
+// both -- and it lands in markup that runs in the reviewing administrator's session.
+//
+// The rest is idempotence and failure handling. The script is re-run by a
+// MutationObserver, by the modal's `open` event and by four timers, so every function
+// has a "already did this" guard; if one of those guards is wrong the panel grows a
+// duplicate button on every mouse move. And the reprocess call must put the button
+// back and say what happened rather than leaving a disabled control behind.
+//
+// The script is a jQuery ready callback with no exports, so each test imports a fresh
+// copy under a cache-busting URL. Two things it touches are global and outlive the
+// module: jQuery's document handlers (dropped with $(document).off()) and the
+// MutationObserver, which is stubbed here so a stale instance cannot re-run updates
+// during a later test -- and so a test can decide when a re-render happens.
+
+const path = require( 'path' );
+const { pathToFileURL } = require( 'url' );
+
+const SCRIPT = pathToFileURL(
+	path.resolve( __dirname, '../../assets/js/exelearning-media-modal.js' )
+).href;
+
+// WordPress puts jQuery on the page as a global; the script closes over it by name.
+const $ = require( 'jquery' );
+global.jQuery = $;
+global.$ = $;
+
+let loadCount = 0;
+/** Attachments wp.media.attachment() will hand out, by id. */
+let attachments = new Map();
+/** MutationObserver instances the script created. */
+let observers = [];
+/** Handlers the script bound to the media modal's `open` event. */
+let modalOpenHandlers = [];
+/** Requests made through the stubbed fetch. */
+let requests = [];
+/** Windows opened through the stubbed window.open. */
+let openedWindows = [];
+
+let originalMutationObserver;
+let originalWindowOpen;
+
+const STRINGS = {
+	info: 'eXeLearning Info',
+	version: 'Versión:',
+	license: 'Licencia:',
+	language: 'Idioma:',
+	type: 'Tipo:',
+	editInExe: 'Editar en eXeLearning',
+	previewNewTab: 'Vista previa en pestaña nueva',
+	noPreview: 'Sin vista previa',
+	noPreviewDesc: 'Es un archivo fuente v2.',
+	processAsExe: 'Procesar como eXeLearning',
+	processing: 'Procesando…',
+	processFailed: 'No se pudo procesar este archivo.',
+	notProcessed: 'Archivo eXeLearning (sin procesar)',
+	sourceFile: '(archivo fuente)',
+	exported: '(exportado)',
+};
+
+beforeAll( () => {
+	originalMutationObserver = window.MutationObserver;
+	originalWindowOpen = window.open;
+} );
+
+afterAll( () => {
+	window.MutationObserver = originalMutationObserver;
+	global.MutationObserver = originalMutationObserver;
+	window.open = originalWindowOpen;
+} );
+
+beforeEach( () => {
+	attachments = new Map();
+	observers = [];
+	modalOpenHandlers = [];
+	requests = [];
+	openedWindows = [];
+
+	vi.useFakeTimers();
+
+	// Inert by default: the real observer would re-run every update on each of the
+	// script's own DOM writes, and a stale one would keep firing in later tests.
+	class StubMutationObserver {
+		constructor( callback ) {
+			this.callback = callback;
+			this.records = [];
+			observers.push( this );
+		}
+		observe( target, options ) {
+			this.target = target;
+			this.options = options;
+		}
+		disconnect() {
+			this.disconnected = true;
+		}
+		/** Test hook: report a DOM change to this observer. */
+		trigger() {
+			this.callback( [], this );
+		}
+	}
+	window.MutationObserver = StubMutationObserver;
+	global.MutationObserver = StubMutationObserver;
+
+	window.open = ( url, target, features ) => {
+		openedWindows.push( { url, target, features } );
+		return null;
+	};
+
+	global.wp = {
+		media: {
+			attachment: ( id ) => attachmentFor( id ),
+			frame: null,
+			view: {
+				Modal: {
+					prototype: {
+						on: ( event, handler ) => modalOpenHandlers.push( { event, handler } ),
+					},
+				},
+			},
+		},
+	};
+
+	window.exelearningMediaStrings = { ...STRINGS };
+	window.exelearningMediaSettings = {
+		restUrl: '/wp-json/exelearning/v1',
+		nonce: 'rest-nonce-123',
+	};
+} );
+
+afterEach( () => {
+	// jQuery keeps one native listener per event type on document, so a handler bound
+	// by a previous copy of the script would still fire during the next test.
+	$( document ).off();
+	vi.useRealTimers();
+	document.body.innerHTML = '';
+	delete global.wp;
+	delete window.exelearningMediaStrings;
+	delete window.exelearningMediaSettings;
+	delete window.ExeLearningEditor;
+	delete window.fetch;
+	// Some tests park an ?item= on the URL for the id-resolution fallbacks.
+	window.history.replaceState( {}, '', '/wp-admin/upload.php' );
+} );
+
+/**
+ * Build a Backbone-ish attachment model of the shape wp.media hands out.
+ *
+ * @param {number} id    Attachment id, or 0 for a model that has not loaded yet.
+ * @param {Object} attrs Prepared attachment attributes.
+ * @return {Object} The stub model.
+ */
+function makeAttachment( id, attrs ) {
+	const data = { ...attrs };
+	if ( id ) {
+		data.id = id;
+	}
+
+	const model = {
+		data,
+		fetchCount: 0,
+		get: ( key ) => data[ key ],
+		set: ( key, value ) => {
+			data[ key ] = value;
+		},
+		fetch() {
+			model.fetchCount++;
+			const deferred = $.Deferred();
+			model.settleFetch = ( loaded ) => {
+				Object.assign( data, loaded || {} );
+				deferred.resolve();
+			};
+			model.failFetch = () => deferred.reject();
+			return deferred.promise();
+		},
+	};
+
+	return model;
+}
+
+/** Register the model wp.media.attachment(id) will return. */
+function registerAttachment( id, attrs ) {
+	const model = makeAttachment( id, attrs );
+	attachments.set( String( id ), model );
+	return model;
+}
+
+/**
+ * wp.media.attachment(): a model that has never been seen is one that has not
+ * loaded yet, which is what sends the script down its fetch path.
+ *
+ * @param {number|string} id Attachment id.
+ * @return {Object} The stub model.
+ */
+function attachmentFor( id ) {
+	const key = String( id );
+	if ( ! attachments.has( key ) ) {
+		attachments.set( key, makeAttachment( 0, {} ) );
+	}
+	return attachments.get( key );
+}
+
+/** Metadata of a fully processed v3 .elpx with a live preview. */
+function previewMetadata( overrides ) {
+	return {
+		version: 3,
+		has_preview: true,
+		preview_url: 'http://example.test/uploads/exelearning/abc123/index.html',
+		...overrides,
+	};
+}
+
+/** Import a fresh copy of the script and let its ready callback run. */
+async function loadScript() {
+	await import( /* @vite-ignore */ `${ SCRIPT }?load=${ ++loadCount }` );
+	await settle();
+}
+
+/** Flush the script's promise chains and any timer due right now. */
+async function settle() {
+	for ( let i = 0; i < 6; i++ ) {
+		await Promise.resolve();
+		await vi.advanceTimersByTimeAsync( 0 );
+	}
+}
+
+/** The grid markup the media library renders for one attachment tile. */
+function gridMarkup( attachmentId ) {
+	return (
+		'<li class="attachment" data-id="' + attachmentId + '">' +
+			'<div class="attachment-preview type-application">' +
+				'<div class="thumbnail"><div class="centered"><img alt=""></div></div>' +
+			'</div>' +
+		'</li>'
+	);
+}
+
+/** The single-column attachment details markup. */
+function detailsMarkup() {
+	return (
+		'<div class="attachment-details">' +
+			'<div class="thumbnail"><img alt=""></div>' +
+		'</div>'
+	);
+}
+
+/** The two-column attachment-info markup, with an actions row. */
+function attachmentInfoMarkup( extra ) {
+	return (
+		'<div class="attachment-details">' +
+			'<div class="attachment-info">' +
+				'<div class="actions">' + ( extra || '' ) + '</div>' +
+			'</div>' +
+		'</div>'
+	);
+}
+
+/** Install a fetch stub that answers the reprocess endpoint. */
+function stubFetch( response ) {
+	window.fetch = ( url, options ) => {
+		requests.push( { url, options } );
+		if ( response.networkError ) {
+			return Promise.reject( new Error( 'offline' ) );
+		}
+		return Promise.resolve( {
+			ok: response.ok !== false,
+			json: () => Promise.resolve( response.body || {} ),
+		} );
+	};
+}
+
+describe( 'exelearning-media-modal: escaping attacker-controlled text', () => {
+	// A contributor who can upload chooses the filename and the .elpx metadata. Both
+	// are concatenated into markup and injected with .html()/.after(). If esc() ever
+	// stops escaping, this is stored XSS running as whoever opens the Media Library.
+
+	it( 'escapes the filename in the grid overlay instead of running it', async () => {
+		registerAttachment( 42, {
+			exelearning: previewMetadata(),
+			filename: '<img src=x onerror="window.__pwned = true">.elpx',
+		} );
+		document.body.innerHTML = gridMarkup( 42 );
+
+		await loadScript();
+		await vi.advanceTimersByTimeAsync( 50 );
+
+		const overlay = document.querySelector( '.exelearning-filename-overlay' );
+		expect( overlay.querySelector( 'img' ) ).toBeNull();
+		expect( overlay.textContent ).toBe( '<img src=x onerror="window.__pwned = true">.elpx' );
+		expect( window.__pwned ).toBeUndefined();
+	} );
+
+	it( 'escapes the version badge on a file with no preview', async () => {
+		registerAttachment( 43, {
+			exelearning: { version: '<script>window.__pwned = true</script>', has_preview: false },
+		} );
+		document.body.innerHTML = gridMarkup( 43 );
+
+		await loadScript();
+
+		const badge = document.querySelector( '.exelearning-version-badge' );
+		expect( badge.querySelector( 'script' ) ).toBeNull();
+		expect( badge.textContent ).toContain( '<script>window.__pwned = true</script>' );
+		expect( window.__pwned ).toBeUndefined();
+	} );
+
+	it( 'escapes every metadata field shown in the details panel', async () => {
+		const payload = '"><img src=x onerror="window.__pwned = true">';
+		registerAttachment( 44, {
+			exelearning: previewMetadata( {
+				license: payload,
+				language: payload,
+				resource_type: payload,
+			} ),
+			exelearningCanEdit: false,
+		} );
+		global.wp.media.frame = frameSelecting( 44 );
+		document.body.innerHTML = detailsMarkup();
+
+		await loadScript();
+
+		const metadata = document.querySelector( '.exelearning-metadata' );
+		expect( metadata.querySelectorAll( 'img' ) ).toHaveLength( 0 );
+		expect( metadata.textContent ).toContain( payload );
+		expect( window.__pwned ).toBeUndefined();
+	} );
+
+	it( 'renders an absent value as nothing rather than the word undefined', async () => {
+		registerAttachment( 45, {
+			exelearning: previewMetadata(),
+			filename: undefined,
+			title: undefined,
+		} );
+		document.body.innerHTML = gridMarkup( 45 );
+
+		await loadScript();
+		await vi.advanceTimersByTimeAsync( 50 );
+
+		expect(
+			document.querySelector( '.exelearning-filename-overlay' ).textContent
+		).toBe( '' );
+	} );
+} );
+
+/** A wp.media.frame whose current selection is the given attachment. */
+function frameSelecting( id ) {
+	return {
+		state: () => ( {
+			get: ( what ) =>
+				'selection' === what
+					? { first: () => attachmentFor( id ) }
+					: null,
+		} ),
+	};
+}
+
+describe( 'exelearning-media-modal: the grid thumbnail', () => {
+	it( 'replaces the thumbnail with a scaled, sandboxed preview iframe', async () => {
+		registerAttachment( 50, { exelearning: previewMetadata(), filename: 'curso.elpx' } );
+		document.body.innerHTML = gridMarkup( 50 );
+
+		await loadScript();
+		await vi.advanceTimersByTimeAsync( 50 );
+
+		const iframe = document.querySelector( '.exelearning-preview-wrapper iframe' );
+		expect( iframe.getAttribute( 'sandbox' ) ).toBe( 'allow-scripts allow-same-origin' );
+		expect( iframe.getAttribute( 'referrerpolicy' ) ).toBe( 'no-referrer' );
+		expect( iframe.getAttribute( 'src' ) ).toContain( '_cb=' );
+		expect( document.querySelector( '.attachment' ).classList )
+			.toContain( 'exelearning-attachment' );
+	} );
+
+	it( 'appends the cache buster with & when the preview URL already has a query', async () => {
+		registerAttachment( 51, {
+			exelearning: previewMetadata( {
+				preview_url: 'http://example.test/preview.html?v=2',
+			} ),
+		} );
+		document.body.innerHTML = gridMarkup( 51 );
+
+		await loadScript();
+		await vi.advanceTimersByTimeAsync( 50 );
+
+		const src = document.querySelector( '.exelearning-preview-wrapper iframe' ).getAttribute( 'src' );
+		expect( src ).toMatch( /\?v=2&_cb=\d+$/ );
+	} );
+
+	it( 'shows a source-file badge instead of a preview for a v2 file', async () => {
+		registerAttachment( 52, { exelearning: { version: 2, has_preview: false } } );
+		document.body.innerHTML = gridMarkup( 52 );
+
+		await loadScript();
+
+		expect( document.querySelector( '.exelearning-version-badge' ).textContent )
+			.toBe( 'eXe v2 (source)' );
+		expect( document.querySelector( '.thumbnail' ).classList )
+			.toContain( 'exelearning-no-preview' );
+	} );
+
+	it( 'does not decorate the same thumbnail twice', async () => {
+		registerAttachment( 53, { exelearning: previewMetadata(), filename: 'curso.elpx' } );
+		document.body.innerHTML = gridMarkup( 53 );
+
+		await loadScript();
+		await vi.advanceTimersByTimeAsync( 50 );
+		// The observer fires on the script's own DOM writes; without the guard this
+		// is where the preview would be rebuilt on every mutation.
+		observers[ 0 ].trigger();
+		await vi.advanceTimersByTimeAsync( 50 );
+
+		expect( document.querySelectorAll( '.exelearning-preview-wrapper' ) ).toHaveLength( 1 );
+	} );
+
+	it( 'leaves attachments that are not eXeLearning files alone', async () => {
+		registerAttachment( 54, { filename: 'documento.pdf' } );
+		document.body.innerHTML = gridMarkup( 54 );
+
+		await loadScript();
+		await vi.advanceTimersByTimeAsync( 50 );
+
+		expect( document.querySelector( '.exelearning-preview-wrapper' ) ).toBeNull();
+		expect( document.querySelector( '.attachment' ).classList )
+			.not.toContain( 'exelearning-attachment' );
+	} );
+
+	it( 'leaves a tile with no attachment id alone', async () => {
+		document.body.innerHTML =
+			'<li class="attachment"><div class="attachment-preview type-application">' +
+			'<div class="thumbnail"><div class="centered"></div></div></div></li>';
+
+		await loadScript();
+		await vi.advanceTimersByTimeAsync( 50 );
+
+		expect( document.querySelector( '.exelearning-preview-wrapper' ) ).toBeNull();
+	} );
+} );
+
+describe( 'exelearning-media-modal: the details panel', () => {
+	it( 'builds the preview, the edit button and the new-tab link in that order', async () => {
+		registerAttachment( 60, {
+			exelearning: previewMetadata( { license: 'CC BY-SA' } ),
+			exelearningCanEdit: true,
+			exelearningEditUrl: '/wp-admin/admin.php?page=exelearning-editor&attachment_id=60',
+		} );
+		global.wp.media.frame = frameSelecting( 60 );
+		document.body.innerHTML = detailsMarkup();
+
+		await loadScript();
+
+		const details = document.querySelector( '.attachment-details' );
+		const order = Array.from( details.children ).map( ( node ) => node.className );
+		expect( order[ 0 ] ).toContain( 'thumbnail' );
+		expect( order[ 1 ] ).toContain( 'exelearning-edit-button' );
+		expect( order[ 2 ] ).toContain( 'exelearning-preview-link' );
+		expect( order[ 3 ] ).toContain( 'exelearning-metadata' );
+		expect( details.querySelector( '.exelearning-preview-container iframe' ) ).not.toBeNull();
+	} );
+
+	it( 'lists only the metadata fields the file actually declares', async () => {
+		registerAttachment( 61, {
+			exelearning: previewMetadata( { license: 'CC BY', version: 3 } ),
+		} );
+		global.wp.media.frame = frameSelecting( 61 );
+		document.body.innerHTML = detailsMarkup();
+
+		await loadScript();
+
+		const text = document.querySelector( '.exelearning-metadata' ).textContent;
+		expect( text ).toContain( 'Licencia: CC BY' );
+		expect( text ).toContain( 'Versión: 3 (exportado)' );
+		expect( text ).not.toContain( 'Idioma:' );
+		expect( text ).not.toContain( 'Tipo:' );
+	} );
+
+	it( 'marks a v2 file as a source file in the version row', async () => {
+		registerAttachment( 62, {
+			exelearning: { version: 2, has_preview: false, license: 'CC BY' },
+		} );
+		global.wp.media.frame = frameSelecting( 62 );
+		document.body.innerHTML = detailsMarkup();
+
+		await loadScript();
+
+		expect( document.querySelector( '.exelearning-metadata' ).textContent )
+			.toContain( 'Versión: 2 (archivo fuente)' );
+		expect( document.querySelector( '.exelearning-no-preview-notice' ) ).not.toBeNull();
+	} );
+
+	it( 'skips the metadata block for a file that declares nothing', async () => {
+		registerAttachment( 63, { exelearning: { has_preview: true, preview_url: 'http://example.test/p.html' } } );
+		global.wp.media.frame = frameSelecting( 63 );
+		document.body.innerHTML = detailsMarkup();
+
+		await loadScript();
+
+		expect( document.querySelector( '.exelearning-metadata' ) ).toBeNull();
+	} );
+
+	it( 'does not rebuild the panel when the updates run again', async () => {
+		registerAttachment( 64, {
+			exelearning: previewMetadata( { license: 'CC BY' } ),
+			exelearningCanEdit: true,
+			exelearningEditUrl: '/edit/64',
+		} );
+		global.wp.media.frame = frameSelecting( 64 );
+		document.body.innerHTML = detailsMarkup();
+
+		await loadScript();
+		observers[ 0 ].trigger();
+		await settle();
+		await vi.advanceTimersByTimeAsync( 1500 );
+
+		expect( document.querySelectorAll( '.exelearning-preview-container' ) ).toHaveLength( 1 );
+		expect( document.querySelectorAll( '.exelearning-edit-button' ) ).toHaveLength( 1 );
+		expect( document.querySelectorAll( '.exelearning-preview-link' ) ).toHaveLength( 1 );
+	} );
+
+	it( 'loads an attachment it does not have yet and then renders it', async () => {
+		global.wp.media.frame = null;
+		window.history.replaceState( {}, '', '/wp-admin/upload.php?item=65' );
+		const model = attachmentFor( 65 );
+		document.body.innerHTML = detailsMarkup();
+
+		await loadScript();
+
+		expect( model.fetchCount ).toBe( 1 );
+		expect( document.querySelector( '.exelearning-preview-container' ) ).toBeNull();
+
+		model.settleFetch( { id: 65, exelearning: previewMetadata() } );
+		await vi.advanceTimersByTimeAsync( 100 );
+
+		expect( document.querySelector( '.exelearning-preview-container' ) ).not.toBeNull();
+	} );
+
+	it( 'reads the id from the details wrapper when nothing else names it', async () => {
+		// No selection and no ?item=: the data-id on the wrapper is the last source.
+		global.wp.media.frame = null;
+		registerAttachment( 66, { exelearning: previewMetadata() } );
+		document.body.innerHTML =
+			'<div class="attachment-details" data-id="66"><div class="thumbnail"></div></div>';
+
+		await loadScript();
+
+		expect( document.querySelector( '.exelearning-preview-container' ) ).not.toBeNull();
+	} );
+
+	it( 'does nothing when there is no details panel on the screen', async () => {
+		document.body.innerHTML = '<div class="unrelated"></div>';
+
+		await expect( loadScript() ).resolves.toBeUndefined();
+		expect( document.querySelector( '.exelearning-metadata' ) ).toBeNull();
+	} );
+} );
+
+describe( 'exelearning-media-modal: the edit button', () => {
+	it( 'opens the in-page editor when the modal controller is loaded', async () => {
+		const opened = [];
+		window.ExeLearningEditor = { open: ( id, url ) => opened.push( { id, url } ) };
+		registerAttachment( 70, {
+			exelearning: previewMetadata(),
+			exelearningCanEdit: true,
+			exelearningEditUrl: '/edit/70',
+		} );
+		global.wp.media.frame = frameSelecting( 70 );
+		document.body.innerHTML = detailsMarkup();
+
+		await loadScript();
+		document.querySelector( '.exelearning-edit-button' ).click();
+
+		expect( opened ).toEqual( [ { id: 70, url: '/edit/70' } ] );
+		expect( openedWindows ).toEqual( [] );
+	} );
+
+	it( 'falls back to a popup window when the controller is absent', async () => {
+		registerAttachment( 71, {
+			exelearning: previewMetadata(),
+			exelearningCanEdit: true,
+			exelearningEditUrl: '/edit/71',
+		} );
+		global.wp.media.frame = frameSelecting( 71 );
+		document.body.innerHTML = detailsMarkup();
+
+		await loadScript();
+		document.querySelector( '.exelearning-edit-button' ).click();
+
+		expect( openedWindows ).toEqual( [
+			{ url: '/edit/71', target: '_blank', features: 'width=1200,height=800' },
+		] );
+	} );
+
+	it( 'is not offered to a user who cannot edit the file', async () => {
+		registerAttachment( 72, {
+			exelearning: previewMetadata(),
+			exelearningCanEdit: false,
+			exelearningEditUrl: '/edit/72',
+		} );
+		global.wp.media.frame = frameSelecting( 72 );
+		document.body.innerHTML = detailsMarkup();
+
+		await loadScript();
+
+		expect( document.querySelector( '.exelearning-edit-button' ) ).toBeNull();
+	} );
+
+	it( 'appears in the two-column actions row as well', async () => {
+		registerAttachment( 73, {
+			exelearning: previewMetadata(),
+			exelearningCanEdit: true,
+			exelearningEditUrl: '/edit/73',
+		} );
+		global.wp.media.frame = frameSelecting( 73 );
+		document.body.innerHTML = attachmentInfoMarkup();
+
+		await loadScript();
+
+		const button = document.querySelector( '.actions .exelearning-edit-button-actions' );
+		expect( button ).not.toBeNull();
+		expect( button.getAttribute( 'href' ) ).toBe( '/edit/73' );
+	} );
+
+	it( 'opens the in-page editor from the actions row as well', async () => {
+		const opened = [];
+		window.ExeLearningEditor = { open: ( id, url ) => opened.push( { id, url } ) };
+		registerAttachment( 75, { exelearningCanEdit: true, exelearningEditUrl: '/edit/75' } );
+		global.wp.media.frame = frameSelecting( 75 );
+		document.body.innerHTML = attachmentInfoMarkup();
+
+		await loadScript();
+		const event = new window.MouseEvent( 'click', { bubbles: true, cancelable: true } );
+		document.querySelector( '.exelearning-edit-button-actions' ).dispatchEvent( event );
+
+		// The href is a real link, so the handler has to stop the navigation that
+		// would otherwise throw away the modal it just opened.
+		expect( event.defaultPrevented ).toBe( true );
+		expect( opened ).toEqual( [ { id: 75, url: '/edit/75' } ] );
+	} );
+
+	it( 'falls back to a popup from the actions row when the controller is absent', async () => {
+		registerAttachment( 76, { exelearningCanEdit: true, exelearningEditUrl: '/edit/76' } );
+		global.wp.media.frame = frameSelecting( 76 );
+		document.body.innerHTML = attachmentInfoMarkup();
+
+		await loadScript();
+		document.querySelector( '.exelearning-edit-button-actions' ).dispatchEvent(
+			new window.MouseEvent( 'click', { bubbles: true, cancelable: true } )
+		);
+
+		expect( openedWindows ).toEqual( [
+			{ url: '/edit/76', target: '_blank', features: 'width=1200,height=800' },
+		] );
+	} );
+
+	it( 'is left out when the two-column panel has no actions row to put it in', async () => {
+		registerAttachment( 77, { exelearningCanEdit: true, exelearningEditUrl: '/edit/77' } );
+		global.wp.media.frame = frameSelecting( 77 );
+		document.body.innerHTML =
+			'<div class="attachment-details"><div class="attachment-info"></div></div>';
+
+		await loadScript();
+
+		expect( document.querySelector( '.exelearning-edit-button-actions' ) ).toBeNull();
+	} );
+
+	it( 'is not duplicated in the actions row when the updates run again', async () => {
+		registerAttachment( 74, {
+			exelearning: previewMetadata(),
+			exelearningCanEdit: true,
+			exelearningEditUrl: '/edit/74',
+		} );
+		global.wp.media.frame = frameSelecting( 74 );
+		document.body.innerHTML = attachmentInfoMarkup();
+
+		await loadScript();
+		observers[ 0 ].trigger();
+		await settle();
+
+		expect( document.querySelectorAll( '.exelearning-edit-button-actions' ) ).toHaveLength( 1 );
+	} );
+} );
+
+describe( 'exelearning-media-modal: finding the attachment in the two-column view', () => {
+	it( 'reads the id from the details wrapper first', async () => {
+		registerAttachment( 79, { exelearningCanEdit: true, exelearningEditUrl: '/edit/79' } );
+		document.body.innerHTML =
+			'<div class="attachment-details" data-id="79">' +
+				'<div class="attachment-info"><div class="actions"></div></div>' +
+			'</div>';
+
+		await loadScript();
+
+		expect( document.querySelector( '.exelearning-edit-button-actions' ).getAttribute( 'href' ) )
+			.toBe( '/edit/79' );
+	} );
+
+	it( 'reads the id from the item query parameter', async () => {
+		window.history.replaceState( {}, '', '/wp-admin/upload.php?item=80' );
+		registerAttachment( 80, { exelearningCanEdit: true, exelearningEditUrl: '/edit/80' } );
+		document.body.innerHTML = attachmentInfoMarkup();
+
+		await loadScript();
+
+		expect( document.querySelector( '.exelearning-edit-button-actions' ) ).not.toBeNull();
+	} );
+
+	it( 'reads the id from the post query parameter on the edit screen', async () => {
+		window.history.replaceState( {}, '', '/wp-admin/post.php?post=81&action=edit' );
+		registerAttachment( 81, { exelearningCanEdit: true, exelearningEditUrl: '/edit/81' } );
+		document.body.innerHTML = attachmentInfoMarkup();
+
+		await loadScript();
+
+		expect( document.querySelector( '.exelearning-edit-button-actions' ) ).not.toBeNull();
+	} );
+
+	it( 'falls back to the edit-more-details link', async () => {
+		registerAttachment( 82, { exelearningCanEdit: true, exelearningEditUrl: '/edit/82' } );
+		document.body.innerHTML = attachmentInfoMarkup(
+			'<a href="/wp-admin/post.php?post=82&action=edit">Edit more details</a>'
+		);
+
+		await loadScript();
+
+		expect( document.querySelector( '.exelearning-edit-button-actions' ) ).not.toBeNull();
+	} );
+
+	it( 'falls back to the view-attachment link', async () => {
+		registerAttachment( 83, { exelearningCanEdit: true, exelearningEditUrl: '/edit/83' } );
+		document.body.innerHTML = attachmentInfoMarkup(
+			'<a href="http://example.test/?attachment_id=83">View</a>'
+		);
+
+		await loadScript();
+
+		expect( document.querySelector( '.exelearning-edit-button-actions' ) ).not.toBeNull();
+	} );
+
+	it( 'falls back to the media frame selection', async () => {
+		registerAttachment( 84, { exelearningCanEdit: true, exelearningEditUrl: '/edit/84' } );
+		global.wp.media.frame = frameSelecting( 84 );
+		document.body.innerHTML = attachmentInfoMarkup();
+
+		await loadScript();
+
+		expect( document.querySelector( '.exelearning-edit-button-actions' ) ).not.toBeNull();
+	} );
+
+	it( 'gives up quietly when no source names an attachment', async () => {
+		document.body.innerHTML = attachmentInfoMarkup();
+
+		await loadScript();
+
+		expect( document.querySelector( '.exelearning-edit-button-actions' ) ).toBeNull();
+	} );
+
+	it( 'waits for an unloaded attachment before deciding', async () => {
+		window.history.replaceState( {}, '', '/wp-admin/upload.php?item=85' );
+		const model = attachmentFor( 85 );
+		document.body.innerHTML = attachmentInfoMarkup();
+
+		await loadScript();
+		expect( document.querySelector( '.exelearning-edit-button-actions' ) ).toBeNull();
+
+		model.settleFetch( {
+			id: 85,
+			exelearningCanEdit: true,
+			exelearningEditUrl: '/edit/85',
+		} );
+		await settle();
+
+		expect( document.querySelector( '.exelearning-edit-button-actions' ) ).not.toBeNull();
+	} );
+} );
+
+describe( 'exelearning-media-modal: processing a file that is not an .elpx yet', () => {
+	/** Details panel showing an unprocessed but reprocessable attachment. */
+	async function loadReprocessable( id ) {
+		const model = registerAttachment( id, { exelearningReprocessable: true } );
+		global.wp.media.frame = frameSelecting( id );
+		document.body.innerHTML = detailsMarkup();
+		await loadScript();
+		return model;
+	}
+
+	it( 'offers the button with a hint about what the file is', async () => {
+		await loadReprocessable( 90 );
+
+		expect( document.querySelector( '.exelearning-process-button' ).textContent )
+			.toContain( 'Procesar como eXeLearning' );
+		expect( document.querySelector( '.exelearning-process-hint' ).textContent )
+			.toBe( 'Archivo eXeLearning (sin procesar)' );
+	} );
+
+	it( 'does not offer it for a file that is already processed', async () => {
+		registerAttachment( 91, {
+			exelearning: previewMetadata(),
+			exelearningReprocessable: true,
+		} );
+		global.wp.media.frame = frameSelecting( 91 );
+		document.body.innerHTML = attachmentInfoMarkup();
+
+		await loadScript();
+
+		expect( document.querySelector( '.exelearning-process-button-actions' ) ).toBeNull();
+	} );
+
+	it( 'does not offer it for a file that cannot be reprocessed', async () => {
+		registerAttachment( 92, { exelearningReprocessable: false } );
+		global.wp.media.frame = frameSelecting( 92 );
+		document.body.innerHTML = detailsMarkup();
+
+		await loadScript();
+
+		expect( document.querySelector( '.exelearning-process-button' ) ).toBeNull();
+	} );
+
+	it( 'posts to the reprocess endpoint with the REST nonce', async () => {
+		await loadReprocessable( 93 );
+		stubFetch( { ok: true, body: { success: true } } );
+
+		document.querySelector( '.exelearning-process-button' ).click();
+		await settle();
+
+		expect( requests ).toHaveLength( 1 );
+		expect( requests[ 0 ].url ).toBe( '/wp-json/exelearning/v1/reprocess/93' );
+		expect( requests[ 0 ].options.method ).toBe( 'POST' );
+		expect( requests[ 0 ].options.headers[ 'X-WP-Nonce' ] ).toBe( 'rest-nonce-123' );
+		expect( requests[ 0 ].options.credentials ).toBe( 'same-origin' );
+	} );
+
+	it( 'disables the button while the request is in flight', async () => {
+		await loadReprocessable( 94 );
+		let release;
+		window.fetch = () => new Promise( ( resolve ) => {
+			release = () => resolve( { ok: true, json: () => Promise.resolve( { success: true } ) } );
+		} );
+
+		const button = document.querySelector( '.exelearning-process-button' );
+		button.click();
+		await settle();
+
+		expect( button.disabled ).toBe( true );
+		expect( button.textContent ).toBe( 'Procesando…' );
+
+		release();
+		await settle();
+	} );
+
+	it( 'reloads the attachment and re-renders once the file is processed', async () => {
+		const model = await loadReprocessable( 95 );
+		stubFetch( { ok: true, body: { success: true } } );
+
+		document.querySelector( '.exelearning-process-button' ).click();
+		await settle();
+
+		expect( model.get( 'exelearningReprocessable' ) ).toBe( false );
+		expect( model.fetchCount ).toBe( 1 );
+
+		model.settleFetch( { exelearning: previewMetadata() } );
+		await settle();
+
+		expect( document.querySelector( '.exelearning-process-button' ) ).toBeNull();
+		expect( document.querySelector( '.exelearning-preview-container' ) ).not.toBeNull();
+	} );
+
+	it( 'reports the server\'s own message and gives the button back', async () => {
+		await loadReprocessable( 96 );
+		stubFetch( {
+			ok: false,
+			body: { code: 'not_an_elp', message: 'El archivo no es un paquete válido.' },
+		} );
+
+		const button = document.querySelector( '.exelearning-process-button' );
+		button.click();
+		await settle();
+
+		expect( document.querySelector( '.exelearning-process-error' ).textContent )
+			.toBe( 'El archivo no es un paquete válido.' );
+		expect( button.disabled ).toBe( false );
+		expect( button.textContent ).toContain( 'Procesar como eXeLearning' );
+	} );
+
+	it( 'treats a 200 carrying an error code as a failure', async () => {
+		// The REST route answers 200 with a WP_Error-shaped body in some paths, so
+		// resp.ok on its own is not enough to call it a success.
+		await loadReprocessable( 97 );
+		stubFetch( { ok: true, body: { code: 'no_index', message: 'Sin index.html.' } } );
+
+		document.querySelector( '.exelearning-process-button' ).click();
+		await settle();
+
+		expect( document.querySelector( '.exelearning-process-error' ).textContent )
+			.toBe( 'Sin index.html.' );
+	} );
+
+	it( 'falls back to a generic message when the server sends none', async () => {
+		await loadReprocessable( 98 );
+		stubFetch( { ok: false, body: {} } );
+
+		document.querySelector( '.exelearning-process-button' ).click();
+		await settle();
+
+		expect( document.querySelector( '.exelearning-process-error' ).textContent )
+			.toBe( 'No se pudo procesar este archivo.' );
+	} );
+
+	it( 'reports a request that never reached the server', async () => {
+		await loadReprocessable( 99 );
+		stubFetch( { networkError: true } );
+
+		const button = document.querySelector( '.exelearning-process-button' );
+		button.click();
+		await settle();
+
+		expect( document.querySelector( '.exelearning-process-error' ).textContent )
+			.toBe( 'No se pudo procesar este archivo.' );
+		expect( button.disabled ).toBe( false );
+	} );
+
+	it( 'replaces the previous error rather than stacking them up', async () => {
+		await loadReprocessable( 100 );
+		stubFetch( { ok: false, body: { message: 'Primer fallo.' } } );
+
+		const button = document.querySelector( '.exelearning-process-button' );
+		button.click();
+		await settle();
+		stubFetch( { ok: false, body: { message: 'Segundo fallo.' } } );
+		button.click();
+		await settle();
+
+		const errors = document.querySelectorAll( '.exelearning-process-error' );
+		expect( errors ).toHaveLength( 1 );
+		expect( errors[ 0 ].textContent ).toBe( 'Segundo fallo.' );
+	} );
+
+	it( 'does nothing at all when the REST settings were not localized', async () => {
+		window.exelearningMediaSettings = {};
+		const model = registerAttachment( 101, { exelearningReprocessable: true } );
+		global.wp.media.frame = frameSelecting( 101 );
+		document.body.innerHTML = detailsMarkup();
+		await loadScript();
+
+		window.fetch = () => {
+			throw new Error( 'should not be called' );
+		};
+		document.querySelector( '.exelearning-process-button' ).click();
+		await settle();
+
+		expect( model.fetchCount ).toBe( 0 );
+		expect( document.querySelector( '.exelearning-process-error' ) ).toBeNull();
+	} );
+
+	it( 'offers the button in the two-column actions row too', async () => {
+		registerAttachment( 102, { exelearningReprocessable: true } );
+		global.wp.media.frame = frameSelecting( 102 );
+		document.body.innerHTML = attachmentInfoMarkup();
+
+		await loadScript();
+
+		expect( document.querySelector( '.actions .exelearning-process-button-actions' ) )
+			.not.toBeNull();
+	} );
+
+	it( 'processes the file from the actions-row button too', async () => {
+		registerAttachment( 106, { exelearningReprocessable: true } );
+		global.wp.media.frame = frameSelecting( 106 );
+		document.body.innerHTML = attachmentInfoMarkup();
+		await loadScript();
+		stubFetch( { ok: true, body: { success: true } } );
+
+		const event = new window.MouseEvent( 'click', { bubbles: true, cancelable: true } );
+		document.querySelector( '.exelearning-process-button-actions' ).dispatchEvent( event );
+		await settle();
+
+		expect( event.defaultPrevented ).toBe( true );
+		expect( requests[ 0 ].url ).toBe( '/wp-json/exelearning/v1/reprocess/106' );
+	} );
+
+	it( 'does not duplicate the actions-row button when the updates run again', async () => {
+		registerAttachment( 103, { exelearningReprocessable: true } );
+		global.wp.media.frame = frameSelecting( 103 );
+		document.body.innerHTML = attachmentInfoMarkup();
+
+		await loadScript();
+		observers[ 0 ].trigger();
+		await settle();
+
+		expect( document.querySelectorAll( '.exelearning-process-button-actions' ) )
+			.toHaveLength( 1 );
+	} );
+
+	it( 'does not duplicate the details button when the updates run again', async () => {
+		await loadReprocessable( 104 );
+
+		observers[ 0 ].trigger();
+		await settle();
+
+		expect( document.querySelectorAll( '.exelearning-process-button' ) ).toHaveLength( 1 );
+	} );
+
+	it( 'skips the actions row entirely when the panel has none', async () => {
+		registerAttachment( 105, { exelearningReprocessable: true } );
+		global.wp.media.frame = frameSelecting( 105 );
+		document.body.innerHTML =
+			'<div class="attachment-details"><div class="attachment-info"></div></div>';
+
+		await loadScript();
+
+		expect( document.querySelector( '.exelearning-process-button-actions' ) ).toBeNull();
+	} );
+} );
+
+describe( 'exelearning-media-modal: when the updates run', () => {
+	it( 'watches the document for attachments arriving later', async () => {
+		document.body.innerHTML = detailsMarkup();
+
+		await loadScript();
+
+		expect( observers ).toHaveLength( 1 );
+		expect( observers[ 0 ].target ).toBe( document.body );
+		expect( observers[ 0 ].options ).toEqual( { childList: true, subtree: true } );
+	} );
+
+	it( 'refreshes shortly after the media modal opens', async () => {
+		document.body.innerHTML = gridMarkup( 110 );
+
+		await loadScript();
+		expect( modalOpenHandlers ).toEqual( [
+			{ event: 'open', handler: expect.any( Function ) },
+		] );
+
+		// The tile only becomes an eXeLearning file once the modal has loaded it.
+		registerAttachment( 110, { exelearning: previewMetadata(), filename: 'curso.elpx' } );
+		modalOpenHandlers[ 0 ].handler();
+		await vi.advanceTimersByTimeAsync( 150 );
+		await vi.advanceTimersByTimeAsync( 50 );
+
+		expect( document.querySelector( '.exelearning-preview-wrapper' ) ).not.toBeNull();
+	} );
+
+	it( 'keeps retrying on a timer for content that loads asynchronously', async () => {
+		document.body.innerHTML = gridMarkup( 111 );
+
+		await loadScript();
+		expect( document.querySelector( '.exelearning-preview-wrapper' ) ).toBeNull();
+
+		registerAttachment( 111, { exelearning: previewMetadata(), filename: 'curso.elpx' } );
+		await vi.advanceTimersByTimeAsync( 1500 );
+		await vi.advanceTimersByTimeAsync( 50 );
+
+		expect( document.querySelector( '.exelearning-preview-wrapper' ) ).not.toBeNull();
+	} );
+} );

--- a/tests/js/wp_exe_bridge.test.js
+++ b/tests/js/wp_exe_bridge.test.js
@@ -1,0 +1,889 @@
+// Unit tests for assets/js/wp-exe-bridge.js.
+//
+// The bridge is the editor's half of the postMessage protocol: it runs inside the
+// embedded eXeLearning page (the export bootstrap and the editor bootstrap both load
+// it) and answers the parent modal's WP_REQUEST_SAVE / WP_REQUEST_EXPORT /
+// GET_PROJECT_INFO / CONFIGURE calls. Everything it does is observable as a message
+// posted to window.parent, so the whole file can be driven through a stubbed parent.
+//
+// What is real here and what is not: the editor itself is stubbed -- there is no
+// eXeLearning app under Vitest -- but the bridge's own logic is real, and it is the
+// part that breaks. A requestId that is not echoed back, an error that is swallowed
+// instead of reported, DOCUMENT_LOADED announced twice, or a message the bridge
+// answers when it should have ignored it all leave the parent modal hanging forever.
+//
+// The script is an IIFE that reads its config and runs init() at import time, so each
+// test imports a fresh copy under a cache-busting URL. Its listeners are recorded
+// during that import and unbound afterwards, otherwise every instance would keep
+// answering messages meant for the next test.
+
+const path = require( 'path' );
+const { pathToFileURL } = require( 'url' );
+
+const BRIDGE = pathToFileURL(
+	path.resolve( __dirname, '../../assets/js/wp-exe-bridge.js' )
+).href;
+
+let loadCount = 0;
+/** Everything the bridge posted to the parent frame, in order. */
+let posted = [];
+/** Listeners the bridge bound during import, so they can be unbound after the test. */
+let bound = [];
+let consoleWarnings = [];
+let consoleErrors = [];
+
+let originalParentDescriptor;
+let originalConsoleWarn;
+let originalConsoleError;
+let originalWindowAdd;
+let originalDocumentAdd;
+
+beforeAll( () => {
+	originalParentDescriptor = Object.getOwnPropertyDescriptor( window, 'parent' );
+	originalConsoleWarn = console.warn;
+	originalConsoleError = console.error;
+	console.warn = ( ...args ) => consoleWarnings.push( args.join( ' ' ) );
+	console.error = ( ...args ) => consoleErrors.push( args.join( ' ' ) );
+} );
+
+afterAll( () => {
+	if ( originalParentDescriptor ) {
+		Object.defineProperty( window, 'parent', originalParentDescriptor );
+	} else {
+		delete window.parent;
+	}
+	console.warn = originalConsoleWarn;
+	console.error = originalConsoleError;
+} );
+
+beforeEach( () => {
+	posted = [];
+	bound = [];
+	consoleWarnings = [];
+	consoleErrors = [];
+	// Fake timers keep the polling loops (getApp, waitForSharedExporters,
+	// notifyWhenDocumentLoaded) suspended unless a test advances the clock. A loop
+	// left pending by one test is discarded with the fake clock rather than waking
+	// up inside the next one.
+	vi.useFakeTimers();
+	embedIn( { postMessage: ( message ) => posted.push( message ) } );
+
+	// Recorded for the whole test, not just for the import: init() is async, so a
+	// bridge that waits on window.eXeLearning.ready binds its listeners well after
+	// the import resolved. Missing those leaves an instance answering messages in
+	// every later test.
+	originalWindowAdd = window.addEventListener;
+	originalDocumentAdd = document.addEventListener;
+	window.addEventListener = function ( type, fn, options ) {
+		bound.push( { target: window, type, fn } );
+		return originalWindowAdd.call( this, type, fn, options );
+	};
+	document.addEventListener = function ( type, fn, options ) {
+		bound.push( { target: document, type, fn } );
+		return originalDocumentAdd.call( this, type, fn, options );
+	};
+} );
+
+afterEach( () => {
+	window.addEventListener = originalWindowAdd;
+	document.addEventListener = originalDocumentAdd;
+	bound.forEach( ( entry ) => entry.target.removeEventListener( entry.type, entry.fn ) );
+	vi.useRealTimers();
+	document.body.innerHTML = '';
+	document.body.removeAttribute( 'data-exe-hide-file-menu' );
+	document.body.removeAttribute( 'data-exe-hide-save' );
+	document.body.removeAttribute( 'data-exe-hide-user-menu' );
+	delete window.eXeLearning;
+	delete window.SharedExporters;
+	delete window.__WP_EXE_CONFIG__;
+	delete window.__EXE_EMBEDDING_CONFIG__;
+	delete window.wpExeBridge;
+	window.onbeforeunload = null;
+} );
+
+/**
+ * Put the page inside a frame with the given parent window.
+ *
+ * The bridge stays silent unless window.parent is another window, so a stubbed
+ * parent is what makes any of its output observable.
+ *
+ * @param {Object|null} parentWindow Stub parent, or null to be the top-level page.
+ */
+function embedIn( parentWindow ) {
+	Object.defineProperty( window, 'parent', {
+		configurable: true,
+		value: null === parentWindow ? window : parentWindow,
+	} );
+}
+
+/**
+ * Import a fresh bridge, recording the listeners it binds.
+ *
+ * @return {Promise<void>} Resolves once init() has run to completion.
+ */
+async function loadBridge() {
+	await import( /* @vite-ignore */ `${ BRIDGE }?load=${ ++loadCount }` );
+	await settle();
+}
+
+/** Let the bridge's promise chains settle without waiting on real time. */
+async function settle() {
+	for ( let i = 0; i < 8; i++ ) {
+		await Promise.resolve();
+		await vi.advanceTimersByTimeAsync( 0 );
+	}
+}
+
+/** Deliver a protocol message from the parent and let the bridge answer it. */
+async function send( data ) {
+	window.dispatchEvent( new window.MessageEvent( 'message', { data } ) );
+	await settle();
+}
+
+/** The first message of a given type the bridge posted, if any. */
+function messageOf( type ) {
+	return posted.find( ( message ) => message.type === type );
+}
+
+/**
+ * Build a stub editor whose project exports through the Yjs + SharedExporters path.
+ *
+ * @param {Object} [overrides] Parts of the Yjs bridge to replace.
+ * @return {Object} The documentManager the stub exposes.
+ */
+function installEditorWithDocument( overrides ) {
+	const documentManager = {
+		getMetadata: () => new Map( [ [ 'title', 'Mi proyecto' ], [ 'author', 'Ada' ] ] ),
+		getNavigation: () => [ {}, {}, {} ],
+		markClean: vi.fn(),
+		...( overrides?.documentManager || {} ),
+	};
+
+	window.eXeLearning = {
+		version: '3.1.0',
+		projectId: 'proj-1',
+		app: {
+			project: {
+				_yjsBridge: {
+					projectId: 'proj-1',
+					documentManager,
+					...( overrides?.yjsBridge || {} ),
+				},
+			},
+		},
+	};
+
+	return documentManager;
+}
+
+describe( 'wp-exe-bridge: announcing itself to the parent', () => {
+	it( 'reports readiness with its version and the protocol it speaks', async () => {
+		installEditorWithDocument();
+
+		await loadBridge();
+
+		expect( messageOf( 'EXELEARNING_READY' ) ).toEqual( {
+			type: 'EXELEARNING_READY',
+			version: '3.1.0',
+			capabilities: [ 'WP_REQUEST_SAVE', 'WP_REQUEST_EXPORT', 'GET_PROJECT_INFO', 'CONFIGURE' ],
+		} );
+	} );
+
+	it( 'passes the attachment id back so the modal knows which file answered', async () => {
+		window.__WP_EXE_CONFIG__ = { attachmentId: 77 };
+		installEditorWithDocument();
+
+		await loadBridge();
+
+		expect( posted ).toContainEqual( {
+			source: 'wp-exe-editor',
+			type: 'editor-ready',
+			data: { attachmentId: 77 },
+		} );
+	} );
+
+	it( 'waits for the editor to be ready before announcing anything', async () => {
+		let releaseEditor;
+		installEditorWithDocument();
+		window.eXeLearning.ready = new Promise( ( resolve ) => {
+			releaseEditor = resolve;
+		} );
+
+		await loadBridge();
+		expect( posted ).toEqual( [] );
+
+		releaseEditor();
+		await settle();
+
+		expect( messageOf( 'EXELEARNING_READY' ) ).toBeDefined();
+	} );
+
+	it( 'reports an unknown version rather than failing without an editor', async () => {
+		await loadBridge();
+
+		expect( messageOf( 'EXELEARNING_READY' ).version ).toBe( 'unknown' );
+	} );
+
+	it( 'stays silent when it is not embedded at all', async () => {
+		// window.parent === window on a top-level page. Posting there would make the
+		// editor answer its own protocol messages.
+		embedIn( null );
+		installEditorWithDocument();
+
+		await loadBridge();
+
+		expect( posted ).toEqual( [] );
+	} );
+
+	it( 'exposes requestSave and the config it was given', async () => {
+		window.__WP_EXE_CONFIG__ = { attachmentId: 5 };
+		installEditorWithDocument();
+
+		await loadBridge();
+		posted = [];
+		window.wpExeBridge.requestSave();
+
+		expect( window.wpExeBridge.config ).toEqual( { attachmentId: 5 } );
+		expect( posted ).toEqual( [
+			{ source: 'wp-exe-editor', type: 'request-save', data: {} },
+		] );
+	} );
+} );
+
+describe( 'wp-exe-bridge: the target origin', () => {
+	it( 'posts to the embedding parent origin when one was configured', async () => {
+		const origins = [];
+		embedIn( { postMessage: ( message, origin ) => origins.push( origin ) } );
+		window.__EXE_EMBEDDING_CONFIG__ = { parentOrigin: 'https://wp.example' };
+		installEditorWithDocument();
+
+		await loadBridge();
+
+		expect( origins.length ).toBeGreaterThan( 0 );
+		expect( new Set( origins ) ).toEqual( new Set( [ 'https://wp.example' ] ) );
+	} );
+
+	it( 'falls back to any origin when the embedder did not declare one', async () => {
+		const origins = [];
+		embedIn( { postMessage: ( message, origin ) => origins.push( origin ) } );
+		installEditorWithDocument();
+
+		await loadBridge();
+
+		expect( new Set( origins ) ).toEqual( new Set( [ '*' ] ) );
+	} );
+} );
+
+describe( 'wp-exe-bridge: announcing the loaded document', () => {
+	it( 'reports DOCUMENT_LOADED once the project is there', async () => {
+		installEditorWithDocument();
+
+		await loadBridge();
+
+		expect( messageOf( 'DOCUMENT_LOADED' ) ).toEqual( { type: 'DOCUMENT_LOADED' } );
+	} );
+
+	it( 'waits for a project that arrives late instead of giving up', async () => {
+		window.eXeLearning = { app: { project: {} } };
+
+		await loadBridge();
+		expect( messageOf( 'DOCUMENT_LOADED' ) ).toBeUndefined();
+
+		installEditorWithDocument();
+		await vi.advanceTimersByTimeAsync( 200 );
+
+		expect( messageOf( 'DOCUMENT_LOADED' ) ).toBeDefined();
+	} );
+
+	it( 'gives up after thirty seconds without announcing a document', async () => {
+		window.eXeLearning = { app: { project: {} } };
+
+		await loadBridge();
+		await vi.advanceTimersByTimeAsync( 31000 );
+
+		expect( messageOf( 'DOCUMENT_LOADED' ) ).toBeUndefined();
+	} );
+
+	it( 'reports the first edit and then stops repeating itself', async () => {
+		// The modal only needs to know the document became dirty; one notification
+		// per edit would be a message storm on every keystroke.
+		const listeners = [];
+		installEditorWithDocument( {
+			documentManager: {
+				ydoc: { on: ( event, fn ) => listeners.push( { event, fn } ) },
+			},
+		} );
+
+		await loadBridge();
+		expect( listeners ).toHaveLength( 1 );
+		expect( listeners[ 0 ].event ).toBe( 'update' );
+
+		listeners[ 0 ].fn();
+		listeners[ 0 ].fn();
+		listeners[ 0 ].fn();
+
+		expect( posted.filter( ( m ) => m.type === 'DOCUMENT_CHANGED' ) ).toHaveLength( 1 );
+	} );
+
+	it( 'survives a document manager whose ydoc cannot be watched', async () => {
+		const documentManager = installEditorWithDocument();
+		// Defined after the fact: a throwing getter in an object literal would blow
+		// up in the spread inside the helper instead of inside the bridge.
+		Object.defineProperty( documentManager, 'ydoc', {
+			get() {
+				throw new Error( 'detached' );
+			},
+		} );
+
+		await loadBridge();
+
+		expect( messageOf( 'DOCUMENT_LOADED' ) ).toBeDefined();
+		expect( consoleWarnings.join( ' ' ) ).toContain( 'Change monitor failed' );
+	} );
+} );
+
+describe( 'wp-exe-bridge: messages it must not answer', () => {
+	it( 'ignores its own messages so it cannot talk to itself', async () => {
+		installEditorWithDocument();
+		await loadBridge();
+		posted = [];
+
+		await send( { source: 'wp-exe-editor', type: 'WP_REQUEST_SAVE', requestId: 'r1' } );
+
+		expect( posted ).toEqual( [] );
+	} );
+
+	it( 'ignores anything without a type', async () => {
+		installEditorWithDocument();
+		await loadBridge();
+		posted = [];
+
+		await send( { requestId: 'r1', data: {} } );
+
+		expect( posted ).toEqual( [] );
+	} );
+
+	it( 'ignores a type it does not implement, without erroring back', async () => {
+		installEditorWithDocument();
+		await loadBridge();
+		posted = [];
+
+		await send( { type: 'SOMETHING_ELSE', requestId: 'r1' } );
+
+		expect( posted ).toEqual( [] );
+	} );
+} );
+
+describe( 'wp-exe-bridge: WP_REQUEST_SAVE', () => {
+	it( 'exports through the Yjs exporter and answers with the bytes', async () => {
+		const documentManager = installEditorWithDocument();
+		// The save path waits on quickExport before reaching for createExporter, so
+		// the stub carries both entry points exactly as the real bundle does.
+		window.SharedExporters = {
+			quickExport: vi.fn(),
+			createExporter: vi.fn( () => ( {
+				export: async () => ( {
+					success: true,
+					data: new Uint8Array( [ 1, 2, 3, 4 ] ),
+					filename: 'mi-proyecto.elpx',
+				} ),
+			} ) ),
+		};
+
+		await loadBridge();
+		posted = [];
+		await send( { type: 'WP_REQUEST_SAVE', requestId: 'save-1' } );
+
+		const answer = messageOf( 'WP_SAVE_FILE' );
+		expect( answer.requestId ).toBe( 'save-1' );
+		expect( answer.filename ).toBe( 'mi-proyecto.elpx' );
+		expect( answer.mimeType ).toBe( 'application/zip' );
+		expect( answer.size ).toBe( 4 );
+		expect( new Uint8Array( answer.bytes ) ).toEqual( new Uint8Array( [ 1, 2, 3, 4 ] ) );
+		expect( window.SharedExporters.createExporter ).toHaveBeenCalledWith(
+			'elpx',
+			documentManager,
+			null,
+			null,
+			null
+		);
+	} );
+
+	it( 'reports the exporter\'s own error message back to the modal', async () => {
+		installEditorWithDocument();
+		window.SharedExporters = {
+			quickExport: vi.fn(),
+			createExporter: () => ( {
+				export: async () => ( { success: false, error: 'Asset missing' } ),
+			} ),
+		};
+
+		await loadBridge();
+		posted = [];
+		await send( { type: 'WP_REQUEST_SAVE', requestId: 'save-2' } );
+
+		expect( messageOf( 'WP_REQUEST_SAVE_ERROR' ) ).toEqual( {
+			type: 'WP_REQUEST_SAVE_ERROR',
+			requestId: 'save-2',
+			error: 'Asset missing',
+		} );
+	} );
+
+	it( 'falls back to the project blob exporter when there is no Yjs bridge', async () => {
+		window.eXeLearning = {
+			app: {
+				project: {
+					exportToElpxBlob: async () =>
+						new Blob( [ new Uint8Array( [ 9, 9 ] ) ], { type: 'application/zip' } ),
+					getExportFilename: () => 'fallback.elpx',
+				},
+			},
+		};
+
+		await loadBridge();
+		posted = [];
+		await send( { type: 'WP_REQUEST_SAVE', requestId: 'save-3' } );
+
+		const answer = messageOf( 'WP_SAVE_FILE' );
+		expect( answer.filename ).toBe( 'fallback.elpx' );
+		expect( answer.size ).toBe( 2 );
+	} );
+
+	it( 'names the file project.elpx when the project will not name it', async () => {
+		window.eXeLearning = {
+			app: {
+				project: {
+					exportToElpxBlob: async () => new Blob( [ new Uint8Array( [ 1 ] ) ] ),
+				},
+			},
+		};
+
+		await loadBridge();
+		posted = [];
+		await send( { type: 'WP_REQUEST_SAVE', requestId: 'save-4' } );
+
+		const answer = messageOf( 'WP_SAVE_FILE' );
+		expect( answer.filename ).toBe( 'project.elpx' );
+		expect( answer.mimeType ).toBe( 'application/zip' );
+	} );
+
+	it( 'says so when the project cannot export at all', async () => {
+		window.eXeLearning = { app: { project: {} } };
+
+		await loadBridge();
+		posted = [];
+		await send( { type: 'WP_REQUEST_SAVE', requestId: 'save-5' } );
+
+		expect( messageOf( 'WP_REQUEST_SAVE_ERROR' ).error ).toBe( 'Export not available' );
+	} );
+} );
+
+describe( 'wp-exe-bridge: WP_REQUEST_EXPORT', () => {
+	/** Install a quickExport stub that succeeds with the given payload. */
+	function installQuickExport( result ) {
+		window.SharedExporters = { quickExport: vi.fn( async () => result ) };
+	}
+
+	it( 'exports the requested format and answers with the bytes', async () => {
+		const documentManager = installEditorWithDocument();
+		installQuickExport( {
+			success: true,
+			data: new Uint8Array( [ 7, 7, 7 ] ),
+			filename: 'curso_scorm.zip',
+		} );
+
+		await loadBridge();
+		posted = [];
+		await send( { type: 'WP_REQUEST_EXPORT', requestId: 'exp-1', data: { format: 'scorm12' } } );
+
+		const answer = messageOf( 'WP_EXPORT_FILE' );
+		expect( answer.requestId ).toBe( 'exp-1' );
+		expect( answer.format ).toBe( 'scorm12' );
+		expect( answer.filename ).toBe( 'curso_scorm.zip' );
+		expect( answer.mimeType ).toBe( 'application/zip' );
+		expect( answer.size ).toBe( 3 );
+		expect( window.SharedExporters.quickExport ).toHaveBeenCalledWith(
+			'scorm12',
+			documentManager,
+			null,
+			null,
+			{},
+			null
+		);
+	} );
+
+	it( 'accepts the format at the top level as well as under data', async () => {
+		installEditorWithDocument();
+		installQuickExport( { success: true, data: new Uint8Array( [ 1 ] ) } );
+
+		await loadBridge();
+		posted = [];
+		await send( { type: 'WP_REQUEST_EXPORT', requestId: 'exp-2', format: 'ims' } );
+
+		expect( messageOf( 'WP_EXPORT_FILE' ).format ).toBe( 'ims' );
+	} );
+
+	it( 'labels an EPUB with the EPUB media type, not a generic zip', async () => {
+		installEditorWithDocument();
+		installQuickExport( { success: true, data: new Uint8Array( [ 1 ] ) } );
+
+		await loadBridge();
+		posted = [];
+		await send( { type: 'WP_REQUEST_EXPORT', requestId: 'exp-3', data: { format: 'epub3' } } );
+
+		const answer = messageOf( 'WP_EXPORT_FILE' );
+		expect( answer.mimeType ).toBe( 'application/epub+zip' );
+		expect( answer.filename ).toBe( 'project.epub3' );
+	} );
+
+	it( 'refuses a request that names no format', async () => {
+		installEditorWithDocument();
+		installQuickExport( { success: true, data: new Uint8Array( [ 1 ] ) } );
+
+		await loadBridge();
+		posted = [];
+		await send( { type: 'WP_REQUEST_EXPORT', requestId: 'exp-4', data: {} } );
+
+		expect( messageOf( 'WP_REQUEST_EXPORT_ERROR' ) ).toEqual( {
+			type: 'WP_REQUEST_EXPORT_ERROR',
+			requestId: 'exp-4',
+			error: 'Missing export format',
+		} );
+	} );
+
+	it( 'reports a failed export instead of answering with nothing', async () => {
+		installEditorWithDocument();
+		installQuickExport( { success: false } );
+
+		await loadBridge();
+		posted = [];
+		await send( { type: 'WP_REQUEST_EXPORT', requestId: 'exp-5', data: { format: 'html5' } } );
+
+		expect( messageOf( 'WP_REQUEST_EXPORT_ERROR' ).error ).toBe( 'Export failed' );
+	} );
+
+	it( 'gives up on an exporters bundle that never loads', async () => {
+		// exporters.bundle.js is lazily loaded in a later group than the readiness
+		// signal, so the bridge polls for it. It must still fail rather than hang.
+		installEditorWithDocument();
+
+		await loadBridge();
+		posted = [];
+		const answered = send( {
+			type: 'WP_REQUEST_EXPORT',
+			requestId: 'exp-6',
+			data: { format: 'html5' },
+		} );
+		await vi.advanceTimersByTimeAsync( 16000 );
+		await answered;
+
+		expect( messageOf( 'WP_REQUEST_EXPORT_ERROR' ).error ).toBe(
+			'SharedExporters bundle not loaded'
+		);
+	} );
+} );
+
+describe( 'wp-exe-bridge: GET_PROJECT_INFO', () => {
+	it( 'answers with the project metadata the modal shows', async () => {
+		installEditorWithDocument();
+
+		await loadBridge();
+		posted = [];
+		await send( { type: 'GET_PROJECT_INFO', requestId: 'info-1' } );
+
+		expect( messageOf( 'PROJECT_INFO' ) ).toEqual( {
+			type: 'PROJECT_INFO',
+			requestId: 'info-1',
+			projectId: 'proj-1',
+			title: 'Mi proyecto',
+			author: 'Ada',
+			description: '',
+			language: 'en',
+			theme: 'base',
+			pageCount: 3,
+		} );
+	} );
+
+	it( 'falls back to sane defaults when the document has no metadata', async () => {
+		installEditorWithDocument( {
+			documentManager: { getMetadata: () => undefined, getNavigation: () => undefined },
+		} );
+
+		await loadBridge();
+		posted = [];
+		await send( { type: 'GET_PROJECT_INFO', requestId: 'info-2' } );
+
+		const answer = messageOf( 'PROJECT_INFO' );
+		expect( answer.title ).toBe( 'Untitled' );
+		expect( answer.language ).toBe( 'en' );
+		expect( answer.theme ).toBe( 'base' );
+		expect( answer.pageCount ).toBe( 0 );
+	} );
+
+	it( 'reports that nothing is loaded rather than inventing a project', async () => {
+		window.eXeLearning = { app: { project: {} } };
+
+		await loadBridge();
+		posted = [];
+		await send( { type: 'GET_PROJECT_INFO', requestId: 'info-3' } );
+
+		expect( messageOf( 'GET_PROJECT_INFO_ERROR' ).error ).toBe( 'No project loaded' );
+	} );
+} );
+
+describe( 'wp-exe-bridge: CONFIGURE', () => {
+	it( 'hides the parts of the editor chrome WordPress provides itself', async () => {
+		installEditorWithDocument();
+
+		await loadBridge();
+		posted = [];
+		await send( {
+			type: 'CONFIGURE',
+			requestId: 'cfg-1',
+			data: { hideUI: { fileMenu: true, saveButton: true, userMenu: true } },
+		} );
+
+		expect( document.body.getAttribute( 'data-exe-hide-file-menu' ) ).toBe( 'true' );
+		expect( document.body.getAttribute( 'data-exe-hide-save' ) ).toBe( 'true' );
+		expect( document.body.getAttribute( 'data-exe-hide-user-menu' ) ).toBe( 'true' );
+		expect( messageOf( 'CONFIGURE_SUCCESS' ) ).toEqual( {
+			type: 'CONFIGURE_SUCCESS',
+			requestId: 'cfg-1',
+		} );
+	} );
+
+	it( 'leaves alone whatever it was not asked to hide', async () => {
+		installEditorWithDocument();
+
+		await loadBridge();
+		await send( { type: 'CONFIGURE', requestId: 'cfg-2', data: { hideUI: { saveButton: true } } } );
+
+		expect( document.body.hasAttribute( 'data-exe-hide-file-menu' ) ).toBe( false );
+		expect( document.body.getAttribute( 'data-exe-hide-save' ) ).toBe( 'true' );
+	} );
+
+	it( 'still acknowledges a CONFIGURE that hides nothing', async () => {
+		installEditorWithDocument();
+
+		await loadBridge();
+		posted = [];
+		await send( { type: 'CONFIGURE', requestId: 'cfg-3' } );
+
+		expect( messageOf( 'CONFIGURE_SUCCESS' ) ).toBeDefined();
+		expect( document.body.hasAttribute( 'data-exe-hide-save' ) ).toBe( false );
+	} );
+} );
+
+describe( 'wp-exe-bridge: WP_SAVE_CONFIRMED', () => {
+	it( 'marks the document clean and drops the unload warning', async () => {
+		const documentManager = installEditorWithDocument();
+		window.onbeforeunload = () => 'unsaved';
+
+		await loadBridge();
+		posted = [];
+		await send( { type: 'WP_SAVE_CONFIRMED', requestId: 'ok-1' } );
+
+		expect( documentManager.markClean ).toHaveBeenCalled();
+		expect( window.onbeforeunload ).toBeNull();
+		expect( messageOf( 'WP_SAVE_CONFIRMED_ACK' ) ).toEqual( {
+			type: 'WP_SAVE_CONFIRMED_ACK',
+			requestId: 'ok-1',
+		} );
+	} );
+
+	it( 'acknowledges even when there is no document to mark clean', async () => {
+		window.eXeLearning = { app: { project: {} } };
+		window.onbeforeunload = () => 'unsaved';
+
+		await loadBridge();
+		posted = [];
+		await send( { type: 'WP_SAVE_CONFIRMED', requestId: 'ok-2' } );
+
+		expect( window.onbeforeunload ).toBeNull();
+		expect( messageOf( 'WP_SAVE_CONFIRMED_ACK' ) ).toBeDefined();
+	} );
+} );
+
+describe( 'wp-exe-bridge: giving up instead of hanging', () => {
+	// Every one of these ends in an answer. A request the bridge simply never
+	// replies to leaves the parent modal spinning with no way out, which is worse
+	// than a visible error.
+
+	it( 'reports that the app never appeared', async () => {
+		await loadBridge();
+		posted = [];
+
+		const answered = send( { type: 'WP_REQUEST_SAVE', requestId: 'slow-1' } );
+		await vi.advanceTimersByTimeAsync( 16000 );
+		await answered;
+
+		expect( messageOf( 'WP_REQUEST_SAVE_ERROR' ).error ).toBe( 'App not ready' );
+	} );
+
+	it( 'reports that the document never finished loading', async () => {
+		window.eXeLearning = { app: { project: {} } };
+		window.SharedExporters = { quickExport: vi.fn() };
+
+		await loadBridge();
+		posted = [];
+
+		const answered = send( {
+			type: 'WP_REQUEST_EXPORT',
+			requestId: 'slow-2',
+			data: { format: 'html5' },
+		} );
+		await vi.advanceTimersByTimeAsync( 16000 );
+		await answered;
+
+		expect( messageOf( 'WP_REQUEST_EXPORT_ERROR' ).error ).toBe( 'Document not ready' );
+	} );
+
+	it( 'falls through to the plain exporters when the bundle never arrives', async () => {
+		// A save waits for the bundle, then carries on without it rather than
+		// failing outright -- here nothing else can export either, so it says so.
+		installEditorWithDocument();
+
+		await loadBridge();
+		posted = [];
+
+		const answered = send( { type: 'WP_REQUEST_SAVE', requestId: 'slow-3' } );
+		await vi.advanceTimersByTimeAsync( 16000 );
+		await answered;
+
+		expect( messageOf( 'WP_REQUEST_SAVE_ERROR' ).error ).toBe( 'Export not available' );
+	} );
+} );
+
+describe( 'wp-exe-bridge: the remaining export routes', () => {
+	it( 'uses the Yjs bridge exporter when that is all the project has', async () => {
+		window.eXeLearning = {
+			app: {
+				project: {
+					_yjsBridge: {
+						exporter: {
+							exportToBlob: async () =>
+								new Blob( [ new Uint8Array( [ 5, 5, 5 ] ) ], { type: 'application/zip' } ),
+							buildFilename: () => 'desde-yjs.elpx',
+						},
+					},
+				},
+			},
+		};
+
+		await loadBridge();
+		posted = [];
+		await send( { type: 'WP_REQUEST_SAVE', requestId: 'save-6' } );
+
+		const answer = messageOf( 'WP_SAVE_FILE' );
+		expect( answer.filename ).toBe( 'desde-yjs.elpx' );
+		expect( answer.size ).toBe( 3 );
+	} );
+
+	it( 'ignores a hideUI that is not a set of flags', async () => {
+		installEditorWithDocument();
+
+		await loadBridge();
+		posted = [];
+		await send( { type: 'CONFIGURE', requestId: 'cfg-4', data: { hideUI: 'everything' } } );
+
+		expect( document.body.hasAttribute( 'data-exe-hide-save' ) ).toBe( false );
+		expect( messageOf( 'CONFIGURE_SUCCESS' ) ).toBeDefined();
+	} );
+} );
+
+describe( 'wp-exe-bridge: starting up', () => {
+	it( 'waits for DOMContentLoaded when it is parsed before the document is ready', async () => {
+		const readyState = Object.getOwnPropertyDescriptor(
+			window.Document.prototype,
+			'readyState'
+		);
+		Object.defineProperty( document, 'readyState', {
+			configurable: true,
+			get: () => 'loading',
+		} );
+		installEditorWithDocument();
+
+		try {
+			await loadBridge();
+			expect( posted ).toEqual( [] );
+
+			document.dispatchEvent( new window.Event( 'DOMContentLoaded' ) );
+			await settle();
+
+			expect( messageOf( 'EXELEARNING_READY' ) ).toBeDefined();
+		} finally {
+			delete document.readyState;
+			if ( readyState ) {
+				Object.defineProperty( window.Document.prototype, 'readyState', readyState );
+			}
+		}
+	} );
+
+	it( 'logs and carries on when the editor never becomes ready', async () => {
+		const ready = Promise.reject( new Error( 'editor exploded' ) );
+		// The bridge only attaches its await after the import, which is a tick too
+		// late for Node: park a no-op handler on the original so the rejection is
+		// not reported as unhandled. init() still sees it throw.
+		ready.catch( () => {} );
+		window.eXeLearning = { ready };
+
+		await loadBridge();
+
+		expect( posted ).toEqual( [] );
+		expect( consoleErrors.join( ' ' ) ).toContain( 'Initialization failed' );
+	} );
+} );
+
+describe( 'wp-exe-bridge: the save shortcut', () => {
+	it( 'asks the modal to save on Ctrl+S and swallows the browser dialog', async () => {
+		installEditorWithDocument();
+		await loadBridge();
+		posted = [];
+
+		const event = new window.KeyboardEvent( 'keydown', {
+			key: 's',
+			ctrlKey: true,
+			bubbles: true,
+			cancelable: true,
+		} );
+		document.dispatchEvent( event );
+
+		expect( event.defaultPrevented ).toBe( true );
+		expect( posted ).toEqual( [
+			{ source: 'wp-exe-editor', type: 'request-save', data: {} },
+		] );
+	} );
+
+	it( 'works with Cmd+S too', async () => {
+		installEditorWithDocument();
+		await loadBridge();
+		posted = [];
+
+		document.dispatchEvent(
+			new window.KeyboardEvent( 'keydown', {
+				key: 's',
+				metaKey: true,
+				bubbles: true,
+				cancelable: true,
+			} )
+		);
+
+		expect( posted ).toHaveLength( 1 );
+	} );
+
+	it( 'leaves a plain s alone so typing still works', async () => {
+		installEditorWithDocument();
+		await loadBridge();
+		posted = [];
+
+		const event = new window.KeyboardEvent( 'keydown', {
+			key: 's',
+			bubbles: true,
+			cancelable: true,
+		} );
+		document.dispatchEvent( event );
+
+		expect( event.defaultPrevented ).toBe( false );
+		expect( posted ).toEqual( [] );
+	} );
+} );

--- a/tests/js/wp_exe_download.test.js
+++ b/tests/js/wp_exe_download.test.js
@@ -7,13 +7,19 @@
 //     goes through whatever serves the uploads (a Playground service worker, for one)
 //     instead of a top-level navigation that bypasses it. If fetch is missing or fails,
 //     a direct link is the fallback -- failing silently here means no file at all.
-//   - Every other format is exported client-side inside a hidden editor iframe. Only
-//     the refusals are unit-tested: the handshake itself needs an iframe that really
-//     loads the editor and answers by postMessage, which is what the Playwright suite
-//     gives it. Faking it here would test the fake.
+//   - Every other format is exported client-side inside a hidden editor iframe.
+//     Whether the real editor answers WP_REQUEST_EXPORT is a question for the Playwright
+//     suite, and it stays there -- no stub can answer it. What is unit-tested here is
+//     this side of the boundary: the bootstrap URL, the readiness handshake, matching an
+//     answer to the request that asked for it, and the timeouts. Those are ordinary
+//     bookkeeping with ordinary bugs -- an answer accepted from the wrong window, a
+//     requestId never cleared, a rejection that leaves the button spinning -- and none
+//     of them need a real editor to go wrong.
 //
 // The script is an IIFE that reads window.wpExeDownloadConfig at load time and binds
 // listeners on the document, so it is configured first and imported once for the file.
+// It also keeps the iframe in module state, so the export tests use a fresh attachment
+// id each time rather than depending on what the previous test left behind.
 
 const path = require( 'path' );
 const { pathToFileURL } = require( 'url' );
@@ -275,11 +281,509 @@ describe( 'wp-exe-download: downloading the .elpx itself', () => {
 	} );
 } );
 
+// The editor iframe never really loads under Vitest: happy-dom is configured not to
+// fetch iframe pages, and it signals that by firing `error` on every one of them --
+// which is exactly what the script reads as a broken editor. So the harness gives the
+// script an iframe it can drive: the src is recorded instead of being applied, the
+// contentWindow is a stub that collects postMessage calls, and the error handler is
+// held back so a load failure is something a test asks for rather than something the
+// environment does on its own. Everything else about the element is a real element.
+let frames = [];
+let restoreCreateElement = null;
+
+/** Make every iframe the script creates from now on inert and observable. */
+function installIframeHarness() {
+	const realCreateElement = document.createElement.bind( document );
+	frames = [];
+
+	document.createElement = ( tagName, options ) => {
+		const element = realCreateElement( tagName, options );
+		if ( 'iframe' !== String( tagName ).toLowerCase() ) {
+			return element;
+		}
+
+		const frame = { element, src: null, posted: [], errorHandlers: [] };
+		frame.contentWindow = {
+			postMessage: ( message ) => frame.posted.push( message ),
+		};
+
+		Object.defineProperty( element, 'src', {
+			configurable: true,
+			get: () => '',
+			set: ( value ) => {
+				frame.src = value;
+			},
+		} );
+		Object.defineProperty( element, 'contentWindow', {
+			configurable: true,
+			value: frame.contentWindow,
+		} );
+
+		const realAddEventListener = element.addEventListener.bind( element );
+		element.addEventListener = ( type, fn, opts ) => {
+			if ( 'error' === type ) {
+				frame.errorHandlers.push( fn );
+				return;
+			}
+			realAddEventListener( type, fn, opts );
+		};
+
+		frames.push( frame );
+		return element;
+	};
+
+	restoreCreateElement = () => {
+		document.createElement = realCreateElement;
+	};
+}
+
+/** The iframe the script is currently working with. */
+function currentFrame() {
+	return frames[ frames.length - 1 ];
+}
+
+/** Deliver a message to the page as if the editor iframe had sent it. */
+function fromEditor( frame, data ) {
+	window.dispatchEvent(
+		new window.MessageEvent( 'message', { data, source: frame.contentWindow } )
+	);
+}
+
+/** Report the editor inside the frame as loaded and ready to export. */
+function reportReady( frame ) {
+	fromEditor( frame, { type: 'EXELEARNING_READY' } );
+}
+
+/** The requestId of the export the script last asked this iframe for. */
+function lastRequestId( frame ) {
+	const request = frame.posted[ frame.posted.length - 1 ];
+	return request && request.requestId;
+}
+
+/** Answer the frame's outstanding export request with some bytes. */
+function answerExport( frame, extra ) {
+	fromEditor( frame, {
+		type: 'WP_EXPORT_FILE',
+		requestId: lastRequestId( frame ),
+		bytes: new Uint8Array( [ 1 ] ),
+		...extra,
+	} );
+}
+
+/**
+ * Append a second download button without disturbing what is already on the page.
+ *
+ * renderButton() replaces the whole body, which would silently detach the script's
+ * hidden iframe and make "the old iframe was removed" true for the wrong reason.
+ *
+ * @param {number} attachmentId Attachment the button downloads.
+ * @return {HTMLElement} The appended container.
+ */
+function appendButton( attachmentId ) {
+	document.body.insertAdjacentHTML(
+		'beforeend',
+		'<div class="exelearning-download" data-attachment-id="' + attachmentId + '"' +
+			' data-elp-url="http://example.test/uploads/project.elpx" data-slug="mi-curso"></div>'
+	);
+	return document.body.lastElementChild;
+}
+
+/** Attachment ids are never reused: the script caches its iframe per attachment. */
+let nextAttachmentId = 1000;
+
 describe( 'wp-exe-download: exporting through the editor iframe', () => {
+	beforeEach( () => {
+		installIframeHarness();
+	} );
+
+	afterEach( () => {
+		restoreCreateElement();
+	} );
+
 	it( 'refuses to export without an attachment id', async () => {
 		await expect(
 			window.wpExeDownload.downloadFormat( { format: 'scorm12' } )
 		).rejects.toThrow( 'Missing attachment id or editor URL' );
 		expect( consoleErrors.join( ' ' ) ).toContain( 'Missing attachment id or editor URL' );
+	} );
+
+	/**
+	 * Start an export and get as far as the iframe asking the editor for it.
+	 *
+	 * @param {Object} [params] Overrides for the downloadFormat call.
+	 * @return {Promise<Object>} The pending download, its iframe and its container.
+	 */
+	async function startExport( params ) {
+		const container = ( params && params.container ) || renderButton();
+		const pending = window.wpExeDownload.downloadFormat( {
+			format: 'scorm12',
+			suffix: '_scorm.zip',
+			attachmentId: ++nextAttachmentId,
+			slug: 'mi-curso',
+			...params,
+			container,
+		} );
+
+		await settle();
+		const frame = currentFrame();
+		reportReady( frame );
+		await settle();
+
+		return { pending, frame, container };
+	}
+
+	it( 'points the hidden iframe at the export bootstrap for that attachment', async () => {
+		const attachmentId = ++nextAttachmentId;
+		const { pending, frame } = await startExport( { attachmentId } );
+
+		const url = new URL( frame.src );
+		expect( url.origin + url.pathname ).toBe( 'http://example.test/' );
+		expect( url.searchParams.get( 'exe_export' ) ).toBe( '1' );
+		expect( url.searchParams.get( 'attachment_id' ) ).toBe( String( attachmentId ) );
+		expect( frame.element.getAttribute( 'aria-hidden' ) ).toBe( 'true' );
+		expect( frame.element.getAttribute( 'tabindex' ) ).toBe( '-1' );
+
+		answerExport( frame );
+		await pending;
+	} );
+
+	it( 'asks the editor for the format and downloads what comes back', async () => {
+		const { pending, frame, container } = await startExport();
+
+		expect( frame.posted ).toHaveLength( 1 );
+		expect( frame.posted[ 0 ].type ).toBe( 'WP_REQUEST_EXPORT' );
+		expect( frame.posted[ 0 ].data ).toEqual( { format: 'scorm12' } );
+
+		answerExport( frame, {
+			bytes: new Uint8Array( [ 1, 2, 3 ] ),
+			filename: 'ignorado.zip',
+			mimeType: 'application/zip',
+		} );
+		await pending;
+
+		expect( downloads ).toEqual( [
+			{ href: 'blob:mock/0', download: 'mi-curso_scorm.zip' },
+		] );
+		expect( objectUrls[ 0 ].blob.type ).toBe( 'application/zip' );
+		expect( container.hasAttribute( 'data-busy' ) ).toBe( false );
+	} );
+
+	it( 'labels an EPUB export as an EPUB when the editor did not say', async () => {
+		const { pending, frame } = await startExport( { format: 'epub3', suffix: '.epub' } );
+
+		answerExport( frame );
+		await pending;
+
+		expect( objectUrls[ 0 ].blob.type ).toBe( 'application/epub+zip' );
+		expect( downloads[ 0 ].download ).toBe( 'mi-curso.epub' );
+	} );
+
+	it( 'marks the button busy for as long as the export runs', async () => {
+		const { pending, frame, container } = await startExport();
+
+		expect( container.getAttribute( 'data-busy' ) ).toBe( '1' );
+
+		answerExport( frame );
+		await pending;
+
+		expect( container.hasAttribute( 'data-busy' ) ).toBe( false );
+	} );
+
+	it( 'reuses the iframe for a second export of the same attachment', async () => {
+		const attachmentId = ++nextAttachmentId;
+		const first = await startExport( { attachmentId } );
+		answerExport( first.frame );
+		await first.pending;
+
+		const pending = window.wpExeDownload.downloadFormat( {
+			format: 'ims',
+			suffix: '_ims.zip',
+			attachmentId,
+			slug: 'mi-curso',
+			container: appendButton( attachmentId ),
+		} );
+		await settle();
+
+		// No second iframe and no second handshake: the editor is already loaded.
+		expect( frames ).toHaveLength( 1 );
+		answerExport( first.frame, { bytes: new Uint8Array( [ 2 ] ) } );
+		await pending;
+
+		expect( downloads[ 1 ].download ).toBe( 'mi-curso_ims.zip' );
+	} );
+
+	it( 'removes the old iframe when a different attachment is exported', async () => {
+		const first = await startExport();
+		answerExport( first.frame );
+		await first.pending;
+
+		expect( first.frame.element.parentNode ).not.toBeNull();
+
+		// A second attachment, with the first iframe still on the page, so the
+		// assertion below is about disposal and not about renderButton() having
+		// wiped the body.
+		const second = await startExport( { container: appendButton( ++nextAttachmentId ) } );
+
+		expect( frames ).toHaveLength( 2 );
+		expect( first.frame.element.parentNode ).toBeNull();
+		expect( second.frame.element.parentNode ).not.toBeNull();
+
+		answerExport( second.frame, { bytes: new Uint8Array( [ 2 ] ) } );
+		await second.pending;
+	} );
+} );
+
+describe( 'wp-exe-download: answers the export must not accept', () => {
+	// The page listens on window for the editor's replies. Anything that gets past
+	// these checks resolves somebody else's export with the wrong bytes.
+
+	beforeEach( () => {
+		installIframeHarness();
+	} );
+
+	afterEach( () => {
+		restoreCreateElement();
+	} );
+
+	/** Start an export that is sitting waiting for its answer. */
+	async function pendingExport() {
+		const container = renderButton();
+		const pending = window.wpExeDownload.downloadFormat( {
+			format: 'html5',
+			suffix: '_web.zip',
+			attachmentId: ++nextAttachmentId,
+			slug: 'curso',
+			container,
+		} );
+		await settle();
+		const frame = currentFrame();
+		reportReady( frame );
+		await settle();
+		return { pending, frame, container };
+	}
+
+	it( 'ignores an answer that came from some other window', async () => {
+		const { pending, frame } = await pendingExport();
+		const impostor = { postMessage: () => {} };
+
+		window.dispatchEvent(
+			new window.MessageEvent( 'message', {
+				data: {
+					type: 'WP_EXPORT_FILE',
+					requestId: lastRequestId( frame ),
+					bytes: new Uint8Array( [ 6, 6, 6 ] ),
+				},
+				source: impostor,
+			} )
+		);
+		await settle();
+
+		expect( downloads ).toEqual( [] );
+
+		// Still waiting, and the real answer still works.
+		answerExport( frame );
+		await pending;
+		expect( downloads ).toHaveLength( 1 );
+	} );
+
+	it( 'ignores an answer to a request nobody made', async () => {
+		const { pending, frame } = await pendingExport();
+
+		fromEditor( frame, {
+			type: 'WP_EXPORT_FILE',
+			requestId: 'exe-9999',
+			bytes: new Uint8Array( [ 9 ] ),
+		} );
+		await settle();
+
+		expect( downloads ).toEqual( [] );
+
+		answerExport( frame );
+		await pending;
+	} );
+
+	it( 'ignores an answer with no requestId at all', async () => {
+		const { pending, frame } = await pendingExport();
+
+		fromEditor( frame, { type: 'WP_EXPORT_FILE', bytes: new Uint8Array( [ 9 ] ) } );
+		await settle();
+
+		expect( downloads ).toEqual( [] );
+
+		answerExport( frame );
+		await pending;
+	} );
+
+	it( 'surfaces an export the editor could not produce', async () => {
+		const { pending, frame, container } = await pendingExport();
+
+		fromEditor( frame, {
+			type: 'WP_REQUEST_EXPORT_ERROR',
+			requestId: lastRequestId( frame ),
+			error: 'Exporter crashed',
+		} );
+
+		await expect( pending ).rejects.toThrow( 'Exporter crashed' );
+		expect( container.querySelector( '.exelearning-download__status' ).textContent ).toBe(
+			'No se pudo descargar. Inténtalo de nuevo.'
+		);
+		expect( container.hasAttribute( 'data-busy' ) ).toBe( false );
+	} );
+
+	it( 'treats an answer carrying an error as a failure whatever its type', async () => {
+		const { pending, frame } = await pendingExport();
+
+		fromEditor( frame, {
+			type: 'WP_EXPORT_FILE',
+			requestId: lastRequestId( frame ),
+			error: 'Out of memory',
+		} );
+
+		await expect( pending ).rejects.toThrow( 'Out of memory' );
+	} );
+
+	it( 'reports an editor iframe that fails to load', async () => {
+		const container = renderButton();
+		const pending = window.wpExeDownload.downloadFormat( {
+			format: 'html5',
+			suffix: '_web.zip',
+			attachmentId: ++nextAttachmentId,
+			slug: 'curso',
+			container,
+		} );
+		await settle();
+
+		currentFrame().errorHandlers.forEach( ( fn ) => fn() );
+
+		await expect( pending ).rejects.toThrow( 'iframe failed to load' );
+		expect( container.querySelector( '.exelearning-download__status' ) ).not.toBeNull();
+	} );
+
+	it( 'exports without a container without tripping over the missing UI', async () => {
+		// The block editor toolbar calls downloadFormat directly, with no container
+		// to put a spinner or an error message on.
+		const pending = window.wpExeDownload.downloadFormat( {
+			format: 'html5',
+			suffix: '_web.zip',
+			attachmentId: ++nextAttachmentId,
+			slug: 'curso',
+		} );
+		await settle();
+
+		const frame = currentFrame();
+		reportReady( frame );
+		await settle();
+		answerExport( frame );
+
+		await expect( pending ).resolves.toBeUndefined();
+		expect( downloads[ 0 ].download ).toBe( 'curso_web.zip' );
+	} );
+} );
+
+describe( 'wp-exe-download: exports that never finish', () => {
+	// A hung export must end in a rejection and a button that is usable again.
+	// Waiting on the real 45s and 120s deadlines is not an option, so this block
+	// drives the clock.
+
+	beforeEach( () => {
+		installIframeHarness();
+		vi.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		vi.useRealTimers();
+		restoreCreateElement();
+	} );
+
+	/** settle(), but for a test whose timers are under its own control. */
+	async function settleFake() {
+		for ( let i = 0; i < 6; i++ ) {
+			await Promise.resolve();
+			await vi.advanceTimersByTimeAsync( 0 );
+		}
+	}
+
+	it( 'gives up on an editor that never reports itself ready', async () => {
+		const container = renderButton();
+		const pending = window.wpExeDownload.downloadFormat( {
+			format: 'html5',
+			suffix: '_web.zip',
+			attachmentId: ++nextAttachmentId,
+			slug: 'curso',
+			container,
+		} );
+		await settleFake();
+
+		// The handler goes on before the clock moves: the rejection lands during
+		// advanceTimersByTimeAsync, and an unhandled one fails the run.
+		const rejected = expect( pending ).rejects.toThrow( 'export iframe timeout' );
+		await vi.advanceTimersByTimeAsync( 45000 );
+		await rejected;
+
+		expect( container.hasAttribute( 'data-busy' ) ).toBe( false );
+	} );
+
+	it( 'gives up on an export the editor accepted and never answered', async () => {
+		const container = renderButton();
+		const pending = window.wpExeDownload.downloadFormat( {
+			format: 'html5',
+			suffix: '_web.zip',
+			attachmentId: ++nextAttachmentId,
+			slug: 'curso',
+			container,
+		} );
+		await settleFake();
+		reportReady( currentFrame() );
+		await settleFake();
+
+		const rejected = expect( pending ).rejects.toThrow( 'Export timed out' );
+		await vi.advanceTimersByTimeAsync( 120000 );
+		await rejected;
+
+		expect( container.hasAttribute( 'data-busy' ) ).toBe( false );
+	} );
+
+	it( 'clears the failure message once the reader has had time to see it', async () => {
+		const container = renderButton();
+		const pending = window.wpExeDownload.downloadFormat( {
+			format: 'html5',
+			suffix: '_web.zip',
+			attachmentId: ++nextAttachmentId,
+			slug: 'curso',
+			container,
+		} );
+		await settleFake();
+		currentFrame().errorHandlers.forEach( ( fn ) => fn() );
+		await expect( pending ).rejects.toThrow( 'iframe failed to load' );
+
+		expect( container.querySelector( '.exelearning-download__status' ) ).not.toBeNull();
+
+		await vi.advanceTimersByTimeAsync( 4000 );
+
+		expect( container.querySelector( '.exelearning-download__status' ) ).toBeNull();
+	} );
+
+	it( 'releases the object URL after handing the blob to the browser', async () => {
+		// Holding every exported package in memory for the life of the tab would be
+		// a leak measured in tens of megabytes.
+		const container = renderButton();
+		const pending = window.wpExeDownload.downloadFormat( {
+			format: 'html5',
+			suffix: '_web.zip',
+			attachmentId: ++nextAttachmentId,
+			slug: 'curso',
+			container,
+		} );
+		await settleFake();
+		reportReady( currentFrame() );
+		await settleFake();
+		answerExport( currentFrame() );
+		await pending;
+
+		expect( objectUrls[ 0 ].revoked ).toBe( false );
+
+		await vi.advanceTimersByTimeAsync( 1000 );
+
+		expect( objectUrls[ 0 ].revoked ).toBe( true );
 	} );
 } );

--- a/tests/unit/AdminSettingsScreenTest.php
+++ b/tests/unit/AdminSettingsScreenTest.php
@@ -43,6 +43,7 @@ class AdminSettingsScreenTest extends WP_UnitTestCase {
 	 * Tear down test fixtures.
 	 */
 	public function tear_down() {
+		ExeLearning_Bundle_Fixture::destroy();
 		$GLOBALS['wp_settings_errors'] = array();
 		$_GET                          = array();
 		wp_dequeue_style( 'exelearning-settings' );
@@ -84,22 +85,36 @@ class AdminSettingsScreenTest extends WP_UnitTestCase {
 	 * bundle is absent. The notice is raised only when that is really the case,
 	 * so the marker cannot be used to fake a warning on a healthy install.
 	 */
-	public function test_the_editor_missing_notice_tracks_the_actual_bundle() {
+	public function test_the_editor_missing_notice_is_raised_when_the_bundle_is_absent() {
+		ExeLearning_Bundle_Fixture::create_empty();
 		set_current_screen( 'settings_page_' . ExeLearning_Admin_Settings::PAGE_SLUG );
 		$_GET['editor-missing'] = '1';
 
 		$this->settings->on_settings_page_load();
 		$notices = get_settings_errors( 'exelearning_editor' );
 
-		if ( ExeLearning_Editor_Bundle::is_available() ) {
-			$this->assertSame( array(), $notices, 'A bundled editor must not be reported as missing.' );
-			return;
-		}
-
 		$this->assertCount( 1, $notices );
 		$this->assertSame( 'exelearning_editor_missing', $notices[0]['code'] );
 		$this->assertSame( 'warning', $notices[0]['type'] );
 		$this->assertStringContainsString( 'make build-editor', $notices[0]['message'] );
+	}
+
+	/**
+	 * The marker alone cannot fake the warning: with the editor bundled, the
+	 * notice is not raised however the query string arrived.
+	 */
+	public function test_the_editor_missing_notice_is_not_raised_when_the_bundle_is_there() {
+		ExeLearning_Bundle_Fixture::create();
+		set_current_screen( 'settings_page_' . ExeLearning_Admin_Settings::PAGE_SLUG );
+		$_GET['editor-missing'] = '1';
+
+		$this->settings->on_settings_page_load();
+
+		$this->assertSame(
+			array(),
+			get_settings_errors( 'exelearning_editor' ),
+			'A bundled editor must not be reported as missing.'
+		);
 	}
 
 	/**

--- a/tests/unit/AdminSettingsTest.php
+++ b/tests/unit/AdminSettingsTest.php
@@ -32,6 +32,7 @@ class AdminSettingsTest extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		global $wp_registered_settings, $wp_settings_sections, $wp_settings_fields;
+		ExeLearning_Bundle_Fixture::destroy();
 		unset( $wp_registered_settings[ ExeLearning_Styles_Service::OPTION_BLOCK_IMPORT ] );
 		unset( $wp_registered_settings[ ExeLearning_Content_Proxy::OPTION_PROXY_ASSETS ] );
 		unset( $wp_registered_settings[ ExeLearning_Styles_Service::OPTION_DISABLED_STYLES ] );
@@ -256,18 +257,101 @@ class AdminSettingsTest extends WP_UnitTestCase {
 	 * There is no runtime editor install/update action (ADR-0002), and the
 	 * editor card only appears as a warning when the bundle is missing.
 	 */
-	public function test_display_settings_page_renders_editor_status_without_install_action() {
+	public function test_display_settings_page_renders_no_install_action_with_the_editor_bundled() {
+		ExeLearning_Bundle_Fixture::create();
 		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
 
 		$output = $this->render_settings_page();
 
 		$this->assertStringNotContainsString( 'exelearning_install_editor', $output );
 		$this->assertStringNotContainsString( 'exelearning-install-editor', $output );
-		if ( ExeLearning_Editor_Bundle::is_available() ) {
-			$this->assertStringNotContainsString( 'exelearning-editor-status', $output );
-		} else {
-			$this->assertStringContainsString( 'exelearning-editor-status', $output );
-		}
+		$this->assertStringNotContainsString( 'exelearning-editor-status', $output );
+	}
+
+	/**
+	 * Without the bundle the card appears as a warning, and still offers no way
+	 * to fetch the editor: the only fix is reinstalling the plugin package.
+	 */
+	public function test_display_settings_page_warns_without_the_editor_bundle() {
+		ExeLearning_Bundle_Fixture::create_empty();
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$output = $this->render_settings_page();
+
+		$this->assertStringContainsString( 'exelearning-editor-status', $output );
+		$this->assertStringNotContainsString( 'exelearning_install_editor', $output );
+		$this->assertStringNotContainsString( 'exelearning-install-editor', $output );
+	}
+
+	/**
+	 * With the editor bundled, each theme it ships gets a row an administrator
+	 * can switch off, wired to the same option as the uploaded styles.
+	 */
+	public function test_the_builtin_styles_table_lists_the_themes_the_editor_ships() {
+		ExeLearning_Bundle_Fixture::create();
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		ob_start();
+		$this->settings->render_builtin_styles_table();
+		$output = (string) ob_get_clean();
+
+		$this->assertStringContainsString( 'id="exelearning-styles-builtins"', $output );
+		$this->assertStringContainsString( '<code>base</code>', $output );
+		$this->assertStringContainsString( '<code>pukao</code>', $output );
+		$this->assertStringContainsString( '2.1.0', $output );
+		$this->assertStringContainsString(
+			ExeLearning_Styles_Service::OPTION_DISABLED_STYLES . '[pukao]',
+			$output
+		);
+		// Built-in styles can be disabled but never deleted.
+		$this->assertStringNotContainsString( 'exelearning-delete-style', $output );
+	}
+
+	/**
+	 * A built-in the administrator disabled comes back with its box cleared,
+	 * which is what makes the setting visible on the screen it was set from.
+	 */
+	public function test_the_builtin_styles_table_reflects_a_disabled_style() {
+		ExeLearning_Bundle_Fixture::create();
+		ExeLearning_Styles_Service::set_builtin_enabled( 'pukao', false );
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		ob_start();
+		$this->settings->render_builtin_styles_table();
+		$output = (string) ob_get_clean();
+
+		$this->assertMatchesRegularExpression(
+			'/id="exelearning-style-enabled-base"[^>]*checked=/s',
+			$output
+		);
+		$this->assertDoesNotMatchRegularExpression(
+			'/id="exelearning-style-enabled-pukao"[^>]*checked=/s',
+			$output
+		);
+	}
+
+	/**
+	 * Without the editor there are no built-in styles to list, and the table is
+	 * replaced by an explanation rather than an empty frame.
+	 */
+	public function test_the_builtin_styles_table_explains_itself_without_the_editor() {
+		ExeLearning_Bundle_Fixture::create_empty();
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		ob_start();
+		$this->settings->render_builtin_styles_table();
+		$output = (string) ob_get_clean();
+
+		$this->assertStringNotContainsString( 'id="exelearning-styles-builtins"', $output );
+		// Resolved through the same translation as the code under test: the
+		// suite does not always run in English.
+		$this->assertStringContainsString(
+			esc_html__(
+				'Built-in styles are not available because the embedded editor is not installed.',
+				'exelearning'
+			),
+			$output
+		);
 	}
 
 	/**

--- a/tests/unit/EditorBootstrapPageTest.php
+++ b/tests/unit/EditorBootstrapPageTest.php
@@ -1,0 +1,437 @@
+<?php
+/**
+ * Tests for the standalone editor page built by admin/views/editor-bootstrap.php.
+ *
+ * The view patches the bundled static editor into something that boots against
+ * this WordPress install: it injects window.__WP_EXE_CONFIG__ with the REST
+ * endpoint and nonce the editor saves through, a <base> tag so the editor's
+ * relative asset paths resolve inside dist/static/, and the approved style
+ * registry. Everything the embedded editor knows about WordPress comes from
+ * here, and until it returned its HTML instead of printing it, none of it could
+ * be checked.
+ *
+ * The bundle is a fixture rather than whatever dist/static/ happens to hold, so
+ * these assertions mean the same thing in CI and on a machine with a built
+ * editor. See ExeLearning_Bundle_Fixture and SDD-0003.
+ *
+ * @package Exelearning
+ */
+
+/**
+ * Editor whose request-ending steps are recorded instead of taken.
+ *
+ * Mirrors the ExeLearning_Admin_Styles::finish_request() pattern: exit() would
+ * end the PHPUnit process, so the subclass records what would have been sent.
+ */
+class ExeLearning_Editor_Recording extends ExeLearning_Editor {
+
+	/**
+	 * Redirect target, if one was issued.
+	 *
+	 * @var string|null
+	 */
+	public $redirected_to = null;
+
+	/**
+	 * Document that would have been printed.
+	 *
+	 * @var string|null
+	 */
+	public $sent_html = null;
+
+	/**
+	 * Record the redirect rather than performing it.
+	 *
+	 * @param string $location Redirect target URL.
+	 * @return void
+	 */
+	protected function redirect_and_exit( $location ) {
+		$this->redirected_to = $location;
+	}
+
+	/**
+	 * Record the document rather than printing it.
+	 *
+	 * @param string $html Assembled HTML document.
+	 * @return void
+	 */
+	protected function send_and_exit( $html ) {
+		$this->sent_html = $html;
+	}
+
+	/**
+	 * Expose the protected entry point to the test.
+	 *
+	 * @param int $attachment_id Attachment being edited.
+	 * @return void
+	 */
+	public function serve( $attachment_id ) {
+		$this->serve_bootstrap_page( $attachment_id );
+	}
+}
+
+/**
+ * Class EditorBootstrapPageTest.
+ *
+ * Deliberately without a @covers annotation. What is under test here is the
+ * view file, not a class, and @covers would restrict attribution to the named
+ * class and discard everything the view itself executed — which is the whole
+ * point of this file.
+ */
+class EditorBootstrapPageTest extends WP_UnitTestCase {
+
+	/**
+	 * Test instance.
+	 *
+	 * @var ExeLearning_Editor
+	 */
+	private $editor;
+
+	/**
+	 * Attachment files to remove on tear down.
+	 *
+	 * @var string[]
+	 */
+	private $cleanup_paths = array();
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->editor        = new ExeLearning_Editor();
+		$this->cleanup_paths = array();
+		$_GET                = array();
+		ExeLearning_Bundle_Fixture::create();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tear_down() {
+		ExeLearning_Bundle_Fixture::destroy();
+		$_GET = array();
+		foreach ( $this->cleanup_paths as $path ) {
+			if ( file_exists( $path ) ) {
+				wp_delete_file( $path );
+			}
+		}
+		parent::tear_down();
+	}
+
+	/**
+	 * Create an .elpx attachment owned by the current user.
+	 *
+	 * @param string $title Attachment title.
+	 * @return int Attachment ID.
+	 */
+	private function make_elpx( $title = 'Mi curso' ) {
+		$attachment_id = $this->factory->attachment->create(
+			array(
+				'post_title'  => $title,
+				'post_author' => get_current_user_id(),
+			)
+		);
+
+		$upload = wp_upload_dir();
+		$path   = trailingslashit( $upload['basedir'] ) . 'bootstrap-' . $attachment_id . '.elpx';
+		file_put_contents( $path, 'fixture' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		update_attached_file( $attachment_id, $path );
+		$this->cleanup_paths[] = $path;
+
+		return $attachment_id;
+	}
+
+	/**
+	 * Read one field out of the injected window.__WP_EXE_CONFIG__ literal.
+	 *
+	 * The block is a JavaScript object literal with bare keys, so it is not
+	 * JSON as a whole; each value, however, is written by wp_json_encode (or is
+	 * a bare integer), so it decodes on its own.
+	 *
+	 * @param string $html Built page.
+	 * @param string $key  Configuration key.
+	 * @return mixed Decoded value.
+	 */
+	private function config_value( $html, $key ) {
+		$pattern = '/^\s*' . preg_quote( $key, '/' ) . ': (.*)$/m';
+		$this->assertMatchesRegularExpression( $pattern, $html, "No {$key} in the injected config." );
+		preg_match( $pattern, $html, $matches );
+
+		return json_decode( rtrim( trim( $matches[1] ), ',' ), true );
+	}
+
+	/**
+	 * Without a bundled editor the page cannot be built, and the view says so
+	 * rather than rendering something broken.
+	 */
+	public function test_no_page_is_built_without_a_bundled_editor() {
+		ExeLearning_Bundle_Fixture::create_empty();
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->assertFalse( $this->editor->build_bootstrap_page( $this->make_elpx() ) );
+	}
+
+	/**
+	 * That refusal points at the settings screen, which is where the missing
+	 * bundle is explained.
+	 */
+	public function test_the_missing_editor_url_targets_the_settings_notice() {
+		$url = ExeLearning_Editor::editor_missing_url();
+
+		$this->assertStringContainsString( 'page=exelearning-settings', $url );
+		$this->assertStringContainsString( 'editor-missing=1', $url );
+		$this->assertStringStartsWith( admin_url( 'options-general.php' ), $url );
+	}
+
+	/**
+	 * The editor is told which attachment it is editing and where to save it.
+	 */
+	public function test_the_page_tells_the_editor_how_to_reach_wordpress() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$attachment_id = $this->make_elpx();
+
+		$html = $this->editor->build_bootstrap_page( $attachment_id );
+
+		$this->assertSame( 'WordPress', $this->config_value( $html, 'mode' ) );
+		$this->assertSame( $attachment_id, $this->config_value( $html, 'attachmentId' ) );
+		$this->assertSame( rest_url( 'exelearning/v1' ), $this->config_value( $html, 'restUrl' ) );
+		$this->assertNotEmpty( $this->config_value( $html, 'nonce' ) );
+		$this->assertSame(
+			wp_get_attachment_url( $attachment_id ),
+			$this->config_value( $html, 'elpUrl' )
+		);
+	}
+
+	/**
+	 * The nonce is a real wp_rest nonce, not a placeholder: the REST routes
+	 * reject the save without it.
+	 */
+	public function test_the_page_carries_a_usable_rest_nonce() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$html = $this->editor->build_bootstrap_page( $this->make_elpx() );
+
+		$this->assertSame( 1, wp_verify_nonce( $this->config_value( $html, 'nonce' ), 'wp_rest' ) );
+	}
+
+	/**
+	 * The signed-in user is passed through so the editor can attribute changes.
+	 */
+	public function test_the_page_identifies_the_signed_in_user() {
+		$user_id = $this->factory->user->create(
+			array(
+				'role'         => 'administrator',
+				'display_name' => 'Ada Lovelace',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$html = $this->editor->build_bootstrap_page( $this->make_elpx() );
+
+		$this->assertSame( 'Ada Lovelace', $this->config_value( $html, 'userName' ) );
+		$this->assertSame( $user_id, $this->config_value( $html, 'userId' ) );
+	}
+
+	/**
+	 * A <base> tag pointing into dist/static/ is what makes the editor's own
+	 * relative asset paths resolve; without it the page loads nothing.
+	 */
+	public function test_the_page_bases_relative_paths_on_the_bundled_editor() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$html = $this->editor->build_bootstrap_page( $this->make_elpx() );
+
+		$this->assertStringContainsString(
+			'<base href="' . esc_url( EXELEARNING_PLUGIN_URL . 'dist/static' ) . '/">',
+			$html
+		);
+	}
+
+	/**
+	 * Exactly one <base>, and it goes in the head.
+	 *
+	 * The editor's own markup contains `<header id="head">`, which the pattern
+	 * that finds the head element used to match as well, dropping a second
+	 * stray <base> into the middle of the body.
+	 */
+	public function test_only_one_base_tag_is_injected() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		ExeLearning_Bundle_Fixture::write(
+			'index.html',
+			'<html><head></head><body><header id="head">Barra</header></body></html>'
+		);
+
+		$html = $this->editor->build_bootstrap_page( $this->make_elpx() );
+
+		$this->assertSame( 1, substr_count( $html, '<base href=' ) );
+		$this->assertStringContainsString( '</head>', $html );
+		$this->assertLessThan(
+			strpos( $html, '<body' ),
+			strpos( $html, '<base href=' ),
+			'The <base> tag must sit in the head, not in the body.'
+		);
+	}
+
+	/**
+	 * Explicit "./" paths in the bundle's own markup are rewritten too, because
+	 * the editor page is served from wp-admin rather than from dist/static/.
+	 */
+	public function test_relative_asset_paths_in_the_bundle_are_rewritten() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		ExeLearning_Bundle_Fixture::write(
+			'index.html',
+			'<html><head></head><body><script src="./app/main.js"></script></body></html>'
+		);
+
+		$html = $this->editor->build_bootstrap_page( $this->make_elpx() );
+
+		$this->assertStringContainsString(
+			'src="' . esc_url( EXELEARNING_PLUGIN_URL . 'dist/static' ) . '/app/main.js"',
+			$html
+		);
+		$this->assertStringNotContainsString( 'src="./app/main.js"', $html );
+	}
+
+	/**
+	 * The bridge script is loaded from the plugin's own assets, not from the
+	 * editor bundle: it is the WordPress half of the protocol.
+	 */
+	public function test_the_page_loads_the_wordpress_bridge() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$html = $this->editor->build_bootstrap_page( $this->make_elpx() );
+
+		$this->assertStringContainsString(
+			esc_url( EXELEARNING_PLUGIN_URL . 'assets' ) . '/js/wp-exe-bridge.js',
+			$html
+		);
+	}
+
+	/**
+	 * Everything is injected inside <head>, before the editor boots.
+	 */
+	public function test_the_configuration_is_injected_into_the_document_head() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$html = $this->editor->build_bootstrap_page( $this->make_elpx() );
+
+		$head = substr( $html, 0, strpos( $html, '</head>' ) );
+		$this->assertStringContainsString( 'window.__WP_EXE_CONFIG__', $head );
+		$this->assertStringContainsString( '<base href=', $head );
+		$this->assertStringContainsString( 'wp-exe-notification', $head );
+	}
+
+	/**
+	 * The approved style registry travels with the page, so the editor offers
+	 * exactly the styles this site allows.
+	 */
+	public function test_the_page_carries_the_style_registry() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		ExeLearning_Styles_Service::set_builtin_enabled( 'pukao', false );
+
+		$html = $this->editor->build_bootstrap_page( $this->make_elpx() );
+
+		// The registry is handed to the boot trap as `var OVERRIDE = {...};`,
+		// which wp_json_encode wrote, so it decodes as JSON on its own.
+		$this->assertMatchesRegularExpression( '/var OVERRIDE = (\{.*?\});/s', $html );
+		preg_match( '/var OVERRIDE = (\{.*?\});/s', $html, $matches );
+		$registry = json_decode( $matches[1], true );
+
+		$this->assertContains( 'pukao', $registry['disabledBuiltins'] );
+
+		delete_option( ExeLearning_Styles_Service::OPTION_DISABLED_STYLES );
+	}
+
+	/**
+	 * The page is localized: the editor boots in the site's language.
+	 */
+	public function test_the_page_passes_the_site_language() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$html = $this->editor->build_bootstrap_page( $this->make_elpx() );
+
+		$this->assertSame( substr( get_locale(), 0, 2 ), $this->config_value( $html, 'locale' ) );
+	}
+
+	/**
+	 * An attachment with no title still produces a usable page rather than an
+	 * empty heading.
+	 */
+	public function test_an_untitled_attachment_falls_back_to_its_filename() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$attachment_id = $this->make_elpx( '' );
+
+		$html = $this->editor->build_bootstrap_page( $attachment_id );
+
+		$this->assertIsString( $html );
+		$this->assertStringContainsString( 'bootstrap-' . $attachment_id . '.elpx', $html );
+	}
+
+	/**
+	 * With an editor bundled, the request ends by sending the built document.
+	 */
+	public function test_serving_the_page_sends_the_built_document() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$editor = new ExeLearning_Editor_Recording();
+
+		$editor->serve( $this->make_elpx() );
+
+		$this->assertNull( $editor->redirected_to );
+		$this->assertStringContainsString( 'window.__WP_EXE_CONFIG__', (string) $editor->sent_html );
+	}
+
+	/**
+	 * Without one, the administrator is sent to the settings screen instead of
+	 * being shown a broken editor.
+	 */
+	public function test_serving_the_page_redirects_when_no_editor_is_bundled() {
+		ExeLearning_Bundle_Fixture::create_empty();
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$editor = new ExeLearning_Editor_Recording();
+
+		$editor->serve( $this->make_elpx() );
+
+		$this->assertNull( $editor->sent_html );
+		$this->assertSame( ExeLearning_Editor::editor_missing_url(), $editor->redirected_to );
+	}
+
+	/**
+	 * The whole front controller, from a nonced request to a served document.
+	 *
+	 * EditorPageTest covers each guard that refuses a request; this is the path
+	 * where every guard passes, which used to end in exit() before the first
+	 * assertion could run.
+	 */
+	public function test_a_valid_request_is_served_end_to_end() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$attachment_id = $this->make_elpx();
+		$editor        = new ExeLearning_Editor_Recording();
+
+		$_GET = array(
+			'_wpnonce'      => wp_create_nonce( 'exelearning_editor' ),
+			'attachment_id' => (string) $attachment_id,
+		);
+
+		// render_editor_page() closes one output buffer on entry, so give it one
+		// of its own to consume rather than PHPUnit's.
+		ob_start();
+		$editor->render_editor_page();
+
+		$this->assertStringContainsString( 'window.__WP_EXE_CONFIG__', (string) $editor->sent_html );
+		$this->assertSame( $attachment_id, $this->config_value( (string) $editor->sent_html, 'attachmentId' ) );
+	}
+
+	/**
+	 * A bundle whose index.html cannot be read stops the request instead of
+	 * serving a half-built document.
+	 */
+	public function test_an_unreadable_bundle_template_stops_the_request() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$attachment_id = $this->make_elpx();
+		ExeLearning_Bundle_Fixture::write( 'index.html', '' );
+
+		$this->expectException( WPDieException::class );
+		$this->editor->build_bootstrap_page( $attachment_id );
+	}
+}

--- a/tests/unit/EditorBundleTest.php
+++ b/tests/unit/EditorBundleTest.php
@@ -55,6 +55,7 @@ class EditorBundleTest extends WP_UnitTestCase {
 	 * Remove the fixture directory.
 	 */
 	public function tear_down() {
+		ExeLearning_Editor_Bundle::set_path_override( null );
 		ExeLearning_Editor_Bundle_Fixture::$plugin_dir = '';
 		$this->recursive_delete( $this->fixture_dir );
 		parent::tear_down();
@@ -114,6 +115,48 @@ class EditorBundleTest extends WP_UnitTestCase {
 			ExeLearning_Editor_Bundle_Fixture::get_path()
 		);
 		$this->assertStringEndsWith( 'dist/static/', ExeLearning_Editor_Bundle::get_path() );
+	}
+
+	/**
+	 * The test seam moves every path the helper resolves, which is what lets
+	 * the suite exercise the bundled-editor code without a built editor.
+	 *
+	 * @see ExeLearning_Bundle_Fixture
+	 */
+	public function test_the_path_override_moves_the_whole_bundle() {
+		$this->make_bundle( array( 'app' ) );
+
+		ExeLearning_Editor_Bundle::set_path_override( $this->fixture_dir );
+
+		$this->assertSame(
+			trailingslashit( $this->fixture_dir ) . 'dist/static/',
+			ExeLearning_Editor_Bundle::get_path()
+		);
+		$this->assertTrue( ExeLearning_Editor_Bundle::is_available() );
+	}
+
+	/**
+	 * Resetting hands the plugin directory back, so one test cannot leak its
+	 * fixture into the next.
+	 */
+	public function test_clearing_the_override_restores_the_plugin_directory() {
+		ExeLearning_Editor_Bundle::set_path_override( $this->fixture_dir );
+		ExeLearning_Editor_Bundle::set_path_override( null );
+
+		$this->assertSame(
+			trailingslashit( EXELEARNING_PLUGIN_DIR ) . 'dist/static/',
+			ExeLearning_Editor_Bundle::get_path()
+		);
+	}
+
+	/**
+	 * An empty directory is the source-checkout case: the plugin is installed
+	 * but `make build-editor` never ran, and embedded editing stays disabled.
+	 */
+	public function test_an_override_pointing_nowhere_disables_the_editor() {
+		ExeLearning_Editor_Bundle::set_path_override( $this->fixture_dir );
+
+		$this->assertFalse( ExeLearning_Editor_Bundle::is_available() );
 	}
 
 	/**

--- a/tests/unit/ExportBootstrapPayloadTest.php
+++ b/tests/unit/ExportBootstrapPayloadTest.php
@@ -34,12 +34,21 @@ class ExportBootstrapPayloadTest extends WP_UnitTestCase {
 	private $editor_base_url;
 
 	/**
+	 * Attachment files to remove on tear down.
+	 *
+	 * @var string[]
+	 */
+	private $export_cleanup_paths = array();
+
+	/**
 	 * Set up test fixtures.
 	 */
 	public function set_up() {
 		parent::set_up();
-		$this->bootstrap       = new ExeLearning_Export_Bootstrap();
-		$this->editor_base_url = EXELEARNING_PLUGIN_URL . 'dist/static';
+		$this->bootstrap            = new ExeLearning_Export_Bootstrap();
+		$this->editor_base_url      = EXELEARNING_PLUGIN_URL . 'dist/static';
+		$this->export_cleanup_paths = array();
+		$_GET                       = array();
 	}
 
 	/**
@@ -47,6 +56,12 @@ class ExportBootstrapPayloadTest extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		ExeLearning_Bundle_Fixture::destroy();
+		$_GET = array();
+		foreach ( $this->export_cleanup_paths as $path ) {
+			if ( file_exists( $path ) ) {
+				wp_delete_file( $path );
+			}
+		}
 		parent::tear_down();
 	}
 
@@ -174,6 +189,70 @@ class ExportBootstrapPayloadTest extends WP_UnitTestCase {
 
 		$this->assertIsString( $template );
 		$this->assertStringContainsString( '</head>', $template );
+	}
+
+	/**
+	 * The whole export document, composed the way a real request composes it.
+	 *
+	 * maybe_render() used to do this inline and then exit, so the composition
+	 * could only ever be tested one private step at a time.
+	 */
+	public function test_the_export_page_is_built_for_the_requested_attachment() {
+		ExeLearning_Bundle_Fixture::create();
+		$attachment_id = $this->make_elpx_attachment();
+		$_GET          = array(
+			'exe_export'    => '1',
+			'attachment_id' => (string) $attachment_id,
+		);
+
+		$html = $this->bootstrap->build_page();
+
+		$this->assertStringContainsString( '</head>', $html );
+		$this->assertStringContainsString( 'window.__WP_EXE_CONFIG__', $html );
+		$this->assertStringContainsString( '"WordPressExport"', $html );
+		$this->assertStringContainsString( (string) $attachment_id, $html );
+		$this->assertStringContainsString( 'wp-exe-bridge.js', $html );
+	}
+
+	/**
+	 * A request naming no attachment is refused before anything is composed.
+	 */
+	public function test_building_the_export_page_needs_an_attachment() {
+		ExeLearning_Bundle_Fixture::create();
+		$_GET = array( 'exe_export' => '1' );
+
+		$this->expectException( WPDieException::class );
+		$this->bootstrap->build_page();
+	}
+
+	/**
+	 * So is a request naming something that is not an .elpx.
+	 */
+	public function test_building_the_export_page_needs_an_elpx() {
+		ExeLearning_Bundle_Fixture::create();
+		$_GET = array(
+			'exe_export'    => '1',
+			'attachment_id' => (string) $this->factory->post->create(),
+		);
+
+		$this->expectException( WPDieException::class );
+		$this->bootstrap->build_page();
+	}
+
+	/**
+	 * Create an .elpx attachment on disk.
+	 *
+	 * @return int Attachment ID.
+	 */
+	private function make_elpx_attachment() {
+		$attachment_id = $this->factory->attachment->create();
+		$upload        = wp_upload_dir();
+		$path          = trailingslashit( $upload['basedir'] ) . 'export-' . $attachment_id . '.elpx';
+		file_put_contents( $path, 'fixture' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		update_attached_file( $attachment_id, $path );
+		$this->export_cleanup_paths[] = $path;
+
+		return $attachment_id;
 	}
 
 	/**

--- a/tests/unit/ExportBootstrapPayloadTest.php
+++ b/tests/unit/ExportBootstrapPayloadTest.php
@@ -43,6 +43,14 @@ class ExportBootstrapPayloadTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Hand the plugin back its real bundle after tests that swapped it out.
+	 */
+	public function tear_down() {
+		ExeLearning_Bundle_Fixture::destroy();
+		parent::tear_down();
+	}
+
+	/**
 	 * The export configuration is injected as valid JSON the editor can read.
 	 */
 	public function test_the_export_configuration_is_injected_as_json() {
@@ -143,9 +151,7 @@ class ExportBootstrapPayloadTest extends WP_UnitTestCase {
 	 * refused with a 503 instead of rendering a broken page.
 	 */
 	public function test_loading_the_template_fails_when_the_editor_is_not_bundled() {
-		if ( file_exists( EXELEARNING_PLUGIN_DIR . 'dist/static/index.html' ) ) {
-			$this->markTestSkipped( 'The bundled editor is present in this checkout.' );
-		}
+		ExeLearning_Bundle_Fixture::create_empty();
 
 		$method = new ReflectionMethod( ExeLearning_Export_Bootstrap::class, 'load_editor_template' );
 		$method->setAccessible( true );
@@ -159,9 +165,7 @@ class ExportBootstrapPayloadTest extends WP_UnitTestCase {
 	 * document ready to be patched.
 	 */
 	public function test_the_template_is_read_from_the_bundled_editor() {
-		if ( ! file_exists( EXELEARNING_PLUGIN_DIR . 'dist/static/index.html' ) ) {
-			$this->markTestSkipped( 'This checkout has no bundled editor (run make build-editor).' );
-		}
+		ExeLearning_Bundle_Fixture::create();
 
 		$method = new ReflectionMethod( ExeLearning_Export_Bootstrap::class, 'load_editor_template' );
 		$method->setAccessible( true );
@@ -170,6 +174,20 @@ class ExportBootstrapPayloadTest extends WP_UnitTestCase {
 
 		$this->assertIsString( $template );
 		$this->assertStringContainsString( '</head>', $template );
+	}
+
+	/**
+	 * The template is read from wherever the bundle helper points, which is
+	 * what keeps every editor path resolving through a single place.
+	 */
+	public function test_the_template_comes_from_the_bundle_directory() {
+		ExeLearning_Bundle_Fixture::create();
+		ExeLearning_Bundle_Fixture::write( 'index.html', '<html><head></head><body>marcador</body></html>' );
+
+		$method = new ReflectionMethod( ExeLearning_Export_Bootstrap::class, 'load_editor_template' );
+		$method->setAccessible( true );
+
+		$this->assertStringContainsString( 'marcador', $method->invoke( $this->bootstrap ) );
 	}
 
 	// ------------------------------------------------------------------

--- a/tests/unit/StylesServiceBuiltinsTest.php
+++ b/tests/unit/StylesServiceBuiltinsTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Tests for the built-in editor styles ExeLearning_Styles_Service reads out of
+ * the bundled editor.
+ *
+ * The list comes from dist/static/data/bundle.json, which only exists once the
+ * editor has been built. Rather than assert against whatever the machine has,
+ * these tests point the bundle helper at a fixture they wrote themselves, so a
+ * source checkout, a developer machine and CI all see the same two themes.
+ *
+ * @package Exelearning
+ */
+
+/**
+ * Class StylesServiceBuiltinsTest.
+ *
+ * @covers ExeLearning_Styles_Service
+ */
+class StylesServiceBuiltinsTest extends WP_UnitTestCase {
+
+	/**
+	 * Hand the plugin back its real bundle.
+	 */
+	public function tear_down() {
+		ExeLearning_Bundle_Fixture::destroy();
+		delete_option( ExeLearning_Styles_Service::OPTION_DISABLED_STYLES );
+		parent::tear_down();
+	}
+
+	/**
+	 * The themes declared by the bundle are read and normalized.
+	 */
+	public function test_the_builtin_themes_come_from_the_bundle() {
+		ExeLearning_Bundle_Fixture::create();
+
+		$themes = ExeLearning_Styles_Service::list_builtin_themes();
+
+		$this->assertSame( array( 'base', 'pukao' ), wp_list_pluck( $themes, 'id' ) );
+		$this->assertSame( array( 'Base', 'Pukao' ), wp_list_pluck( $themes, 'title' ) );
+		$this->assertSame( array( '1.0.0', '2.1.0' ), wp_list_pluck( $themes, 'version' ) );
+	}
+
+	/**
+	 * Without a bundle there are no built-in styles, and asking for them is not
+	 * an error: the settings screen renders an explanation instead.
+	 */
+	public function test_there_are_no_builtin_themes_without_a_bundle() {
+		ExeLearning_Bundle_Fixture::create_empty();
+
+		$this->assertSame( array(), ExeLearning_Styles_Service::list_builtin_themes() );
+	}
+
+	/**
+	 * A bundle whose data/bundle.json was never written is the same as none.
+	 */
+	public function test_a_bundle_without_its_manifest_yields_no_themes() {
+		ExeLearning_Bundle_Fixture::create();
+		ExeLearning_Bundle_Fixture::delete( 'data/bundle.json' );
+
+		$this->assertSame( array(), ExeLearning_Styles_Service::list_builtin_themes() );
+	}
+
+	/**
+	 * A truncated or unreadable manifest is ignored rather than fatal.
+	 */
+	public function test_an_empty_manifest_yields_no_themes() {
+		ExeLearning_Bundle_Fixture::create();
+		ExeLearning_Bundle_Fixture::write( 'data/bundle.json', '' );
+
+		$this->assertSame( array(), ExeLearning_Styles_Service::list_builtin_themes() );
+	}
+
+	/**
+	 * Nor does a manifest that is not JSON at all bring the screen down.
+	 */
+	public function test_a_corrupt_manifest_yields_no_themes() {
+		ExeLearning_Bundle_Fixture::create();
+		ExeLearning_Bundle_Fixture::write( 'data/bundle.json', 'not json {' );
+
+		$this->assertSame( array(), ExeLearning_Styles_Service::list_builtin_themes() );
+	}
+
+	/**
+	 * A manifest that declares an empty theme list is read successfully and
+	 * simply has nothing in it.
+	 */
+	public function test_a_manifest_can_declare_no_themes() {
+		ExeLearning_Bundle_Fixture::create( array() );
+
+		$this->assertSame( array(), ExeLearning_Styles_Service::list_builtin_themes() );
+	}
+
+	/**
+	 * The registry override the editor consumes reports the built-ins that an
+	 * administrator switched off.
+	 */
+	public function test_the_registry_override_reports_disabled_builtins() {
+		ExeLearning_Bundle_Fixture::create();
+		ExeLearning_Styles_Service::set_builtin_enabled( 'pukao', false );
+
+		$override = ExeLearning_Styles_Service::build_theme_registry_override();
+
+		$this->assertContains( 'pukao', $override['disabledBuiltins'] );
+		$this->assertNotContains( 'base', $override['disabledBuiltins'] );
+	}
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -10,6 +10,22 @@ export default defineConfig( {
 		globals: true,
 		environment: 'happy-dom',
 		include: [ 'tests/js/**/*.test.js' ],
+		// wp-exe-download.js exports through a hidden iframe whose src points at
+		// the site. happy-dom would really resolve and fetch that URL, so the
+		// suite would depend on DNS and fail offline (and the failed load fires
+		// the iframe's `error` event, which is a code path the tests drive
+		// deliberately). Iframes stay inert; their contentWindow is stubbed.
+		environmentOptions: {
+			happyDOM: {
+				settings: {
+					disableIframePageLoading: true,
+					// Without this a disabled load still fires the element's
+					// `error` event, which wp-exe-download.js treats as a real
+					// load failure and rejects on.
+					handleDisabledFileLoadingAsSuccess: true,
+				},
+			},
+		},
 		coverage: {
 			provider: 'v8',
 			reporter: [ 'text', 'lcov' ],


### PR DESCRIPTION
Raises coverage from **80.2% to ~96.7%** (PHP 94.37% → 97.12%, JavaScript 37.81% → 95.93%), in seven reviewable commits.

The starting point was a Codecov analysis of `main`: **79% of the uncovered lines in the repository were JavaScript**, and two thirds of the PHP gap sat behind a single condition — whether the machine happened to have a built editor in `dist/static/`.

## What each commit does

| Commit | File | Before | After |
|--------|------|--------|-------|
| Remove two JS files that were never enqueued | `exelearning.js`, `exelearning-admin.js` | dead code | deleted |
| Cover `wp-exe-bridge.js` | 163 lines | 0% | 98.77% |
| Cover the client-side export path | `wp-exe-download.js` | 50% | 98.40% |
| Cover `exelearning-media-modal.js` | 239 lines | 0% | 99.16% |
| Resolve editor bundle paths through one helper | `class-admin-settings.php` | 94.65% | 100% |
| Make the editor bootstrap return its HTML | `editor-bootstrap.php` | 0% (84 lines) | 90.8% |
| Cover `elp-upload.js` | 141 lines | 0% | 98.58% |

Two of these needed production changes, both designed up front:
[SDD-0003](docs/architecture/sdd/SDD-0003-testable-editor-bundle-paths.md) and
[SDD-0004](docs/architecture/sdd/SDD-0004-editor-bootstrap-view-returns-html.md),
both linked to ADR-0002.

## Beyond the number

**Four tests used to branch on the environment.** `AdminSettingsScreenTest` and
`AdminSettingsTest` each ran `if ( ExeLearning_Editor_Bundle::is_available() )`
and asserted something different per branch; two `ExportBootstrapPayloadTest`
tests skipped each other out on the same condition — one of them was the suite's
only skipped test on a developer machine. A test whose assertion depends on
whether someone ran `make build-editor` is not testing the plugin. They are now
pairs that each assert one outcome against an explicit fixture bundle, and the
suite reports **zero skips**.

**`esc()` in the media modal had nothing checking it.** It is the only barrier
against stored XSS from attachment filenames and `.elpx` metadata — both chosen
by whoever uploads the file, both concatenated into markup injected with
`.html()`/`.after()`, and both running in the reviewing administrator's session.
Four tests now cover it.

**The editor page contract had no test at all.** Everything the embedded editor
knows about WordPress — the REST endpoint, the `wp_rest` nonce, the `<base>` tag
its assets resolve against, the approved style registry — is built by
`editor-bootstrap.php`, and merely running that file tore down PHPUnit's output
buffering and called `exit`. The E2E suite does not open the editor page either,
so a nonce created for the wrong action would have shipped unnoticed.

## Three real defects found on the way

1. **A stray `<base>` tag in every editor page.** The pattern that finds the head
   element, `/(<head[^>]*>)/i`, also matches the editor's own
   `<header id="head">`, so a second `<base href="…">` was injected into the
   middle of the body. Browsers honour only the first, so nothing looked broken,
   but the markup was invalid. Fixed with a word boundary, verified against the
   real 125 KB editor bundle.
2. **The JS suite depended on DNS.** happy-dom really resolved and fetched the
   export iframe's `src`, so the tests failed offline. `disableIframePageLoading`
   stops that.
3. **The block is registered with `apiVersion: 1`**, which WordPress 6.9
   deprecates: a single API-version-1 block makes the whole post editor fall
   back to the non-iframe path. Not changed here — migrating to `apiVersion: 3`
   means adopting `useBlockProps` and moving the editor styles from
   `enqueue_block_editor_assets` to the block type so they reach the iframed
   canvas, and it has to be verified inside that canvas. It follows in its own
   PR on top of this one.

   Worth noting how it surfaced: no linter reported it. It appeared only once
   the block's tests started registering it against the real
   `@wordpress/blocks` package instead of a stub.

## Two of my own tests were wrong, and the tests caught them

- *"Refuses to run a disabled format"* passed because the DOM blocks clicks on a
  disabled button, not because the guard ran — it would have stayed green with
  the wiring deleted. Spotted because the guard's line stayed uncovered.
- *"Throws the old iframe away"* asserted the iframe was detached, but
  `renderButton()` had already wiped the body, so it was true for the wrong
  reason. Spotted because `removeChild` stayed uncovered.

Both now assert the real mechanism. Coverage was useful here as a *detector of
bad tests*, which is most of why the per-line numbers were checked rather than
just the totals.

## Testing approach

The Gutenberg block is tested against the **real** `@wordpress` packages —
`element` (React 18, the version WordPress ships), `blocks`, `components` and
`i18n` — not hand-written stand-ins. `registerBlockType` really validates the
block and a real `ToggleControl` really renders its checkbox, so
`getByLabelText` finds a control only when it was wired up accessibly. This is
what caught the two bad tests above.

Only `wp.blockEditor` is substituted, because it cannot be anything else:
`MediaUpload` *is* the media modal, and `BlockControls`/`InspectorControls` are
Slot/Fill pairs whose children render into slots the editor owns.

**Cost:** 198 packages added to the lockfile; `npm ci` measured at 31s from
scratch, with the suite passing after a clean reinstall. `@wordpress/components`
is the bulk of it (36 MB). If that is too much for CI it can be dropped for
stubs — at the price of the real label and checked-state rendering that found
the bad tests.

## A note for reviewers reading coverage in this repo

PHPUnit's `@covers` **discards everything executed outside the named class**. A
line can report 0% while running on every test, attributed elsewhere. This bit
twice during the work: the bundle test seam, and `editor-bootstrap.php` still
showing 0% with 13 green tests driving it. `EditorBootstrapPageTest` therefore
carries no `@covers` annotation on purpose — its subject is a view file, not a
class — and says so in its docblock.

## Verification

- `make test` — 940 tests, 2068 assertions, 0 skipped
- `npm run test:js` — 246 tests
- `make test-e2e` — 40 tests, chromium + firefox
- `make test-coverage` — 97.12%, gate `MIN_COVERAGE = 94`
- `phpcs --standard=.phpcs.xml.dist` — clean

## Not done

- `editor-bootstrap.php` keeps its `ABSPATH` guard and a `class_exists()`
  fallback uncovered; both are unreachable in a loaded plugin.
- `ExeLearning_Editor_Bundle::get_url()` — three call sites still build
  `EXELEARNING_PLUGIN_URL . 'dist/static'` by hand. Carried as a follow-up in
  both SDDs.
- `ResizableBox`'s `onResizeStop` in the block.
