### PR TITLE
ci: fail when the architecture validator drifts from core

### DIFF
--- a/.github/workflows/architecture-records.yml
+++ b/.github/workflows/architecture-records.yml
@@ -38,6 +38,20 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Architecture validator matches core
+        run: |
+          # The validator is a verbatim copy of the canonical file in
+          # exelearning/exelearning. Fix it there and re-copy — never edit it
+          # here, or the copies drift apart silently.
+          curl -fsSL --retry 3 \
+            https://raw.githubusercontent.com/exelearning/exelearning/main/scripts/architecture-records.mts \
+            -o /tmp/architecture-records.core.mts
+          if ! diff -u /tmp/architecture-records.core.mts bin/architecture-records.mts; then
+            echo "::error file=bin/architecture-records.mts::drifted from exelearning/exelearning@main."
+            echo "Re-copy it from core; do not patch it here."
+            exit 1
+          fi
+          echo "In sync with core ($(shasum -a 256 bin/architecture-records.mts | cut -c1-16)…)."
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
ci: fail when the architecture validator drifts from core

The validator here is a verbatim copy of the canonical file in
exelearning/exelearning. Until now nothing enforced that: the copies stayed
identical only because whoever changed one remembered to re-copy the rest.

Twice during the recent review rounds that memory was the only safeguard,
and once a sync commit was lost without anyone noticing for hours.

The step fetches the canonical file from core's default branch and diffs it
against this copy. A drift fails the job and prints the diff, so the report
says what changed rather than just that something did.

It needs no dependency and no setup: curl and diff are on the runner.

Verified locally: the step passes against the current copy, and fails with a readable diff when a line is appended to it.

```
+// drift injected by a local edit
  would FAIL — correct
```