### PR TITLE
chore(deps): keep React aligned with WordPress

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,10 @@ updates:
         patterns:
           - "react"
           - "react-dom"
+    ignore:
+      - dependency-name: "react"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "react-dom"
+        update-types:
+          - "version-update:semver-major"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,8 @@
         "happy-dom": "^20.11.2",
         "jquery": "^3.7.1",
         "nunjucks": "^3.2.4",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
+        "react": "18.3.1",
+        "react-dom": "18.3.1",
         "vitest": "^4.1.8"
       }
     },

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "happy-dom": "^20.11.2",
     "jquery": "^3.7.1",
     "nunjucks": "^3.2.4",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
     "vitest": "^4.1.8"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

- pin `react` and `react-dom` to `18.3.1`
- keep `package-lock.json` aligned with the manifest
- keep React dependency updates grouped
- ignore major React and React DOM updates in Dependabot

## Why

The grouped React 19 update in #98 resolves the npm peer dependency conflict, but the JavaScript test suite then mixes React elements created by `@wordpress/element@8.4.0` with `react-dom@19`. React 19 rejects elements created by the React 18 runtime shipped through the current WordPress packages.

The test environment also consumes `@testing-library/react`, which declares React and React DOM as peer dependencies. Keeping both packages explicit avoids relying on transitive dependency hoisting.

## Impact

React remains aligned with the version used by the current WordPress package set. Dependabot can still group compatible updates, but it will not open automatic major-version updates until the WordPress dependencies are ready for React 19.

## Validation

- parsed the updated `.github/dependabot.yml`
- verified the React group contains exactly `react` and `react-dom`
- verified both major-version ignore rules
- verified `package.json` and the root lockfile declarations use `18.3.1`
- verified the lockfile resolves one root `react@18.3.1` and `react-dom@18.3.1`
