### PR TITLE
chore(deps): group React dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,4 +29,8 @@ updates:
       prefix: "chore"
       include: "scope"
     open-pull-requests-limit: 5
-
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"


### PR DESCRIPTION
## Summary

- group `react` and `react-dom` Dependabot version updates
- keep the grouping scoped to the npm ecosystem

## Why

Dependabot opened #92 and #94 as separate updates. Each PR fails during `npm install` because `react` and `react-dom` require compatible versions and only one package is upgraded at a time.

## Impact

Future Dependabot version updates for these two packages will be proposed in the same pull request.

## Validation

- parsed the updated `.github/dependabot.yml` successfully
- verified that the `react` group is nested under the npm update configuration
- verified the exact package patterns: `react` and `react-dom`
